### PR TITLE
[#190] Improved pgexporter_os_kernel_version to align BSD version for…

### DIFF
--- a/src/libpgexporter/utils.c
+++ b/src/libpgexporter/utils.c
@@ -2482,7 +2482,7 @@ pgexporter_backtrace(void)
 int
 pgexporter_os_kernel_version(char** os, int* kernel_major, int* kernel_minor, int* kernel_patch)
 {
-
+   bool bsd = false;
    *os = NULL;
    *kernel_major = 0;
    *kernel_minor = 0;
@@ -2519,12 +2519,20 @@ pgexporter_os_kernel_version(char** os, int* kernel_major, int* kernel_minor, in
       goto error;
    }
    *kernel_patch = 0; // BSD doesn't use patch version
+   bsd = true;
 
 #endif
 
-   pgexporter_log_debug("OS: %s | Kernel Version: %d.%d.%d", *os, *kernel_major, *kernel_minor, *kernel_patch);
-   return 0;
+   if (!bsd)
+   {
+      pgexporter_log_debug("OS: %s | Kernel Version: %d.%d.%d", *os, *kernel_major, *kernel_minor, *kernel_patch);
+   }
+   else
+   {
+      pgexporter_log_debug("OS: %s | Version: %d.%d", *os, *kernel_major, *kernel_minor);
+   }
 
+   return 0;
 error:
    //Free memory if already allocated
    if (*os != NULL)


### PR DESCRIPTION
### Summary  
Updated `pgexporter_os_kernel_version` to report only major and minor versions for BSD-based systems (FreeBSD, OpenBSD).  

### Changes  
- Introduced a `bsd` flag to differentiate BSD from Linux.  
- Adjusted logging to show:  
  - **Linux**: `OS: <name> | Kernel Version: <major>.<minor>.<patch>`  
  - **BSD**: `OS: <name> | Version: <major>.<minor>`  
- Ensured consistency with pgmoneta and pgagroal implementations.  
