### PR TITLE
[#201] Fix broken Docker manual link in CONTRIBUTING.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Sangkeun J.C. Kim <jchrys@me.com>
 Tejas Tyagi <tejastyagi.tt@gmail.com>
 Arshdeep Singh <balarsh535@gmail.com>
 Botir Khaltaev <btrghstk@gmail.com>
+Ahmed Osama Fathy <ahmedosamaft@gmail.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ If you believe you found a bug, and it's likely possible, please indicate a way 
 Don't forget to indicate your pgexporter version.
 
 ## Running with docker 
-Follow [this](./doc/DOCKER.md) to build using docker 
+Follow [this](./doc/manual/user15-docker.md) to build using docker 
 
 ## Setup your build environment
 

--- a/doc/manual/97-acknowledgement.md
+++ b/doc/manual/97-acknowledgement.md
@@ -21,6 +21,7 @@ Bassam Adnan <mailbassam@gmail.com>
 Sangkeun J.C. Kim <jchrys@me.com>
 Tejas Tyagi <tejastyagi.tt@gmail.com>
 Arshdeep Singh <balarsh535@gmail.com>
+Ahmed Osama Fathy <ahmedosamaft@gmail.com>
 ```
 
 ## Contributing

--- a/doc/manual/advanced/97-acknowledgement.md
+++ b/doc/manual/advanced/97-acknowledgement.md
@@ -21,6 +21,7 @@ Bassam Adnan <mailbassam@gmail.com>
 Sangkeun J.C. Kim <jchrys@me.com>
 Tejas Tyagi<tejastyagi.tt@gmail.com>
 Arshdeep Singh <balarsh535@gmail.com>
+Ahmed Osama Fathy <ahmedosamaft@gmail.com>
 ```
 
 ## Contributing


### PR DESCRIPTION
Resolves #201 

**Description**
This PR addresses the issue with the broken Docker manual link in the CONTRIBUTING.md file. The link has been updated to point to the correct path: ./doc/manual/user15-docker.md.