### PR TITLE
[#32] Improve built-in /metrics endpoints to use both counter and gauge

### DIFF
--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2023 Red Hat
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGEXPORTER_INTERNAL_H
+#define PGEXPORTER_INTERNAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define INTERNAL_YAML "" \
+   "# Internal Metrics Collectors\n" \
+   "\n" \
+   "  -\n" \
+   "    query: SELECT datname, pg_database_size(datname) FROM pg_database;\n" \
+   "    tag: pg_database_size\n" \
+   "    sort: data\n" \
+   "    collector: db\n" \
+   "    columns:\n" \
+   "      -\n" \
+   "        name: database\n" \
+   "        type: label\n" \
+   "      -\n" \
+   "        description: Size of the database\n" \
+   "        type: gauge\n" \
+   "\n" \
+   "  -\n" \
+   "    query: SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count\n" \
+   "                        FROM\n" \
+   "                        (\n" \
+   "                         VALUES ('accesssharelock'),\n" \
+   "                                ('rowsharelock'),\n" \
+   "                                ('rowexclusivelock'),\n" \
+   "                                ('shareupdateexclusivelock'),\n" \
+   "                                ('sharelock'),\n" \
+   "                                ('sharerowexclusivelock'),\n" \
+   "                                ('exclusivelock'),\n" \
+   "                                ('accessexclusivelock'),\n" \
+   "                                ('sireadlock')\n" \
+   "                        ) AS tmp(mode) CROSS JOIN pg_database\n" \
+   "                        LEFT JOIN\n" \
+   "                        (SELECT database, lower(mode) AS mode, count(*) AS count\n" \
+   "                         FROM pg_locks WHERE database IS NOT NULL\n" \
+   "                         GROUP BY database, lower(mode)\n" \
+   "                        ) AS tmp2\n" \
+   "                        ON tmp.mode = tmp2.mode and pg_database.oid = tmp2.database ORDER BY 1, 2;\n" \
+   "    tag: pg_locks_count\n" \
+   "    sort: data\n" \
+   "    collector: locks\n" \
+   "    columns:\n" \
+   "      -\n" \
+   "        name: database\n" \
+   "        type: label\n" \
+   "      -\n" \
+   "        name: mode\n" \
+   "        type: label\n" \
+   "      -\n" \
+   "        description: Lock count of a database\n" \
+   "        type: gauge\n" \
+   "\n" \
+   "  -\n" \
+   "    query: SELECT slot_name,active,temporary FROM pg_replication_slots;\n" \
+   "    tag: pg_replication_slots\n" \
+   "    sort: data\n" \
+   "    collector: replication\n" \
+   "    columns:\n" \
+   "      -\n" \
+   "        name: slot_name\n" \
+   "        type: label\n" \
+   "      -\n" \
+   "        description: Is the replication active\n" \
+   "        name: active\n" \
+   "        type: gauge\n" \
+   "      -\n" \
+   "        description: Is the replication temporary\n" \
+   "        name: temporary\n" \
+   "        type: gauge\n" \
+   "\n" \
+   "  -\n" \
+   "    query: SELECT buffers_alloc, buffers_backend, buffers_backend_fsync,\n" \
+   "                        buffers_checkpoint, buffers_clean, checkpoint_sync_time,\n" \
+   "                        checkpoint_write_time, checkpoints_req, checkpoints_timed,\n" \
+   "                        maxwritten_clean\n" \
+   "                        FROM pg_stat_bgwriter;\n" \
+   "    tag: pg_stat_bgwriter\n" \
+   "    sort: name\n" \
+   "    collector: stat_bgwriter\n" \
+   "    columns:\n" \
+   "      -\n" \
+   "        description: pg_stat_bgwriter_buffers_alloc\n" \
+   "        name: buffers_alloc\n" \
+   "        type: gauge\n" \
+   "      -\n" \
+   "        description: pg_stat_bgwriter_buffers_backend\n" \
+   "        name: buffers_backend\n" \
+   "        type: gauge\n" \
+   "      -\n" \
+   "        description: pg_stat_bgwriter_buffers_backend_fsync\n" \
+   "        name: buffers_backend_fsync\n" \
+   "        type: gauge\n" \
+   "      -\n" \
+   "        description: pg_stat_bgwriter_buffers_checkpoint\n" \
+   "        name: buffers_checkpoint\n" \
+   "        type: gauge\n" \
+   "      -\n" \
+   "        description: pg_stat_bgwriter_buffers_clean\n" \
+   "        name: buffers_clean\n" \
+   "        type: gauge\n" \
+   "      -\n" \
+   "        description: pg_stat_bgwriter_checkpoint_sync_time\n" \
+   "        name: checkpoint_sync_time\n" \
+   "        type: counter\n" \
+   "      -\n" \
+   "        description: pg_stat_bgwriter_checkpoint_write_time\n" \
+   "        name: checkpoint_write_time\n" \
+   "        type: counter\n" \
+   "      -\n" \
+   "        description: pg_stat_bgwriter_checkpoints_req\n" \
+   "        name: checkpoints_req\n" \
+   "        type: counter\n" \
+   "      -\n" \
+   "        description: pg_stat_bgwriter_checkpoints_timed\n" \
+   "        name: checkpoints_timed\n" \
+   "        type: counter\n" \
+   "      -\n" \
+   "        description: pg_stat_bgwriter_maxwritten_clean\n" \
+   "        name: maxwritten_clean\n" \
+   "        type: counter\n" \
+   "\n" \
+   "  -\n" \
+   "    query:  SELECT datname, blk_read_time, blk_write_time,\n" \
+   "                        blks_hit, blks_read, checksum_failures\n" \
+   "                        deadlocks, temp_files, temp_bytes,\n" \
+   "                        tup_returned, tup_fetched, tup_inserted,\n" \
+   "                        tup_updated, tup_deleted, xact_commit,\n" \
+   "                        xact_rollback, conflicts, numbackends\n" \
+   "                        FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;\n" \
+   "    tag: pg_stat_database\n" \
+   "    sort: data\n" \
+   "    collector: stat_db\n" \
+   "    columns:\n" \
+   "      -\n" \
+   "        name: database\n" \
+   "        type: label\n" \
+   "      -\n" \
+   "        name: blk_read_time\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_blk_read_time\n" \
+   "      -\n" \
+   "        name: blk_write_time\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_blk_write_time\n" \
+   "      -\n" \
+   "        name: blks_hit\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_blks_hit\n" \
+   "      -\n" \
+   "        name: blks_read\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_blks_read\n" \
+   "      -\n" \
+   "        name: deadlocks\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_deadlocks\n" \
+   "      -\n" \
+   "        name: temp_files\n" \
+   "        type: gauge\n" \
+   "        description: pg_stat_database_temp_files\n" \
+   "      -\n" \
+   "        name: temp_bytes\n" \
+   "        type: gauge\n" \
+   "        description: pg_stat_database_temp_bytes\n" \
+   "      -\n" \
+   "        name: tup_returned\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_tup_returned\n" \
+   "      -\n" \
+   "        name: tup_fetched\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_tup_fetched\n" \
+   "      -\n" \
+   "        name: tup_inserted\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_tup_inserted\n" \
+   "      -\n" \
+   "        name: tup_updated\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_tup_updated\n" \
+   "      -\n" \
+   "        name: tup_deleted\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_tup_deleted\n" \
+   "      -\n" \
+   "        name: xact_commit\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_xact_commit\n" \
+   "      -\n" \
+   "        name: xact_rollback\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_xact_rollback\n" \
+   "      -\n" \
+   "        name: conflicts\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_conflicts\n" \
+   "      -\n" \
+   "        name: numbackends\n" \
+   "        type: gauge\n" \
+   "        description: pg_stat_database_numbackends\n" \
+   "\n" \
+   "  -\n" \
+   "    query: SELECT datname, confl_tablespace, confl_lock,\n" \
+   "                      confl_snapshot, confl_bufferpin, confl_deadlock\n" \
+   "                      FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;\n" \
+   "    tag: pg_stat_database_conflicts\n" \
+   "    sort: data\n" \
+   "    collector: stat_conflicts\n" \
+   "    columns:\n" \
+   "      -\n" \
+   "        name: database\n" \
+   "        type: label\n" \
+   "      -\n" \
+   "        name: confl_tablespace\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_conflicts_confl_tablespace\n" \
+   "      -\n" \
+   "        name: confl_lock\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_conflicts_confl_lock\n" \
+   "      -\n" \
+   "        name: confl_snapshot\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_conflicts_confl_snapshot\n" \
+   "      -\n" \
+   "        name: confl_bufferpin\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_conflicts_confl_bufferpin\n" \
+   "      -\n" \
+   "        name: confl_deadlock\n" \
+   "        type: counter\n" \
+   "        description: pg_stat_database_conflicts_confl_deadlock"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -61,12 +61,13 @@ extern "C" {
 #define MAX_USERNAME_LENGTH  128
 #define MAX_PASSWORD_LENGTH 1024
 
-#define MAX_PATH 1024
-#define MISC_LENGTH 128
-#define NUMBER_OF_SERVERS 64
-#define NUMBER_OF_USERS    64
-#define NUMBER_OF_ADMINS    8
-#define NUMBER_OF_METRICS 256
+#define MAX_PATH             1024
+#define MISC_LENGTH           128
+#define NUMBER_OF_SERVERS      64
+#define NUMBER_OF_USERS        64
+#define NUMBER_OF_ADMINS        8
+#define NUMBER_OF_METRICS     256
+#define NUMBER_OF_COLLECTORS  256
 
 #define STATE_FREE        0
 #define STATE_IN_USE      1
@@ -84,7 +85,8 @@ extern "C" {
 #define HUGEPAGE_TRY 1
 #define HUGEPAGE_ON  2
 
-#define MAX_QUERY_LENGTH 1024
+#define MAX_QUERY_LENGTH      1024
+#define MAX_COLLECTOR_LENGTH  1024
 
 #define LABEL_TYPE      0
 #define COUNTER_TYPE    1
@@ -113,18 +115,6 @@ extern "C" {
 #define UPDATE_PROCESS_TITLE_STRICT  1
 #define UPDATE_PROCESS_TITLE_MINIMAL 2
 #define UPDATE_PROCESS_TITLE_VERBOSE 3
-
-/* Bit Masks for Metrics Collectors flags */
-#define FLAG_GENERAL          1 << 0
-#define FLAG_DB               1 << 1
-#define FLAG_LOCKS            1 << 2
-#define FLAG_REPLICATION      1 << 3
-#define FLAG_STAT_BGWRITER    1 << 4
-#define FLAG_STAT_DB          1 << 5
-#define FLAG_STAT_CONFLICTS   1 << 6
-#define FLAG_SETTINGS         1 << 7
-#define FLAG_EXTENSION        1 << 8
-#define FLAG_ALL              (1 << 9) - 1
 
 #define likely(x)    __builtin_expect (!!(x), 1)
 #define unlikely(x)  __builtin_expect (!!(x), 0)
@@ -262,6 +252,7 @@ struct prometheus
    int server_query_type;                          /*< Query type 0--SERVER_QUERY_BOTH 1--SERVER_QUERY_PRIMARY 2--SERVER_QUERY_REPLICA */
    int number_of_columns;                          /*< The number of columns */
    struct column columns[MAX_NUMBER_OF_COLUMNS];   /*< Metric columns */
+   char collector[MAX_COLLECTOR_LENGTH];           /*< Collector Tag for query */
 } __attribute__ ((aligned (64)));
 
 /** @struct
@@ -278,7 +269,6 @@ struct configuration
    int metrics_cache_max_age;  /**< Number of seconds to cache the Prometheus response */
    int metrics_cache_max_size; /**< Number of bytes max to cache the Prometheus response */
    int management;             /**< The management port */
-   short int collectors;       /**< Flag for collectors */
 
    bool cache; /**< Cache connection */
 
@@ -316,13 +306,15 @@ struct configuration
    int number_of_users;          /**< The number of users */
    int number_of_admins;         /**< The number of admins */
    int number_of_metrics;        /**< The number of metrics*/
+   int number_of_collectors;     /**< Number of total collectors */
 
    char metrics_path[MAX_PATH]; /**< The metrics path */
 
-   struct server servers[NUMBER_OF_SERVERS];       /**< The servers */
-   struct user users[NUMBER_OF_USERS];             /**< The users */
-   struct user admins[NUMBER_OF_ADMINS];           /**< The admins */
-   struct prometheus prometheus[NUMBER_OF_METRICS];/**< The Prometheus metrics */
+   char collectors[NUMBER_OF_COLLECTORS][MAX_COLLECTOR_LENGTH];/**< List of collectors in total */
+   struct server servers[NUMBER_OF_SERVERS];                   /**< The servers */
+   struct user users[NUMBER_OF_USERS];                         /**< The users */
+   struct user admins[NUMBER_OF_ADMINS];                       /**< The admins */
+   struct prometheus prometheus[NUMBER_OF_METRICS];            /**< The Prometheus metrics */
 } __attribute__ ((aligned (64)));
 
 #ifdef __cplusplus

--- a/src/include/yaml_configuration.h
+++ b/src/include/yaml_configuration.h
@@ -38,12 +38,22 @@ extern "C" {
 #include <yaml.h>
 
 /**
- * Read the custome configuration from YAML file
+ * Read the custome configuration from YAML file provided by user.
  * @param shmem The shared memory segment
  * @return 0 upon success, otherwise 1
  */
 int
 pgexporter_read_metrics_configuration(void* shmem);
+
+/**
+ * Read and load YAML configuration from file pointer.
+ * @param prometheus The data structure where the YAML configuration is loaded
+ * @param number_of_metrics The number of metrics the configuration has. This value will be set by the function.
+ * @param file File pointer
+ * @return 0 upon success, otherwise 1
+ */
+int
+read_yaml_from_file_pointer(struct prometheus* prometheus, int* number_of_metrics, FILE* file);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
@jesperpedersen This is the implementation of what I had in my mind for #32. I still haven't added an install instruction for `internal.yml` file to have the path `/etc/pgexporter/internal.yml`, but using the following command before running the binary should do it.

```sh
sudo cp ./contrib/yaml/internal.yml /etc/pgexporter/internal.yml
```

I am not much familiar with writing CMake files or Spec files for RPM, so I'll look into those for this when this idea gets a green signal.

PS: This is just a bare-bones working change to the repo to demonstrate my idea. This needs work here and there, which I'll be glad to do.