### PR TITLE
Use MAX_PATH for files

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -320,7 +320,7 @@ static int
 master_key(char* password, bool generate_pwd, int pwd_length, int32_t output_format)
 {
    FILE* file = NULL;
-   char buf[MISC_LENGTH];
+   char buf[MAX_PATH];
    char* encoded = NULL;
    size_t encoded_length;
    struct stat st = {0};
@@ -786,7 +786,7 @@ update_user(char* users_path, char* username, char* password, bool generate_pwd,
 {
    FILE* users_file = NULL;
    FILE* users_file_tmp = NULL;
-   char tmpfilename[MISC_LENGTH];
+   char tmpfilename[MAX_PATH];
    char line[MISC_LENGTH];
    char line_copy[MISC_LENGTH];
    char* entry = NULL;
@@ -1051,7 +1051,7 @@ remove_user(char* users_path, char* username, int32_t output_format)
 {
    FILE* users_file = NULL;
    FILE* users_file_tmp = NULL;
-   char tmpfilename[MISC_LENGTH];
+   char tmpfilename[MAX_PATH];
    char line[MISC_LENGTH];
    char line_copy[MISC_LENGTH];
    char* ptr = NULL;

--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -231,9 +231,9 @@ struct server
    int state;                          /**< The state of the server */
    int version;                        /**< The major version of the server*/
    int minor_version;                  /**< The minor version of the server*/
-   char tls_cert_file[MISC_LENGTH];    /**< TLS certificate path */
-   char tls_key_file[MISC_LENGTH];     /**< TLS key path */
-   char tls_ca_file[MISC_LENGTH];      /**< TLS CA certificate path */
+   char tls_cert_file[MAX_PATH];       /**< TLS certificate path */
+   char tls_key_file[MAX_PATH];        /**< TLS key path */
+   char tls_ca_file[MAX_PATH];         /**< TLS CA certificate path */
 } __attribute__ ((aligned (64)));
 
 /** @struct user
@@ -370,7 +370,7 @@ struct configuration
 
    int blocking_timeout;       /**< The blocking timeout in seconds */
    int authentication_timeout; /**< The authentication timeout in seconds */
-   char pidfile[MISC_LENGTH];  /**< File containing the PID */
+   char pidfile[MAX_PATH];     /**< File containing the PID */
 
    unsigned int update_process_title;  /**< Behaviour for updating the process title */
 

--- a/src/libpgexporter/configuration.c
+++ b/src/libpgexporter/configuration.c
@@ -661,9 +661,9 @@ pgexporter_read_configuration(void* shm, char* filename)
                   if (!strcmp(section, "pgexporter"))
                   {
                      max = strlen(value);
-                     if (max > MISC_LENGTH - 1)
+                     if (max > MAX_PATH - 1)
                      {
-                        max = MISC_LENGTH - 1;
+                        max = MAX_PATH - 1;
                      }
                      memcpy(config->pidfile, value, max);
                   }
@@ -925,9 +925,9 @@ pgexporter_read_configuration(void* shm, char* filename)
                   if (!strcmp(section, "pgexporter"))
                   {
                      max = strlen(value);
-                     if (max > MISC_LENGTH - 1)
+                     if (max > MAX_PATH - 1)
                      {
-                        max = MISC_LENGTH - 1;
+                        max = MAX_PATH - 1;
                      }
                      memcpy(config->metrics_path, value, max);
                   }
@@ -1812,9 +1812,9 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
       else if (!strcmp(key, "metrics_path"))
       {
          max = strlen(config_value);
-         if (max > MISC_LENGTH - 1)
+         if (max > MAX_PATH - 1)
          {
-            max = MISC_LENGTH - 1;
+            max = MAX_PATH - 1;
          }
          memcpy(config->metrics_path, config_value, max);
          pgexporter_json_put(response, key, (uintptr_t)config->metrics_path, ValueString);
@@ -1909,9 +1909,9 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
          if (strlen(section) > 0)
          {
             max = strlen(config_value);
-            if (max > MISC_LENGTH - 1)
+            if (max > MAX_PATH - 1)
             {
-               max = MISC_LENGTH - 1;
+               max = MAX_PATH - 1;
             }
             memcpy(&config->servers[server_index].tls_ca_file, config_value, max);
             pgexporter_json_put(server_j, key, (uintptr_t)config->servers[server_index].tls_ca_file, ValueString);
@@ -1933,9 +1933,9 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
          if (strlen(section) > 0)
          {
             max = strlen(config_value);
-            if (max > MISC_LENGTH - 1)
+            if (max > MAX_PATH - 1)
             {
-               max = MISC_LENGTH - 1;
+               max = MAX_PATH - 1;
             }
             memcpy(&config->servers[server_index].tls_cert_file, config_value, max);
             pgexporter_json_put(server_j, key, (uintptr_t)config->servers[server_index].tls_cert_file, ValueString);
@@ -1957,9 +1957,9 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
          if (strlen(section) > 0)
          {
             max = strlen(config_value);
-            if (max > MISC_LENGTH - 1)
+            if (max > MAX_PATH - 1)
             {
-               max = MISC_LENGTH - 1;
+               max = MAX_PATH - 1;
             }
             memcpy(&config->servers[server_index].tls_key_file, config_value, max);
             pgexporter_json_put(server_j, key, (uintptr_t)config->servers[server_index].tls_key_file, ValueString);
@@ -1979,9 +1979,9 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
       else if (!strcmp(key, "metrics_ca_file"))
       {
             max = strlen(config_value);
-            if (max > MISC_LENGTH - 1)
+            if (max > MAX_PATH - 1)
             {
-               max = MISC_LENGTH - 1;
+               max = MAX_PATH - 1;
             }
             memcpy(config->metrics_ca_file, config_value, max);
             pgexporter_json_put(response, key, (uintptr_t)config->metrics_ca_file, ValueString);
@@ -1989,9 +1989,9 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
       else if (!strcmp(key, "metrics_cert_file"))
       {
             max = strlen(config_value);
-            if (max > MISC_LENGTH - 1)
+            if (max > MAX_PATH - 1)
             {
-               max = MISC_LENGTH - 1;
+               max = MAX_PATH - 1;
             }
             memcpy(config->metrics_cert_file, config_value, max);
             pgexporter_json_put(response, key, (uintptr_t)config->metrics_cert_file, ValueString);
@@ -1999,9 +1999,9 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
       else if (!strcmp(key, "metrics_key_file"))
       {
             max = strlen(config_value);
-            if (max > MISC_LENGTH - 1)
+            if (max > MAX_PATH - 1)
             {
-               max = MISC_LENGTH - 1;
+               max = MAX_PATH - 1;
             }
             memcpy(config->metrics_key_file, config_value, max);
             pgexporter_json_put(response, key, (uintptr_t)config->metrics_key_file, ValueString);
@@ -2017,9 +2017,9 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
       else if (!strcmp(key, "pidfile"))
       {
          max = strlen(config_value);
-         if (max > MISC_LENGTH - 1)
+         if (max > MAX_PATH - 1)
          {
-            max = MISC_LENGTH - 1;
+            max = MAX_PATH - 1;
          }
          memcpy(config->pidfile, config_value, max);
          pgexporter_json_put(response, key, (uintptr_t)config->pidfile, ValueString);
@@ -3258,12 +3258,12 @@ transfer_configuration(struct configuration* config, struct configuration* reloa
    /* log_lock */
 
    config->tls = reload->tls;
-   memcpy(config->tls_cert_file, reload->tls_cert_file, MISC_LENGTH);
-   memcpy(config->tls_key_file, reload->tls_key_file, MISC_LENGTH);
-   memcpy(config->tls_ca_file, reload->tls_ca_file, MISC_LENGTH);
-   memcpy(config->metrics_cert_file, reload->metrics_cert_file, MISC_LENGTH);
-   memcpy(config->metrics_key_file, reload->metrics_key_file, MISC_LENGTH);
-   memcpy(config->metrics_ca_file, reload->metrics_ca_file, MISC_LENGTH);
+   memcpy(config->tls_cert_file, reload->tls_cert_file, MAX_PATH);
+   memcpy(config->tls_key_file, reload->tls_key_file, MAX_PATH);
+   memcpy(config->tls_ca_file, reload->tls_ca_file, MAX_PATH);
+   memcpy(config->metrics_cert_file, reload->metrics_cert_file, MAX_PATH);
+   memcpy(config->metrics_key_file, reload->metrics_key_file, MAX_PATH);
+   memcpy(config->metrics_ca_file, reload->metrics_ca_file, MAX_PATH);
 
    config->blocking_timeout = reload->blocking_timeout;
    config->authentication_timeout = reload->authentication_timeout;
@@ -3319,7 +3319,7 @@ transfer_configuration(struct configuration* config, struct configuration* reloa
    config->number_of_admins = reload->number_of_admins;
 
    /* prometheus */
-   memcpy(config->metrics_path, reload->metrics_path, MISC_LENGTH);
+   memcpy(config->metrics_path, reload->metrics_path, MAX_PATH);
    for (int i = 0; i < reload->number_of_metrics; i++)
    {
       copy_promethus(&config->prometheus[i], &reload->prometheus[i]);

--- a/src/libpgexporter/security.c
+++ b/src/libpgexporter/security.c
@@ -294,9 +294,9 @@ pgexporter_remote_management_scram_sha256(char* username, char* password, int se
 {
    int status = MESSAGE_STATUS_ERROR;
    SSL* ssl = NULL;
-   char key_file[MISC_LENGTH];
-   char cert_file[MISC_LENGTH];
-   char root_file[MISC_LENGTH];
+   char key_file[MAX_PATH];
+   char cert_file[MAX_PATH];
+   char root_file[MAX_PATH];
    struct stat st = {0};
    char* salt = NULL;
    size_t salt_length = 0;


### PR DESCRIPTION
Addressing #224  I changed `pidfile` to MAX_PATH since that was done in pgagroal and pgmoneta as well, rest I think are understandable. @jesperpedersen  PTAL