### PR TITLE
[#197] Port CLI Argument Parser to pgexporter

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -33,6 +33,7 @@
 /* pgexporter */
 #include <pgexporter.h>
 #include <aes.h>
+#include <cmd.h>
 #include <logging.h>
 #include <management.h>
 #include <security.h>
@@ -155,13 +156,11 @@ usage(void)
 int
 main(int argc, char** argv)
 {
-   int c;
    char* username = NULL;
    char* password = NULL;
    char* file_path = NULL;
    bool generate_pwd = false;
    int pwd_length = DEFAULT_PASSWORD_LENGTH;
-   int option_index = 0;
    size_t command_count = sizeof(command_table) / sizeof(struct pgexporter_command);
    struct pgexporter_parsed_command parsed = {.cmd = NULL, .args = {0}};
    int32_t output_format = MANAGEMENT_OUTPUT_FORMAT_TEXT;
@@ -169,69 +168,86 @@ main(int argc, char** argv)
    // Disable stdout buffering (i.e. write to stdout immediatelly).
    setbuf(stdout, NULL);
 
-   while (1)
+   char* filepath = NULL;
+   int optind = 0;
+   int num_options = 0;
+   int num_results = 0;
+
+   cli_option options[] = {
+      {"U", "user", true},
+      {"P", "password", true},
+      {"f", "file", true},
+      {"g", "generate", false},
+      {"l", "length", true},
+      {"F", "format", true},
+      {"V", "version", false},
+      {"?", "help", false},
+   };
+
+   num_options = sizeof(options) / sizeof(cli_option);
+   cli_result results[num_options];
+
+   num_results = cmd_parse(argc, argv, options, num_options, results, num_options, false, &filepath, &optind);
+
+   if (num_results < 0)
    {
-      static struct option long_options[] =
-      {
-         {"user", required_argument, 0, 'U'},
-         {"password", required_argument, 0, 'P'},
-         {"file", required_argument, 0, 'f'},
-         {"generate", no_argument, 0, 'g'},
-         {"length", required_argument, 0, 'l'},
-         {"format", required_argument, 0, 'F'},
-         {"version", no_argument, 0, 'V'},
-         {"help", no_argument, 0, '?'}
-      };
+      errx(1, "Error parsing command line\n");
+      return 1;
+   }
 
-      c = getopt_long(argc, argv, "gV?f:U:P:l:F:",
-                      long_options, &option_index);
+   for (int i = 0; i < num_results; i++)
+   {
+      char* optname = results[i].option_name;
+      char* optarg = results[i].argument;
 
-      if (c == -1)
+      if (optname == NULL)
       {
          break;
       }
-
-      switch (c)
+      else if (!strcmp(optname, "user") || !strcmp(optname, "U"))
       {
-         case 'U':
-            username = optarg;
-            break;
-         case 'P':
-            password = optarg;
-            break;
-         case 'f':
-            file_path = optarg;
-            break;
-         case 'g':
-            generate_pwd = true;
-            break;
-         case 'l':
-            pwd_length = atoi(optarg);
-            break;
-         case 'V':
-            version();
-            break;
-         case 'F':
-            if (!strncmp(optarg, "json", MISC_LENGTH))
-            {
-               output_format = MANAGEMENT_OUTPUT_FORMAT_JSON;
-            }
-            else if (!strncmp(optarg, "text", MISC_LENGTH))
-            {
-               output_format = MANAGEMENT_OUTPUT_FORMAT_TEXT;
-            }
-            else
-            {
-               warnx("pgexporter-cli: Format type is not correct");
-               exit(1);
-            }
-            break;
-         case '?':
-            usage();
+         username = optarg;
+      }
+      else if (!strcmp(optname, "password") || !strcmp(optname, "P"))
+      {
+         password = optarg;
+      }
+      else if (!strcmp(optname, "file") || !strcmp(optname, "f"))
+      {
+         file_path = optarg;
+      }
+      else if (!strcmp(optname, "generate") || !strcmp(optname, "g"))
+      {
+         generate_pwd = true;
+      }
+      else if (!strcmp(optname, "length") || !strcmp(optname, "l"))
+      {
+         pwd_length = atoi(optarg);
+      }
+      else if (!strcmp(optname, "version") || !strcmp(optname, "V"))
+      {
+         version();
+      }
+      else if (!strcmp(optname, "format") || !strcmp(optname, "F"))
+      {
+         if (!strncmp(optarg, "json", MISC_LENGTH))
+         {
+            output_format = MANAGEMENT_OUTPUT_FORMAT_JSON;
+         }
+         else if (!strncmp(optarg, "text", MISC_LENGTH))
+         {
+            output_format = MANAGEMENT_OUTPUT_FORMAT_TEXT;
+         }
+         else
+         {
+            warnx("pgexporter-cli: Format type is not correct");
             exit(1);
-            break;
-         default:
-            break;
+         }
+      }
+      else if (!strcmp(optname, "help") || !strcmp(optname, "?"))
+      {
+         usage();
+         exit(1);
       }
    }
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -28,6 +28,7 @@
 
 /* pgexporter */
 #include <pgexporter.h>
+#include <cmd.h>
 #include <configuration.h>
 #include <json.h>
 #include <logging.h>
@@ -236,8 +237,6 @@ main(int argc, char** argv)
    bool verbose = false;
    char* logfile = NULL;
    bool do_free = true;
-   int c;
-   int option_index = 0;
    /* Store the result from command parser*/
    size_t size;
    char un[MAX_USERNAME_LENGTH];
@@ -251,137 +250,158 @@ main(int argc, char** argv)
    // Disable stdout buffering (i.e. write to stdout immediatelly).
    setbuf(stdout, NULL);
 
-   while (1)
+   char* filepath = NULL;
+   int optind = 0;
+   int num_options = 0;
+   int num_results = 0;
+
+   cli_option options[] = {
+      {"c", "config", true},
+      {"h", "host", true},
+      {"p", "port", true},
+      {"U", "user", true},
+      {"P", "password", true},
+      {"L", "logfile", true},
+      {"v", "verbose", false},
+      {"V", "version", false},
+      {"F", "format", true},
+      {"?", "help", false},
+      {"C", "compress", true},
+      {"E", "encrypt", true}
+   };
+
+   num_options = sizeof(options) / sizeof(cli_option);
+   cli_result results[num_options];
+
+   num_results = cmd_parse(argc, argv, options, num_options, results, num_options, false, &filepath, &optind);
+
+   if (num_results < 0)
    {
-      static struct option long_options[] =
-      {
-         {"config", required_argument, 0, 'c'},
-         {"host", required_argument, 0, 'h'},
-         {"port", required_argument, 0, 'p'},
-         {"user", required_argument, 0, 'U'},
-         {"password", required_argument, 0, 'P'},
-         {"logfile", required_argument, 0, 'L'},
-         {"verbose", no_argument, 0, 'v'},
-         {"version", no_argument, 0, 'V'},
-         {"format", required_argument, 0, 'F'},
-         {"help", no_argument, 0, '?'},
-         {"compress", required_argument, 0, 'C'},
-         {"encrypt", required_argument, 0, 'E'}
-      };
+      errx(1, "Error parsing command line\n");
+      return 1;
+   }
 
-      c = getopt_long(argc, argv, "vV?c:h:p:U:P:L:F:C:E:",
-                      long_options, &option_index);
+   for (int i = 0; i < num_results; i++)
+   {
+      char* optname = results[i].option_name;
+      char* optarg = results[i].argument;
 
-      if (c == -1)
+      if (optname == NULL)
       {
          break;
       }
-
-      switch (c)
+      else if (!strcmp(optname, "config") || !strcmp(optname, "c"))
       {
-         case 'c':
-            configuration_path = optarg;
-            break;
-         case 'h':
-            host = optarg;
-            break;
-         case 'p':
-            port = optarg;
-            break;
-         case 'U':
-            username = optarg;
-            break;
-         case 'P':
-            password = optarg;
-            break;
-         case 'L':
-            logfile = optarg;
-            break;
-         case 'v':
-            verbose = true;
-            break;
-         case 'V':
-            version();
-            break;
-         case 'F':
-            if (!strncmp(optarg, "json", MISC_LENGTH))
-            {
-               output_format = MANAGEMENT_OUTPUT_FORMAT_JSON;
-            }
-            else if (!strncmp(optarg, "raw", MISC_LENGTH))
-            {
-               output_format = MANAGEMENT_OUTPUT_FORMAT_RAW;
-            }
-            else if (!strncmp(optarg, "text", MISC_LENGTH))
-            {
-               output_format = MANAGEMENT_OUTPUT_FORMAT_TEXT;
-            }
-            else
-            {
-               warnx("pgexporter-cli: Format type is not correct");
-               exit(1);
-            }
-            break;
-         case 'C':
-            if (!strncmp(optarg, "gz", MISC_LENGTH))
-            {
-               compression = MANAGEMENT_COMPRESSION_GZIP;
-            }
-            else if (!strncmp(optarg, "zstd", MISC_LENGTH))
-            {
-               compression = MANAGEMENT_COMPRESSION_ZSTD;
-            }
-            else if (!strncmp(optarg, "lz4", MISC_LENGTH))
-            {
-               compression = MANAGEMENT_COMPRESSION_LZ4;
-            }
-            else if (!strncmp(optarg, "bz2", MISC_LENGTH))
-            {
-               compression = MANAGEMENT_COMPRESSION_BZIP2;
-            }
-            else if (!strncmp(optarg, "none", MISC_LENGTH))
-            {
-               break;
-            }
-            else
-            {
-               warnx("pgexporter-cli: Compress method is not correct");
-               exit(1);
-            }
-            break;
-         case 'E':
-            if (!strncmp(optarg, "aes", MISC_LENGTH))
-            {
-               encryption = MANAGEMENT_ENCRYPTION_AES256;
-            }
-            else if (!strncmp(optarg, "aes256", MISC_LENGTH))
-            {
-               encryption = MANAGEMENT_ENCRYPTION_AES256;
-            }
-            else if (!strncmp(optarg, "aes192", MISC_LENGTH))
-            {
-               encryption = MANAGEMENT_ENCRYPTION_AES192;
-            }
-            else if (!strncmp(optarg, "aes128", MISC_LENGTH))
-            {
-               encryption = MANAGEMENT_ENCRYPTION_AES128;
-            }
-            else if (!strncmp(optarg, "none", MISC_LENGTH))
-            {
-               break;
-            }
-            else
-            {
-               warnx("pgexporter-cli: Encrypt method is not correct");
-               exit(1);
-            }
-            break;
-         case '?':
-            usage();
+         configuration_path = optarg;
+      }
+      else if (!strcmp(optname, "host") || !strcmp(optname, "h"))
+      {
+         host = optarg;
+      }
+      else if (!strcmp(optname, "port") || !strcmp(optname, "p"))
+      {
+         port = optarg;
+      }
+      else if (!strcmp(optname, "user") || !strcmp(optname, "U"))
+      {
+         username = optarg;
+      }
+      else if (!strcmp(optname, "password") || !strcmp(optname, "P"))
+      {
+         password = optarg;
+      }
+      else if (!strcmp(optname, "logfile") || !strcmp(optname, "L"))
+      {
+         logfile = optarg;
+      }
+      else if (!strcmp(optname, "verbose") || !strcmp(optname, "v"))
+      {
+         verbose = true;
+      }
+      else if (!strcmp(optname, "version") || !strcmp(optname, "V"))
+      {
+         version();
+      }
+      else if (!strcmp(optname, "format") || !strcmp(optname, "F"))
+      {
+         if (!strncmp(optarg, "json", MISC_LENGTH))
+         {
+            output_format = MANAGEMENT_OUTPUT_FORMAT_JSON;
+         }
+         else if (!strncmp(optarg, "raw", MISC_LENGTH))
+         {
+            output_format = MANAGEMENT_OUTPUT_FORMAT_RAW;
+         }
+         else if (!strncmp(optarg, "text", MISC_LENGTH))
+         {
+            output_format = MANAGEMENT_OUTPUT_FORMAT_TEXT;
+         }
+         else
+         {
+            warnx("pgexporter-cli: Format type is not correct");
             exit(1);
+         }
+      }
+      else if (!strcmp(optname, "compress") || !strcmp(optname, "C"))
+      {
+         if (!strncmp(optarg, "gz", MISC_LENGTH))
+         {
+            compression = MANAGEMENT_COMPRESSION_GZIP;
+         }
+         else if (!strncmp(optarg, "zstd", MISC_LENGTH))
+         {
+            compression = MANAGEMENT_COMPRESSION_ZSTD;
+         }
+         else if (!strncmp(optarg, "lz4", MISC_LENGTH))
+         {
+            compression = MANAGEMENT_COMPRESSION_LZ4;
+         }
+         else if (!strncmp(optarg, "bz2", MISC_LENGTH))
+         {
+            compression = MANAGEMENT_COMPRESSION_BZIP2;
+         }
+         else if (!strncmp(optarg, "none", MISC_LENGTH))
+         {
             break;
-         default:
+         }
+         else
+         {
+            warnx("pgexporter-cli: Compress method is not correct");
+            exit(1);
+         }
+      }
+      else if (!strcmp(optname, "encrypt") || !strcmp(optname, "E"))
+      {
+         if (!strncmp(optarg, "aes", MISC_LENGTH))
+         {
+            encryption = MANAGEMENT_ENCRYPTION_AES256;
+         }
+         else if (!strncmp(optarg, "aes256", MISC_LENGTH))
+         {
+            encryption = MANAGEMENT_ENCRYPTION_AES256;
+         }
+         else if (!strncmp(optarg, "aes192", MISC_LENGTH))
+         {
+            encryption = MANAGEMENT_ENCRYPTION_AES192;
+         }
+         else if (!strncmp(optarg, "aes128", MISC_LENGTH))
+         {
+            encryption = MANAGEMENT_ENCRYPTION_AES128;
+         }
+         else if (!strncmp(optarg, "none", MISC_LENGTH))
+         {
             break;
+         }
+         else
+         {
+            warnx("pgexporter-cli: Encrypt method is not correct");
+            exit(1);
+         }
+      }
+      else if (!strcmp(optname, "help") || !strcmp(optname, "?"))
+      {
+         usage();
+         exit(1);
       }
    }
 

--- a/src/include/cmd.h
+++ b/src/include/cmd.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef CMD_H
+#define CMD_H
+
+#include <stdbool.h>
+
+/**
+ * @struct cli_option
+ * Struct to hold option definition
+ */
+typedef struct
+{
+   char* short_name;     /**< Short option name */
+   char* long_name;      /**< Long option name */
+   bool requires_arg;    /**< Whether this option requires an argument */
+} cli_option;
+
+/**
+ * @struct cli_result
+ * Struct to hold parsed option result
+ */
+typedef struct
+{
+   char* option_name;    /**< The matched option name (short or long) */
+   char* argument;       /**< Argument value if applicable, NULL otherwise */
+} cli_result;
+
+/**
+ * Parse command line arguments based on the provided options
+ *
+ * @param argc Number of arguments
+ * @param argv Array of argument strings
+ * @param options Array of option definitions
+ * @param num_options Number of options in the array
+ * @param results Output array for results
+ * @param num_results Maximum number of results to store
+ * @param use_last_arg_as_filename Whether to use the last argument as a filename
+ * @param filename Output parameter for filename if requested
+ * @param optind Output parameter for the index of the first non-option argument
+ *
+ * @return Number of results found, or -1 on error
+ */
+int cmd_parse(
+   int argc,
+   char** argv,
+   cli_option* options,
+   int num_options,
+   cli_result* results,
+   int num_results,
+   bool use_last_arg_as_filename,
+   char** filename,
+   int* optind
+   );
+
+#endif

--- a/src/libpgexporter/cmd.c
+++ b/src/libpgexporter/cmd.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2025 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cmd.h>
+#include <string.h>
+#include <stdio.h>
+#include <err.h>
+#include <stdlib.h>
+
+static bool
+option_requires_arg(char* option_name, cli_option* options, int num_options, bool is_long_option)
+{
+   for (int j = 0; j < num_options; j++)
+   {
+      cli_option* option = &options[j];
+      bool matches = false;
+
+      if (is_long_option)
+      {
+         matches = (strcmp(option_name, option->long_name) == 0);
+      }
+      else
+      {
+         matches = (strcmp(option_name, option->short_name) == 0);
+      }
+
+      if (matches)
+      {
+         return option->requires_arg;
+      }
+   }
+   return false;
+}
+
+int
+cmd_parse(
+   int argc,
+   char** argv,
+   cli_option* options,
+   int num_options,
+   cli_result* results,
+   int num_results,
+   bool use_last_arg_as_filename,
+   char** filename,
+   int* optind
+   )
+{
+   int result_count = 0;
+   *filename = NULL;
+   char** sorted_argv = malloc(argc * sizeof(char*));
+   int sorted_idx = 0;
+   char* arg = NULL;
+
+   if (!sorted_argv)
+   {
+      warnx("Memory allocation error\n");
+      return -1;
+   }
+
+   sorted_argv[sorted_idx++] = argv[0];
+
+   /* First pass: collect flag options (options without arguments) */
+   for (int i = 1; i < argc; i++)
+   {
+      arg = argv[i];
+
+      if (arg[0] == '-')
+      {
+         bool is_long_option = (arg[1] == '-');
+         char* option_text = arg + (is_long_option ? 2 : 1);
+
+         /* Check if this option has an argument */
+         bool has_equals = (strchr(option_text, '=') != NULL);
+
+         /* If the option doesn't have an equals sign, check if it requires an argument */
+         if (!has_equals)
+         {
+            bool requires_arg = option_requires_arg(option_text, options, num_options, is_long_option);
+
+            if (!requires_arg)
+            {
+               /* This is a flag, add it to the sorted array */
+               sorted_argv[sorted_idx++] = argv[i];
+            }
+         }
+      }
+   }
+
+   /* Second pass: collect options with arguments */
+   for (int i = 1; i < argc; i++)
+   {
+      arg = argv[i];
+
+      if (arg[0] == '-')
+      {
+         bool is_long_option = (arg[1] == '-');
+         char* option_text = arg + (is_long_option ? 2 : 1);
+
+         /* Check if this option has an argument */
+         bool has_equals = (strchr(option_text, '=') != NULL);
+
+         if (has_equals)
+         {
+            /* Option with equals sign already includes its argument */
+            sorted_argv[sorted_idx++] = argv[i];
+         }
+         else
+         {
+            bool requires_arg = option_requires_arg(option_text, options, num_options, is_long_option);
+
+            if (requires_arg)
+            {
+               sorted_argv[sorted_idx++] = argv[i];
+
+               if (i + 1 < argc && argv[i + 1][0] != '-')
+               {
+                  sorted_argv[sorted_idx++] = argv[i + 1];
+                  i++;
+               }
+            }
+         }
+      }
+   }
+
+   /* Third pass: collect non-option arguments */
+   for (int i = 1; i < argc; i++)
+   {
+      arg = argv[i];
+
+      if (arg[0] != '-')
+      {
+         if (i > 1 && argv[i - 1][0] == '-')
+         {
+            bool is_long_option = (argv[i - 1][1] == '-');
+            char* prev_option = argv[i - 1] + (is_long_option ? 2 : 1);
+
+            if (!strchr(prev_option, '=') && option_requires_arg(prev_option, options, num_options, is_long_option))
+            {
+               continue;
+            }
+         }
+
+         sorted_argv[sorted_idx++] = argv[i];
+      }
+   }
+
+   for (int i = 0; i < sorted_idx; i++)
+   {
+      argv[i] = sorted_argv[i];
+   }
+
+   free(sorted_argv);
+
+   int i = 1;
+   for (; i < argc && result_count < num_results; i++)
+   {
+      arg = argv[i];
+
+      if (arg[0] == '-')
+      {
+         bool is_long_option = (arg[1] == '-');
+         char* option_text = arg + (is_long_option ? 2 : 1);
+         bool option_matched = false;
+
+         for (int j = 0; j < num_options; j++)
+         {
+            cli_option* option = &options[j];
+            bool matches = false;
+
+            if (is_long_option)
+            {
+               /* Match long option (--option) */
+               matches = (strcmp(option_text, option->long_name) == 0);
+            }
+            else
+            {
+               /* Match short option (-X) */
+               matches = (strcmp(option_text, option->short_name) == 0);
+            }
+
+            if (matches)
+            {
+               option_matched = true;
+
+               results[result_count].option_name = is_long_option ?
+                                                   option->long_name :
+                                                   option->short_name;
+
+               if (option->requires_arg)
+               {
+                  /* Handle option arguments in two ways:
+                   * 1. As the next argument (--option value or -o value)
+                   * 2. Joined with equals sign (--option=value or -o=value)
+                   */
+                  char* equals = strchr(option_text, '=');
+
+                  if (equals && (is_long_option || equals == option_text + 1))
+                  {
+                     /* Option with argument in the form --option=value or -o=value */
+                     results[result_count].argument = (char*)(equals + 1);
+                  }
+                  else if (i + 1 < argc && argv[i + 1][0] != '-')
+                  {
+                     /* Option with argument as the next parameter */
+                     results[result_count].argument = (char*)argv[i + 1];
+                     i++;
+                  }
+                  else
+                  {
+                     warnx("Error: Option %s requires an argument\n", arg);
+                     return -1;
+                  }
+               }
+               else
+               {
+                  results[result_count].argument = NULL;
+               }
+
+               result_count++;
+               break;
+            }
+         }
+
+         if (!option_matched)
+         {
+            /* Found an unknown option, we'll stop parsing here */
+            warnx("Error: Unknown option %s\n", arg);
+            // valid = false;
+            break;
+         }
+      }
+      else
+      {
+         /* We've found a non-option argument, stop parsing options */
+
+         break;
+      }
+   }
+
+   /* Set optind to the index of the first non-option argument */
+   *optind = i;
+
+   /* If we're configured to treat the last non-option argument as a filename
+    * and there are remaining arguments, use the last one as filename */
+   if (use_last_arg_as_filename && i < argc && argc - i == 1)
+   {
+      *filename = argv[i];
+   }
+
+   return result_count;
+}


### PR DESCRIPTION
Resolves #197 

**Description**
This PR replaces getopt_long with a new CLI argument parser in pgexporter, similar to the implementation in [pgmoneta PR #531](https://github.com/pgmoneta/pgmoneta/pull/531).

The key improvement is that short options can now be strings instead of single characters, enabling better flexibility for command-line arguments.

**Changes Introduced**
- Imported the new CLI parser from pgmoneta.

- Replaced all instances of getopt_long with the new parser.

- Ensured that all existing command-line options remain fully compatible.