### PR TITLE
admin: support password through environment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Jakub Jirutka <jakub@jirutka.cz>
 Andreas Wahlen <andreas.wahlen@nerou.de>
 John Hsu <hsuchen@amazon.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
+Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -81,6 +81,10 @@ pgexporter-admin master-key
 pgexporter-admin -f pgexporter_users.conf user add
 ```
 
+The master key must be at least 8 characters if provided interactively.
+
+For scripted use, the master key and user password can be provided using the `PGEXPORTER_PASSWORD` environment variable.
+
 We are now ready to run `pgexporter`.
 
 See [Configuration](./CONFIGURATION.md) for all configuration options.

--- a/doc/man/pgexporter-admin.1.rst
+++ b/doc/man/pgexporter-admin.1.rst
@@ -60,6 +60,14 @@ user user del
 user ls
   List all users
 
+ENVIRONMENT VARIABLES
+=====================
+
+PGEXPORTER_PASSWORD
+  Provide either a key for use with the `master-key` command, or a user password for use with the `user add` or `user edit` commands.
+  If provided, `pgexporter-admin` will not ask for the key/password interactively.
+  Note that a password provided using the `--password` command line argument will have precedence over this variable.
+
 REPORTING BUGS
 ==============
 

--- a/doc/manual/97-acknowledgement.md
+++ b/doc/manual/97-acknowledgement.md
@@ -16,6 +16,7 @@ Saurav Pal <resyfer.dev@gmail.com>
 Jakub Jirutka <jakub@jirutka.cz>
 Andreas Wahlen <andreas.wahlen@nerou.de>
 Haoran Zhang <andrewzhr9911@gmail.com>
+Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>
 ```
 
 ## Contributing

--- a/doc/manual/advanced/03-installation.md
+++ b/doc/manual/advanced/03-installation.md
@@ -164,6 +164,10 @@ First, we will need to create a master security key for the [**pgexporter**][pge
 pgexporter-admin -g master-key
 ```
 
+By default, this will ask for a key interactively. Alternatively, a key can be provided using either the
+`--password` command line argument, or the `PGEXPORTER_PASSWORD` environment variable. Note that passing the
+key using the command line might not be secure.
+
 Then we will create the configuration for [**pgexporter**][pgexporter],
 
 ```

--- a/doc/manual/advanced/97-acknowledgement.md
+++ b/doc/manual/advanced/97-acknowledgement.md
@@ -16,6 +16,7 @@ Saurav Pal <resyfer.dev@gmail.com>
 Jakub Jirutka <jakub@jirutka.cz>
 Andreas Wahlen <andreas.wahlen@nerou.de>
 Haoran Zhang <andrewzhr9911@gmail.com>
+Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>
 ```
 
 ## Contributing

--- a/doc/manual/user-01-quickstart.md
+++ b/doc/manual/user-01-quickstart.md
@@ -74,8 +74,10 @@ We will need a user vault for the `pgexporter` account, so the following command
 
 ``` sh
 pgexporter-admin master-key
-pgexporter-admin -f pgexporter_users.conf add-user
+pgexporter-admin -f pgexporter_users.conf user add
 ```
+
+For scripted use, the master key and user password can be provided using the `PGEXPORTER_PASSWORD` environment variable.
 
 We are now ready to run [**pgexporter**][pgexporter].
 

--- a/doc/tutorial/01_install.md
+++ b/doc/tutorial/01_install.md
@@ -108,10 +108,12 @@ Add the master key and create vault
 
 ```
 pgexporter-admin master-key
-pgexporter-admin -f pgexporter_users.conf -U pgexporter -P pgexporter user add
+pgexporter-admin -f pgexporter_users.conf -U pgexporter user add
 ```
 
 You have to choose a password for the master key - remember it !
+
+For scripted use, the master key and user password can be provided using the `PGEXPORTER_PASSWORD` environment variable.
 
 Create the `pgexporter.conf` configuration
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -392,25 +392,34 @@ master_key(char* password, bool generate_pwd, int pwd_length, int32_t output_for
 
    if (password == NULL)
    {
-      if (!generate_pwd)
-      {
-         while (!is_valid_key(password))
-         {
-            if (password != NULL)
-            {
-               free(password);
-               password = NULL;
-            }
-
-            printf("Master key: ");
-            password = pgexporter_get_password();
-            printf("\n");
-         }
-      }
-      else
+      if (generate_pwd)
       {
          password = generate_password(pwd_length);
          do_free = false;
+      }
+      else
+      {
+         password = secure_getenv("PGEXPORTER_PASSWORD");
+
+         if (password == NULL)
+         {
+            while (!is_valid_key(password))
+            {
+               if (password != NULL)
+               {
+                  free(password);
+                  password = NULL;
+               }
+
+               printf("Master key: ");
+               password = pgexporter_get_password();
+               printf("\n");
+            }
+         }
+         else
+         {
+            do_free = false;
+         }
       }
    }
    else
@@ -619,15 +628,25 @@ password:
       }
       else
       {
-         printf("Password : ");
+         password = secure_getenv("PGEXPORTER_PASSWORD");
 
-         if (password != NULL)
+         if (password == NULL)
          {
-            free(password);
-            password = NULL;
-         }
+            printf("Password : ");
 
-         password = pgexporter_get_password();
+            if (password != NULL)
+            {
+               free(password);
+               password = NULL;
+            }
+
+            password = pgexporter_get_password();
+         }
+         else
+         {
+            do_free = false;
+            do_verify = false;
+         }
       }
       printf("\n");
    }
@@ -844,15 +863,25 @@ password:
             }
             else
             {
-               printf("Password : ");
+               password = secure_getenv("PGEXPORTER_PASSWORD");
 
-               if (password != NULL)
+               if (password == NULL)
                {
-                  free(password);
-                  password = NULL;
-               }
+                  printf("Password : ");
 
-               password = pgexporter_get_password();
+                  if (password != NULL)
+                  {
+                     free(password);
+                     password = NULL;
+                  }
+
+                  password = pgexporter_get_password();
+               }
+               else
+               {
+                  do_free = false;
+                  do_verify = false;
+               }
             }
             printf("\n");
          }


### PR DESCRIPTION
Passing the password through the "--password" command line argument is potentially insecure, as the value would be exposed in a process listing or shell history. Read an environment variable as an alternative.