### PR TITLE
[#90] Duplicate Server Name

### DIFF
--- a/src/libpgexporter/configuration.c
+++ b/src/libpgexporter/configuration.c
@@ -163,6 +163,17 @@ pgexporter_read_configuration(void* shm, char* filename)
                memcpy(&section, line + 1, max);
                if (strcmp(section, "pgexporter"))
                {
+
+                  for (int j = 0; j < idx_server - 1; j++)
+                  {
+                     if (!strcmp(srv.name, config->servers[j].name))
+                     {
+                        warnx("Duplicate server name \"%s\"", srv.name);
+                        fclose(file);
+                        exit(1);
+                     }
+                  }
+
                   if (idx_server > 0 && idx_server <= NUMBER_OF_SERVERS)
                   {
                      memcpy(&(config->servers[idx_server - 1]), &srv, sizeof(struct server));


### PR DESCRIPTION
Warns the user about a name duplication (replication for config is provided in the issue):

![image](https://github.com/pgexporter/pgexporter/assets/74897008/d979c586-96c3-40a7-9806-7cdd7278716e)

It will still run as it did before, but the warning would hopefully encourage users to fix it.