### PR TITLE
Update HTTP APIs

### DIFF
--- a/src/include/http.h
+++ b/src/include/http.h
@@ -33,44 +33,117 @@
 extern "C" {
 #endif
 
+#include <pgexporter.h>
+
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+/* HTTP method definitions */
+#define PGEXPORTER_HTTP_GET  0
+#define PGEXPORTER_HTTP_POST 1
+#define PGEXPORTER_HTTP_PUT  2
 
 /** @struct http
  * Defines a HTTP interaction
  */
 struct http
 {
-   int endpoint;  /**< The endpoint */
-   int socket;    /**< The socket */
-   char* headers; /**< The HTTP headers */
-   char* body;    /**< The HTTP body */
+   int endpoint;            /**< The endpoint */
+   int socket;              /**< The socket descriptor */
+   char* body;              /**< The HTTP response body */
+   char* headers;           /**< The HTTP response headers */
+   char* request_headers;   /**< The HTTP request headers */
+   SSL* ssl;                /**< The SSL connection (NULL for non-secure) */
 };
 
 /**
- * Create a HTTP interaction
- * @param endpoint The endpoint
- * @param http The resulting HTTP interaction
- * @return 0 if success, otherwise 1
+ * Connect to an HTTP/HTTPS server
+ * @param hostname The host to connect to
+ * @param port The port number
+ * @param secure Use SSL if true
+ * @param result The resulting HTTP structure
+ * @return 0 upon success, otherwise 1
  */
 int
-pgexporter_http_create(int endpoint, struct http** http);
+pgexporter_http_connect(char* hostname, int port, bool secure, struct http** result);
 
 /**
- * Execute GET request
- * @param http The HTTP interaction
- * @return 0 if success, otherwise 1
+ * Disconnect and clean up HTTP resources
+ * @param http The HTTP structure
+ * @return 0 upon success, otherwise 1
  */
 int
-pgexporter_http_get(struct http* http);
+pgexporter_http_disconnect(struct http* http);
 
 /**
- * Destroy HTTP interaction
- * @param http The HTTP interaction
- * @return 0 if success, otherwise 1
+ * Add a header to the HTTP request
+ * @param http The HTTP structure
+ * @param name The header name
+ * @param value The header value
+ * @return 0 upon success, otherwise 1
  */
 int
-pgexporter_http_destroy(struct http* http);
+pgexporter_http_add_header(struct http* http, char* name, char* value);
+
+/**
+ * Read response data directly from a socket
+ * @param ssl SSL connection (can be NULL for non-secure connections)
+ * @param socket The socket to read from
+ * @param response_text Pointer to store the response text
+ * @return MESSAGE_STATUS_OK on success, MESSAGE_STATUS_ERROR otherwise
+ */
+int
+pgexporter_http_read(SSL* ssl, int socket, char** response_text);
+
+/**
+ * Perform HTTP GET request
+ * @param http The HTTP structure
+ * @param hostname The hostname for the Host header
+ * @param path The path for the request
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_http_get(struct http* http, char* hostname, char* path);
+
+/**
+ * Perform HTTP POST request
+ * @param http The HTTP structure
+ * @param hostname The hostname for the Host header
+ * @param path The path for the request
+ * @param data The data to send
+ * @param length The length of the data
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_http_post(struct http* http, char* hostname, char* path, char* data, size_t length);
+
+/**
+ * Perform HTTP PUT request
+ * @param http The HTTP structure
+ * @param hostname The hostname for the Host header
+ * @param path The path for the request
+ * @param data The data to upload
+ * @param length The length of the data
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_http_put(struct http* http, char* hostname, char* path, const void* data, size_t length);
+
+/**
+ * Perform HTTP PUT request with a file
+ * @param http The HTTP structure
+ * @param hostname The hostname for the Host header
+ * @param path The path for the request
+ * @param file The file to upload
+ * @param file_size The size of the file
+ * @param content_type The content type of the file (can be NULL for default)
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_http_put_file(struct http* http, char* hostname, char* path, FILE* file, size_t file_size, char* content_type);
 
 #ifdef __cplusplus
 }

--- a/src/libpgexporter/http.c
+++ b/src/libpgexporter/http.c
@@ -27,188 +27,83 @@
  */
 
 /* pgexporter */
-#include "message.h"
 #include <pgexporter.h>
 #include <http.h>
 #include <logging.h>
-#include <memory.h>
 #include <network.h>
-#include <stdlib.h>
+#include <security.h>
 #include <utils.h>
 
-#include <stdio.h>
-#include <string.h>
+/* system */
+#include <errno.h>
+#include <unistd.h>
+#include <openssl/err.h>
 
-static int build_get_request(int endpoint, char** request);
-static int extract_headers_body(char* response, struct http* http);
-
-int
-pgexporter_http_create(int endpoint, struct http** http)
-{
-   struct http* h = NULL;
-   struct configuration* config = NULL;
-
-   config = (struct configuration*)shmem;
-
-   *http = NULL;
-
-   h = (struct http*)malloc(sizeof(struct http));
-
-   if (h == NULL)
-   {
-      pgexporter_log_error("Failed to allocate to HTTP");
-      goto error;
-   }
-
-   /* Initialize */
-   memset(h, 0, sizeof(struct http));
-
-   h->endpoint = endpoint;
-
-   if (pgexporter_connect(config->endpoints[endpoint].host, config->endpoints[endpoint].port, &h->socket))
-   {
-      pgexporter_log_error("Failed to connect to %s:%d",
-                           config->endpoints[endpoint].host,
-                           config->endpoints[endpoint].port);
-      goto error;
-   }
-
-   *http = h;
-
-   return 0;
-
-error:
-
-   free(h);
-
-   return 1;
-}
+static int http_build_header(int method, char* path, char** request);
+static int http_extract_headers_body(char* response, struct http* http);
 
 int
-pgexporter_http_get(struct http* http)
+pgexporter_http_add_header(struct http* http, char* name, char* value)
 {
-   struct message* msg_request = NULL;
-   struct message* msg_response = NULL;
-   int error = 0;
-   int status;
-   char* request = NULL;
-   char* response = NULL;
+   char* tmp = NULL;
 
-   if (build_get_request(http->endpoint, &request))
+   tmp = pgexporter_append(http->request_headers, name);
+   if (tmp == NULL)
    {
-      goto error;
+      return 1;
    }
+   http->request_headers = tmp;
 
-   msg_request = (struct message*)malloc(sizeof(struct message));
-   if (msg_request == NULL)
+   tmp = pgexporter_append(http->request_headers, ": ");
+   if (tmp == NULL)
    {
-      goto error;
+      return 1;
    }
+   http->request_headers = tmp;
 
-   memset(msg_request, 0, sizeof(struct message));
-
-   msg_request->data = request;
-   msg_request->length = strlen(request) + 1;
-
-   error = 0;
-req:
-   if (error < 5)
+   tmp = pgexporter_append(http->request_headers, value);
+   if (tmp == NULL)
    {
-      status = pgexporter_write_message(NULL, http->socket, msg_request);
-      if (status != MESSAGE_STATUS_OK)
-      {
-         error++;
-         goto req;
-      }
+      return 1;
    }
-   else
+   http->request_headers = tmp;
+
+   tmp = pgexporter_append(http->request_headers, "\r\n");
+   if (tmp == NULL)
    {
-      goto error;
+      return 1;
    }
-
-res:
-   status = pgexporter_read_block_message(NULL, http->socket, &msg_response);
-   if (status != MESSAGE_STATUS_ZERO)
-   {
-      if (status == MESSAGE_STATUS_OK)
-      {
-         response = pgexporter_append(response, (char*)msg_response->data);
-         pgexporter_clear_message();
-         goto res;
-      }
-      else
-      {
-         goto error;
-      }
-   }
-
-   if (msg_response->length > 0)
-   {
-      response = pgexporter_append(response, (char*)msg_response->data);
-   }
-
-   if (extract_headers_body(response, http))
-   {
-      goto error;
-   }
-
-   free(request);
-   free(response);
-
-   free(msg_request);
-
-   return 0;
-
-error:
-
-   free(request);
-   free(response);
-
-   free(msg_request);
-
-   return 1;
-}
-
-int
-pgexporter_http_destroy(struct http* http)
-{
-   if (http != NULL)
-   {
-      pgexporter_disconnect(http->socket);
-
-      free(http->headers);
-      free(http->body);
-   }
-
-   free(http);
-   http = NULL;
+   http->request_headers = tmp;
 
    return 0;
 }
 
 static int
-build_get_request(int endpoint, char** request)
+http_build_header(int method, char* path, char** request)
 {
    char* r = NULL;
-   struct configuration* config = NULL;
-
-   config = (struct configuration*)shmem;
-
    *request = NULL;
 
-   r = pgexporter_append(r, "GET /metrics HTTP/1.1\r\n");
+   if (method == PGEXPORTER_HTTP_GET)
+   {
+      r = pgexporter_append(r, "GET ");
+   }
+   else if (method == PGEXPORTER_HTTP_POST)
+   {
+      r = pgexporter_append(r, "POST ");
+   }
+   else if (method == PGEXPORTER_HTTP_PUT)
+   {
+      r = pgexporter_append(r, "PUT ");
+   }
+   else
+   {
+      pgexporter_log_error("Invalid HTTP method: %d", method);
+      return 1;
+   }
 
-   r = pgexporter_append(r, "Host: ");
-   r = pgexporter_append(r, config->endpoints[endpoint].host);
-   r = pgexporter_append(r, "\r\n");
-
-   r = pgexporter_append(r, "User-Agent: pgexporter/");
-   r = pgexporter_append(r, VERSION);
-   r = pgexporter_append(r, "\r\n");
-
-   r = pgexporter_append(r, "Accept: text/*\r\n");
-
-   r = pgexporter_append(r, "\r\n");
+   r = pgexporter_append(r, path);
+   r = pgexporter_append(r, " HTTP/1.1\r\n");
 
    *request = r;
 
@@ -216,12 +111,26 @@ build_get_request(int endpoint, char** request)
 }
 
 static int
-extract_headers_body(char* response, struct http* http)
+http_extract_headers_body(char* response, struct http* http)
 {
    bool header = true;
    char* p = NULL;
+   char* response_copy = NULL;
 
-   p = strtok(response, "\n");
+   if (response == NULL)
+   {
+      pgexporter_log_error("Response is NULL");
+      goto error;
+   }
+
+   response_copy = strdup(response);
+   if (response_copy == NULL)
+   {
+      pgexporter_log_error("Failed to duplicate response string");
+      goto error;
+   }
+
+   p = strtok(response_copy, "\n");
    while (p != NULL)
    {
       if (*p == '\r')
@@ -248,5 +157,770 @@ extract_headers_body(char* response, struct http* http)
       p = strtok(NULL, "\n");
    }
 
+   free(response_copy);
    return 0;
+
+error:
+   free(response_copy);
+   return 1;
+}
+
+int
+pgexporter_http_get(struct http* http, char* hostname, char* path)
+{
+   struct message msg_request;
+   struct message* msg_response = NULL;
+   int error = 0;
+   int status;
+   char* request = NULL;
+   char* full_request = NULL;
+   char* response = NULL;
+   char* user_agent = NULL;
+   char* endpoint = (path != NULL) ? path : "/metrics";
+
+   memset(&msg_request, 0, sizeof(struct message));
+
+   pgexporter_log_trace("Starting pgexporter_http_get");
+   if (http_build_header(PGEXPORTER_HTTP_GET, endpoint, &request))
+   {
+      pgexporter_log_error("Failed to build HTTP header");
+      goto error;
+   }
+
+   pgexporter_http_add_header(http, "Host", hostname);
+   user_agent = pgexporter_append(user_agent, "pgexporter/");
+   user_agent = pgexporter_append(user_agent, VERSION);
+   pgexporter_http_add_header(http, "User-Agent", user_agent);
+   pgexporter_http_add_header(http, "Accept", "text/*");
+   pgexporter_http_add_header(http, "Connection", "close");
+
+   full_request = pgexporter_append(NULL, request);
+   full_request = pgexporter_append(full_request, http->request_headers);
+   full_request = pgexporter_append(full_request, "\r\n");
+
+   msg_request.data = full_request;
+   msg_request.length = strlen(full_request) + 1;
+
+   error = 0;
+req:
+   if (error < 5)
+   {
+      status = pgexporter_write_message(http->ssl, http->socket, &msg_request);
+      if (status != MESSAGE_STATUS_OK)
+      {
+         error++;
+         pgexporter_log_debug("Write failed, retrying (%d/5)", error);
+         goto req;
+      }
+   }
+   else
+   {
+      pgexporter_log_error("Failed to write after 5 attempts");
+      goto error;
+   }
+
+res:
+   // Get a pointer to the global message structure
+   status = pgexporter_read_block_message(http->ssl, http->socket, &msg_response);
+   if (status != MESSAGE_STATUS_ZERO)
+   {
+      if (status == MESSAGE_STATUS_OK)
+      {
+         // Get data from the response message
+         if (msg_response != NULL && msg_response->data != NULL)
+         {
+            response = pgexporter_append(response, (char*)msg_response->data);
+         }
+         pgexporter_clear_message();
+         goto res;
+      }
+      else
+      {
+         pgexporter_log_error("Error reading response");
+         goto error;
+      }
+   }
+
+   if (msg_response != NULL && msg_response->length > 0 && msg_response->data != NULL)
+   {
+      response = pgexporter_append(response, (char*)msg_response->data);
+   }
+
+   if (http_extract_headers_body(response, http))
+   {
+      pgexporter_log_error("Failed to extract headers and body");
+      goto error;
+   }
+
+   pgexporter_log_debug("HTTP Headers: %s", http->headers != NULL ? http->headers : "NULL");
+   pgexporter_log_debug("HTTP Body: %s", http->body != NULL ? http->body : "NULL");
+
+   free(request);
+   free(full_request);
+   free(response);
+   free(user_agent);
+
+   free(http->request_headers);
+   http->request_headers = NULL;
+
+   return 0;
+
+error:
+   free(request);
+   free(full_request);
+   free(response);
+   free(user_agent);
+   free(http->request_headers);
+   http->request_headers = NULL;
+   return 1;
+}
+
+int
+pgexporter_http_connect(char* hostname, int port, bool secure, struct http** result)
+{
+   struct http* h = NULL;
+   int socket_fd = -1;
+   SSL* ssl = NULL;
+   SSL_CTX* ctx = NULL;
+
+   pgexporter_log_debug("Connecting to %s:%d (secure: %d)", hostname, port, secure);
+   h = (struct http*) malloc(sizeof(struct http));
+   if (h == NULL)
+   {
+      pgexporter_log_error("Failed to allocate HTTP structure");
+      goto error;
+   }
+
+   memset(h, 0, sizeof(struct http));
+
+   if (pgexporter_connect(hostname, port, &socket_fd))
+   {
+      pgexporter_log_error("Failed to connect to %s:%d", hostname, port);
+      goto error;
+   }
+
+   h->socket = socket_fd;
+
+   if (secure)
+   {
+      if (pgexporter_create_ssl_ctx(true, &ctx))
+      {
+         pgexporter_log_error("Failed to create SSL context");
+         goto error;
+      }
+
+      if (SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION) == 0)
+      {
+         pgexporter_log_error("Failed to set minimum TLS version");
+         goto error;
+      }
+
+      ssl = SSL_new(ctx);
+      if (ssl == NULL)
+      {
+         pgexporter_log_error("Failed to create SSL structure");
+         goto error;
+      }
+
+      if (SSL_set_fd(ssl, socket_fd) == 0)
+      {
+         pgexporter_log_error("Failed to set SSL file descriptor");
+         goto error;
+      }
+
+      int connect_result;
+      do
+      {
+         connect_result = SSL_connect(ssl);
+
+         if (connect_result != 1)
+         {
+            int err = SSL_get_error(ssl, connect_result);
+            switch (err)
+            {
+               case SSL_ERROR_WANT_READ:
+               case SSL_ERROR_WANT_WRITE:
+                  continue;
+               default:
+                  pgexporter_log_error("SSL connection failed: %s", ERR_error_string(err, NULL));
+                  goto error;
+            }
+         }
+      }
+      while (connect_result != 1);
+
+      h->ssl = ssl;
+   }
+
+   *result = h;
+
+   return 0;
+
+error:
+   if (ssl != NULL)
+   {
+      SSL_free(ssl);
+   }
+   if (ctx != NULL)
+   {
+      SSL_CTX_free(ctx);
+   }
+   if (socket_fd != -1)
+   {
+      pgexporter_disconnect(socket_fd);
+   }
+   free(h);
+   return 1;
+}
+
+int
+pgexporter_http_post(struct http* http, char* hostname, char* path, char* data, size_t length)
+{
+   struct message msg_request;
+   struct message* msg_request_ptr = NULL;
+   int error = 0;
+   int status;
+   char* request = NULL;
+   char* full_request = NULL;
+   char* response = NULL;
+   char* user_agent = NULL;
+   char content_length[32];
+
+   memset(&msg_request, 0, sizeof(struct message));
+
+   pgexporter_log_trace("Starting pgexporter_http_post");
+   if (http_build_header(PGEXPORTER_HTTP_POST, path, &request))
+   {
+      pgexporter_log_error("Failed to build HTTP header");
+      goto error;
+   }
+
+   pgexporter_http_add_header(http, "Host", hostname);
+   user_agent = pgexporter_append(user_agent, "pgexporter/");
+   user_agent = pgexporter_append(user_agent, VERSION);
+   pgexporter_http_add_header(http, "User-Agent", user_agent);
+   pgexporter_http_add_header(http, "Connection", "close");
+
+   sprintf(content_length, "%zu", length);
+   pgexporter_http_add_header(http, "Content-Length", content_length);
+   pgexporter_http_add_header(http, "Content-Type", "application/x-www-form-urlencoded");
+
+   full_request = pgexporter_append(NULL, request);
+   full_request = pgexporter_append(full_request, http->request_headers);
+   full_request = pgexporter_append(full_request, "\r\n");
+
+   if (data != NULL && length > 0)
+   {
+      full_request = pgexporter_append(full_request, data);
+   }
+
+   msg_request_ptr = (struct message*)malloc(sizeof(struct message));
+   if (msg_request_ptr == NULL)
+   {
+      pgexporter_log_error("Failed to allocate msg_request");
+      goto error;
+   }
+
+   memset(msg_request_ptr, 0, sizeof(struct message));
+
+   msg_request_ptr->data = full_request;
+   msg_request_ptr->length = strlen(full_request) + 1;
+
+   error = 0;
+req:
+   if (error < 5)
+   {
+      status = pgexporter_write_message(http->ssl, http->socket, msg_request_ptr);
+      if (status != MESSAGE_STATUS_OK)
+      {
+         error++;
+         pgexporter_log_debug("Write failed, retrying (%d/5)", error);
+         goto req;
+      }
+   }
+   else
+   {
+      pgexporter_log_error("Failed to write after 5 attempts");
+      goto error;
+   }
+
+   status = pgexporter_http_read(http->ssl, http->socket, &response);
+
+   if (response == NULL)
+   {
+      pgexporter_log_error("No response data collected");
+      goto error;
+   }
+
+   if (http_extract_headers_body(response, http))
+   {
+      pgexporter_log_error("Failed to extract headers and body");
+      goto error;
+   }
+
+   free(request);
+   free(full_request);
+   free(response);
+   free(msg_request_ptr);
+   free(user_agent);
+
+   free(http->request_headers);
+   http->request_headers = NULL;
+
+   return 0;
+
+error:
+   free(request);
+   free(full_request);
+   free(response);
+   free(msg_request_ptr);
+   free(user_agent);
+   free(http->request_headers);
+   http->request_headers = NULL;
+   return 1;
+}
+
+int
+pgexporter_http_put(struct http* http, char* hostname, char* path, const void* data, size_t length)
+{
+   struct message msg_request;
+   struct message* msg_request_ptr = NULL;
+   int error = 0;
+   int status;
+   char* request = NULL;
+   char* full_request = NULL;
+   char* response = NULL;
+   char* user_agent = NULL;
+   char* complete_request = NULL;
+   char content_length[32];
+
+   memset(&msg_request, 0, sizeof(struct message));
+
+   pgexporter_log_trace("Starting pgexporter_http_put");
+   if (http_build_header(PGEXPORTER_HTTP_PUT, path, &request))
+   {
+      pgexporter_log_error("Failed to build HTTP header");
+      goto error;
+   }
+
+   pgexporter_http_add_header(http, "Host", hostname);
+   user_agent = pgexporter_append(user_agent, "pgexporter/");
+   user_agent = pgexporter_append(user_agent, VERSION);
+   pgexporter_http_add_header(http, "User-Agent", user_agent);
+   pgexporter_http_add_header(http, "Connection", "close");
+
+   sprintf(content_length, "%zu", length);
+   pgexporter_http_add_header(http, "Content-Length", content_length);
+   pgexporter_http_add_header(http, "Content-Type", "application/octet-stream");
+
+   full_request = pgexporter_append(NULL, request);
+   full_request = pgexporter_append(full_request, http->request_headers);
+   full_request = pgexporter_append(full_request, "\r\n");
+
+   size_t headers_len = strlen(full_request);
+   size_t total_len = headers_len + length;
+
+   complete_request = malloc(total_len + 1);
+   if (complete_request == NULL)
+   {
+      pgexporter_log_error("Failed to allocate complete request");
+      goto error;
+   }
+
+   memcpy(complete_request, full_request, headers_len);
+
+   if (data != NULL && length > 0)
+   {
+      memcpy(complete_request + headers_len, data, length);
+   }
+
+   complete_request[total_len] = '\0';
+
+   msg_request_ptr = (struct message*)malloc(sizeof(struct message));
+   if (msg_request_ptr == NULL)
+   {
+      pgexporter_log_error("Failed to allocate msg_request");
+      goto error;
+   }
+
+   memset(msg_request_ptr, 0, sizeof(struct message));
+
+   msg_request_ptr->data = complete_request;
+   msg_request_ptr->length = total_len + 1;
+
+   error = 0;
+req:
+   if (error < 5)
+   {
+      status = pgexporter_write_message(http->ssl, http->socket, msg_request_ptr);
+      if (status != MESSAGE_STATUS_OK)
+      {
+         error++;
+         pgexporter_log_debug("Write failed, retrying (%d/5)", error);
+         goto req;
+      }
+   }
+   else
+   {
+      pgexporter_log_error("Failed to write after 5 attempts");
+      goto error;
+   }
+
+   status = pgexporter_http_read(http->ssl, http->socket, &response);
+
+   if (response == NULL)
+   {
+      pgexporter_log_error("No response data collected");
+      goto error;
+   }
+
+   if (http_extract_headers_body(response, http))
+   {
+      pgexporter_log_error("Failed to extract headers and body");
+      goto error;
+   }
+
+   free(request);
+   free(full_request);
+   free(response);
+   free(msg_request_ptr->data);
+   free(msg_request_ptr);
+   free(user_agent);
+
+   free(http->request_headers);
+   http->request_headers = NULL;
+
+   return 0;
+
+error:
+   free(request);
+   free(full_request);
+   free(response);
+   free(complete_request);
+   free(msg_request_ptr);
+   free(user_agent);
+   free(http->request_headers);
+   http->request_headers = NULL;
+
+   return 1;
+}
+
+int
+pgexporter_http_put_file(struct http* http, char* hostname, char* path, FILE* file, size_t file_size, char* content_type)
+{
+   struct message msg_request;
+   struct message* msg_request_ptr = NULL;
+   int error = 0;
+   int status;
+   char* request = NULL;
+   char* header_part = NULL;
+   char* response = NULL;
+   char* user_agent = NULL;
+   char* full_request = NULL;
+   char content_length[32];
+   void* file_buffer = NULL;
+
+   memset(&msg_request, 0, sizeof(struct message));
+
+   pgexporter_log_trace("Starting pgexporter_http_put_file");
+   if (file == NULL)
+   {
+      pgexporter_log_error("File is NULL");
+      goto error;
+   }
+
+   if (http_build_header(PGEXPORTER_HTTP_PUT, path, &request))
+   {
+      pgexporter_log_error("Failed to build HTTP header");
+      goto error;
+   }
+
+   pgexporter_http_add_header(http, "Host", hostname);
+   user_agent = pgexporter_append(user_agent, "pgexporter/");
+   user_agent = pgexporter_append(user_agent, VERSION);
+   pgexporter_http_add_header(http, "User-Agent", user_agent);
+   pgexporter_http_add_header(http, "Connection", "close");
+
+   sprintf(content_length, "%zu", file_size);
+   pgexporter_http_add_header(http, "Content-Length", content_length);
+
+   /* default to application/octet-stream if not specified */
+   char* type = (content_type != NULL) ? content_type : "application/octet-stream";
+   pgexporter_http_add_header(http, "Content-Type", type);
+
+   header_part = pgexporter_append(NULL, request);
+   header_part = pgexporter_append(header_part, http->request_headers);
+   header_part = pgexporter_append(header_part, "\r\n");
+
+   pgexporter_log_trace("File size: %zu", file_size);
+
+   rewind(file);
+
+   file_buffer = malloc(file_size);
+   if (file_buffer == NULL)
+   {
+      pgexporter_log_error("Failed to allocate memory for file content: %zu bytes", file_size);
+      goto error;
+   }
+
+   size_t bytes_read = fread(file_buffer, 1, file_size, file);
+   if (bytes_read != file_size)
+   {
+      pgexporter_log_error("Failed to read entire file. Expected %zu bytes, got %zu", file_size, bytes_read);
+      goto error;
+   }
+
+   pgexporter_log_trace("Read %zu bytes from file", bytes_read);
+
+   msg_request_ptr = (struct message*)malloc(sizeof(struct message));
+   if (msg_request_ptr == NULL)
+   {
+      pgexporter_log_error("Failed to allocate msg_request");
+      goto error;
+   }
+
+   memset(msg_request_ptr, 0, sizeof(struct message));
+
+   size_t header_len = strlen(header_part);
+   size_t total_len = header_len + file_size;
+
+   full_request = malloc(total_len + 1);
+   if (full_request == NULL)
+   {
+      pgexporter_log_error("Failed to allocate memory for full request: %zu bytes", total_len + 1);
+      goto error;
+   }
+
+   memcpy(full_request, header_part, header_len);
+
+   memcpy(full_request + header_len, file_buffer, file_size);
+
+   full_request[total_len] = '\0';
+
+   pgexporter_log_trace("Setting msg_request data, total size: %zu", total_len);
+   msg_request_ptr->data = full_request;
+   msg_request_ptr->length = total_len;
+
+   error = 0;
+req:
+   if (error < 5)
+   {
+      status = pgexporter_write_message(http->ssl, http->socket, msg_request_ptr);
+      if (status != MESSAGE_STATUS_OK)
+      {
+         error++;
+         pgexporter_log_debug("Write failed, retrying (%d/5)", error);
+         goto req;
+      }
+   }
+   else
+   {
+      pgexporter_log_error("Failed to write after 5 attempts");
+      goto error;
+   }
+
+   status = pgexporter_http_read(http->ssl, http->socket, &response);
+
+   if (response == NULL)
+   {
+      pgexporter_log_error("No response data collected");
+      goto error;
+   }
+
+   if (http_extract_headers_body(response, http))
+   {
+      pgexporter_log_error("Failed to extract headers and body");
+      goto error;
+   }
+
+   int status_code = 0;
+   if (http->headers != NULL && sscanf(http->headers, "HTTP/1.1 %d", &status_code) == 1)
+   {
+      pgexporter_log_debug("HTTP status code: %d", status_code);
+      if (status_code >= 200 && status_code < 300)
+      {
+         pgexporter_log_debug("HTTP request successful");
+      }
+      else
+      {
+         pgexporter_log_error("HTTP request failed with status code: %d", status_code);
+      }
+   }
+
+   free(request);
+   free(header_part);
+   free(response);
+   free(file_buffer);
+   free(full_request);
+   free(msg_request_ptr);
+   free(user_agent);
+
+   free(http->request_headers);
+   http->request_headers = NULL;
+
+   return (status_code >= 200 && status_code < 300) ? 0 : 1;
+
+error:
+   free(request);
+   free(header_part);
+   free(response);
+   free(file_buffer);
+   free(full_request);
+   free(msg_request_ptr);
+   free(user_agent);
+   free(http->request_headers);
+   http->request_headers = NULL;
+
+   return 1;
+}
+
+int
+pgexporter_http_read(SSL* ssl, int socket, char** response_text)
+{
+   char buffer[8192];
+   ssize_t bytes_read;
+   int total_bytes = 0;
+   bool headers_complete = false;
+   bool chunked_encoding = false;
+
+   *response_text = NULL;
+
+   while (1)
+   {
+      if (ssl != NULL)
+      {
+         bytes_read = SSL_read(ssl, buffer, sizeof(buffer) - 1);
+         if (bytes_read <= 0)
+         {
+            int err = SSL_get_error(ssl, bytes_read);
+            if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE)
+            {
+               continue;
+            }
+            break;
+         }
+      }
+      else
+      {
+         bytes_read = read(socket, buffer, sizeof(buffer) - 1);
+         if (bytes_read < 0)
+         {
+            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
+            {
+               continue;
+            }
+            break;
+         }
+         else if (bytes_read == 0)
+         {
+            break;
+         }
+      }
+
+      buffer[bytes_read] = '\0';
+
+      if (*response_text == NULL)
+      {
+         *response_text = malloc(bytes_read + 1);
+         if (*response_text == NULL)
+         {
+            return MESSAGE_STATUS_ERROR;
+         }
+         memcpy(*response_text, buffer, bytes_read + 1);
+      }
+      else
+      {
+         size_t current_len = strlen(*response_text);
+         char* new_response = realloc(*response_text, current_len + bytes_read + 1);
+         if (new_response == NULL)
+         {
+            free(*response_text);
+            *response_text = NULL;
+            return MESSAGE_STATUS_ERROR;
+         }
+         *response_text = new_response;
+         memcpy(*response_text + current_len, buffer, bytes_read + 1);
+      }
+
+      total_bytes += bytes_read;
+
+      if (!headers_complete)
+      {
+         if (strstr(*response_text, "\r\n\r\n") != NULL)
+         {
+            headers_complete = true;
+            if (strstr(*response_text, "Transfer-Encoding: chunked") != NULL)
+            {
+               chunked_encoding = true;
+            }
+         }
+      }
+
+      if (!chunked_encoding && bytes_read < sizeof(buffer) - 1)
+      {
+         break;
+      }
+
+      if (chunked_encoding && strstr(*response_text, "\r\n0\r\n\r\n") != NULL)
+      {
+         break;
+      }
+   }
+
+   pgexporter_log_debug("Read %d bytes from socket", total_bytes);
+
+   return total_bytes > 0 ? MESSAGE_STATUS_OK : MESSAGE_STATUS_ERROR;
+}
+
+int
+pgexporter_http_disconnect(struct http* http)
+{
+   int status = 0;
+
+   if (http != NULL)
+   {
+      if (http->ssl != NULL)
+      {
+         pgexporter_close_ssl(http->ssl);
+         http->ssl = NULL;
+      }
+
+      if (http->socket != -1)
+      {
+         if (pgexporter_disconnect(http->socket))
+         {
+            pgexporter_log_error("Failed to disconnect socket in pgexporter_http_disconnect");
+            status = 1;
+         }
+         http->socket = -1;
+      }
+
+      if (http->headers != NULL)
+      {
+         free(http->headers);
+         http->headers = NULL;
+      }
+
+      if (http->body != NULL)
+      {
+         free(http->body);
+         http->body = NULL;
+      }
+
+      if (http->request_headers != NULL)
+      {
+         free(http->request_headers);
+         http->request_headers = NULL;
+      }
+   }
+
+   if (status != 0)
+   {
+      goto error;
+   }
+
+   return 0;
+
+error:
+   return 1;
 }

--- a/src/libpgexporter/utils.c
+++ b/src/libpgexporter/utils.c
@@ -963,6 +963,11 @@ pgexporter_vappend(char* orig, unsigned int n_str, ...)
    }
 
    strings = (char**) malloc(n_str * sizeof(char*));
+   if (strings == NULL)
+   {
+      pgexporter_log_error("malloc failed for strings array");
+      return orig;
+   }
 
    va_start(args, n_str);
 
@@ -972,7 +977,16 @@ pgexporter_vappend(char* orig, unsigned int n_str, ...)
       fin_len += strlen(strings[i]);
    }
 
-   str = (char*) realloc(orig, fin_len + 1);
+   char* new_str = (char*) realloc(orig, fin_len + 1);
+   if (new_str == NULL)
+   {
+      pgexporter_log_error("realloc failed for appended string");
+      free(strings);
+      va_end(args);
+      return orig;
+   }
+
+   str = new_str;
    ptr = str + orig_len;
 
    for (unsigned int i = 0; i < n_str; i++)


### PR DESCRIPTION
This is a port from [pgmoneta](https://github.com/pgmoneta/pgmoneta/pull/620/) where we improvise our http functionality. I added a bridge and sent curl request to 5003 with this configuration. Addressing #226 

```
[pgexporter]
host = localhost
metrics = 5002
bridge = 5003
bridge_endpoints = localhost:5002
log_type = file
log_level = debug
log_path = /tmp/pgexporter.log
```

The logs remain the same what we obtained from previous implementation, and bridge works just fine. PTAL @jesperpedersen 