### PR TITLE
Use malloc in http_get

### DIFF
--- a/src/libpgexporter/utils.c
+++ b/src/libpgexporter/utils.c
@@ -240,6 +240,11 @@ pgexporter_has_message(char type, void* data, size_t data_size)
       else
       {
          offset += 1;
+         if (offset + sizeof(int32_t) > data_size)
+         {
+            pgexporter_log_debug("Not enough bytes left for int32_t");
+            break;
+         }
          offset += pgexporter_read_int32(data + offset);
       }
    }


### PR DESCRIPTION
Revamped the `http_get` to match exactly the one we use in `pgmoneta`. This was missing some validation checks earlier since we were receiving corrupted data from the bridge endpoint, now that the bridge issue has been fixed this free's the allocated memory on all paths. 

Apart from that also added a debug statement incase we try to read an integer out of bounds. Without this check, `curl` fails on FreeBSD debug mode on CI.
Part of the ongoing fixes in #241 