### PR TITLE
Add dereference check for bridge

### DIFF
--- a/src/libpgexporter/prometheus_client.c
+++ b/src/libpgexporter/prometheus_client.c
@@ -753,7 +753,7 @@ add_line(struct prometheus_metric* metric, char* line, int endpoint, time_t time
             goto error;
          }
       }
-      else if (*saveptr == '\0')
+      else if (saveptr == NULL || (saveptr != NULL && *saveptr == '\0'))
       {
          /* Final token. */
          line_value = strdup(token);


### PR DESCRIPTION
This was causing tests to fails, systems like Ubuntu can differentiate end of a line has been reached even by checking for '\0' but FreeBSD/Mac points the next token to NULL. This is why dereferencing it (checking if *saveptr = '\0') was causing it to crash.

I have added a check to first confirm if it is already NULL or if it ends by checking '\0'. In my ubuntu I do experience a slight  increase in the speed while hitting the bridge endpoint after this change as well. 

tldr; [short clip](https://youtu.be/HSmKiws-4NU?si=Kt8Pr8PRMlnmwMdq)