### PR TITLE
Fix prompts not being printed by disabling stdout buffering

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -118,6 +118,9 @@ main(int argc, char** argv)
    int option_index = 0;
    int32_t action = ACTION_UNKNOWN;
 
+   // Disable stdout buffering (i.e. write to stdout immediatelly).
+   setbuf(stdout, NULL);
+
    while (1)
    {
       static struct option long_options[] =

--- a/src/cli.c
+++ b/src/cli.c
@@ -134,6 +134,9 @@ main(int argc, char** argv)
    char un[MAX_USERNAME_LENGTH];
    configuration_t* config = NULL;
 
+   // Disable stdout buffering (i.e. write to stdout immediatelly).
+   setbuf(stdout, NULL);
+
    while (1)
    {
       static struct option long_options[] =


### PR DESCRIPTION
When built against musl libc, prompts like "Master key:", "Username:" etc. are not printed to console because of stdout buffering.