### PR TITLE
Query Extensions on Startup

### DIFF
--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -70,6 +70,7 @@ extern "C" {
 #define NUMBER_OF_METRICS     256
 #define NUMBER_OF_COLLECTORS  256
 #define NUMBER_OF_ENDPOINTS    32
+#define NUMBER_OF_EXTENSIONS   64
 
 #define STATE_FREE        0
 #define STATE_IN_USE      1
@@ -213,27 +214,41 @@ extern void* bridge_cache_shmem;
  */
 extern void* bridge_json_cache_shmem;
 
+/** @struct extension_info
+ * Defines information about a PostgreSQL extension
+ */
+struct extension_info
+{
+   char name[MISC_LENGTH];              /**< The extension name */
+   char installed_version[MISC_LENGTH]; /**< The installed version */
+   char comment[MISC_LENGTH];           /**< The extension description/comment */
+   int server;                          /**< The server index */
+   bool enabled;                        /**< Is extension enabled */
+} __attribute__ ((aligned (64)));
+
 /** @struct server
  * Defines a server
  */
 struct server
 {
-   char name[MISC_LENGTH];             /**< The name of the server */
-   char host[MISC_LENGTH];             /**< The host name of the server */
-   int port;                           /**< The port of the server */
-   char username[MAX_USERNAME_LENGTH]; /**< The user name */
-   char data[MISC_LENGTH];             /**< The data directory */
-   char wal[MISC_LENGTH];              /**< The WAL directory */
-   SSL* ssl;                           /**< The SSL structure */
-   int fd;                             /**< The socket descriptor */
-   bool new;                           /**< Is the connection new */
-   bool extension;                     /**< Is the pgexporter_ext extension installed */
-   int state;                          /**< The state of the server */
-   int version;                        /**< The major version of the server*/
-   int minor_version;                  /**< The minor version of the server*/
-   char tls_cert_file[MAX_PATH];       /**< TLS certificate path */
-   char tls_key_file[MAX_PATH];        /**< TLS key path */
-   char tls_ca_file[MAX_PATH];         /**< TLS CA certificate path */
+   char name[MISC_LENGTH];                                      /**< The name of the server */
+   char host[MISC_LENGTH];                                      /**< The host name of the server */
+   int port;                                                    /**< The port of the server */
+   char username[MAX_USERNAME_LENGTH];                          /**< The user name */
+   char data[MISC_LENGTH];                                      /**< The data directory */
+   char wal[MISC_LENGTH];                                       /**< The WAL directory */
+   SSL* ssl;                                                    /**< The SSL structure */
+   int fd;                                                      /**< The socket descriptor */
+   bool new;                                                    /**< Is the connection new */
+   bool extension;                                              /**< Is the pgexporter_ext extension installed */
+   int state;                                                   /**< The state of the server */
+   int version;                                                 /**< The major version of the server*/
+   int minor_version;                                           /**< The minor version of the server*/
+   int number_of_extensions;                                    /**< The number of extensions */
+   char tls_cert_file[MAX_PATH];                                /**< TLS certificate path */
+   char tls_key_file[MAX_PATH];                                 /**< TLS key path */
+   char tls_ca_file[MAX_PATH];                                  /**< TLS CA certificate path */
+   struct extension_info extensions[NUMBER_OF_EXTENSIONS];      /**< The extensions */
 } __attribute__ ((aligned (64)));
 
 /** @struct user

--- a/src/include/queries.h
+++ b/src/include/queries.h
@@ -159,6 +159,15 @@ int
 pgexporter_query_database_size(int server, struct query** query);
 
 /**
+ * Query for installed extensions
+ * @param server The server
+ * @param query The resulting query
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_query_extensions_list(int server, struct query** query);
+
+/**
  * Query pg_replication_slot for active
  * @param server The server
  * @param query The resulting query


### PR DESCRIPTION
PTAL @jesperpedersen @resyfer , here's an example of what the metrics page additionaly displays now:
```
#HELP pgexporter_postgresql_extension_info Information about installed PostgreSQL extensions
#TYPE pgexporter_postgresql_extension_info gauge
pgexporter_postgresql_extension_info{server="primary",extension="pg_stat_statements",version="1_10",comment="track planning and execution statistics of all SQL statements executed"} 1
pgexporter_postgresql_extension_info{server="primary",extension="pgexporter_ext",version="0_3_0",comment="pgexporter extension for extra metrics"} 1
pgexporter_postgresql_extension_info{server="primary",extension="plpgsql",version="1_0",comment="PL/pgSQL procedural language"} 1
pgexporter_postgresql_extension_info{server="primary",extension="postgis",version="3_4_2",comment="PostGIS geometry and geography spatial types and functions"} 1
pgexporter_postgresql_extension_info{server="primary",extension="timescaledb",version="2_18_2",comment="Enables scalable inserts and complex queries for time-series data"} 1
```

I have added null terminators just incase the comment `MISC_LENGTH` of 128 chars