### PR TITLE
Add test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         build_type: [Debug, Release]
       fail-fast: false
 
-
     steps:
       - uses: actions/checkout@v4
 
@@ -31,13 +30,30 @@ jobs:
             libyaml-dev python3-docutils libatomic1 zlib1g zlib1g-dev \
             libzstd-dev liblz4-dev bzip2 libbz2-dev pandoc texlive-base \
             texlive-latex-recommended texlive-fonts-recommended texlive-extra-utils \
-            texlive-xetex texlive-fonts-extra wget graphviz doxygen
+            texlive-xetex texlive-fonts-extra wget graphviz doxygen \
+            check curl
+
+      - name: Install PostgreSQL
+        run: |
+          sudo apt install curl ca-certificates
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt update
+          sudo apt install -y postgresql-17
+
+      - name: Set Env Path Variable
+        run: |
+          echo "PATH=$PATH:/usr/lib/postgresql/17/bin" >> $GITHUB_ENV
+          echo $PATH
+
       - name: Install Eisvogel template for Pandoc
         run: |
               wget https://github.com/Wandmalfarbe/pandoc-latex-template/releases/download/v3.2.0/Eisvogel-3.2.0.tar.gz
               tar -xzf Eisvogel-3.2.0.tar.gz
               mkdir -p ~/.local/share/pandoc/templates
               mv Eisvogel-3.2.0/eisvogel.latex ~/.local/share/pandoc/templates/
+
       - name: Build Project
         run: |
               mkdir build
@@ -52,6 +68,33 @@ jobs:
               make -j$(nproc)
         working-directory: /home/runner/work/pgexporter/pgexporter/
 
+      - name: Run Tests
+        run: |
+          if [ "${{ matrix.compiler }}" = "gcc" ] && [ "${{ matrix.build_type }}" = "Debug" ]; then
+            ASAN_LIB=$(gcc -print-file-name=libasan.so)
+              export ASAN_OPTIONS=verify_asan_link_order=0
+              export LD_PRELOAD=$ASAN_LIB
+              export ASAN_OPTIONS=detect_leaks=0,verify_asan_link_order=0
+          fi
+          $(which bash) ./testsuite.sh
+        working-directory: /home/runner/work/pgexporter/pgexporter/build
+
+      - name: Upload pgexporter log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pgexporter-log-ubuntu-${{ matrix.compiler }}-${{ matrix.build_type }}
+          path: /home/runner/work/pgexporter/pgexporter/build/log/pgexporter.log
+          retention-days: 7
+
+      - name: Upload Build and Run Logs as Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-${{ matrix.compiler }}-${{ matrix.build_type }}
+          path: /home/runner/work/pgexporter/pgexporter/build/log
+          retention-days: 90
+
       - name: Upload Generated Documentation Artifact
         if: matrix.compiler == 'gcc' && matrix.build_type == 'Release'
         uses: actions/upload-artifact@v4
@@ -59,7 +102,6 @@ jobs:
           name: generated-docs
           path: /home/runner/work/pgexporter/pgexporter/build/doc
           retention-days: 90
-
 
   build-macos:
     runs-on: macos-latest
@@ -82,10 +124,15 @@ jobs:
         run: |
           brew update
           brew upgrade
-          brew install libev zstd lz4 bzip2 graphviz doxygen libyaml cmake docutils
+          brew install libev zstd lz4 bzip2 graphviz doxygen libyaml cmake docutils check pkg-config curl
           brew link --force bzip2
           brew link --force zstd
           brew link --force lz4
+
+      - name: Install PostgreSQL
+        run: |
+          brew install postgresql@17
+          echo "$(brew --prefix postgresql@17)/bin" >> $GITHUB_PATH
 
       - name: Debug Build
         run: |
@@ -93,13 +140,25 @@ jobs:
           cd build
           export CC=/usr/bin/clang
 
-          # Set library paths based on architecture
           cmake -DCMAKE_BUILD_TYPE=Debug .. \
             -DCMAKE_PREFIX_PATH="$HOMEBREW_PREFIX" \
             -DCMAKE_INCLUDE_PATH="$HOMEBREW_PREFIX/include" \
             -DCMAKE_LIBRARY_PATH="$HOMEBREW_PREFIX/lib"
 
           make
+
+      - name: Run Tests (Debug)
+        run: |
+          cd build
+          $(which bash) ./testsuite.sh
+
+      - name: Upload pgexporter log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pgexporter-log-macos
+          path: build/log/pgexporter.log
+          retention-days: 7
 
       - name: Release Build
         run: |
@@ -108,7 +167,6 @@ jobs:
           cd build
           export CC=/usr/bin/clang
 
-          # Set library paths based on architecture
           cmake -DCMAKE_BUILD_TYPE=Release .. \
             -DCMAKE_C_FLAGS='-D_DARWIN_C_SOURCE' \
             -DCMAKE_PREFIX_PATH="$HOMEBREW_PREFIX" \
@@ -139,6 +197,7 @@ jobs:
             libvirt-clients \
             bridge-utils
           sudo systemctl start libvirtd
+
       - name: Setup FreeBSD VM
         uses: vmactions/freebsd-vm@v1
         id: freebsd-vm
@@ -150,17 +209,17 @@ jobs:
           sync: rsync
           copyback: true
           prepare: |
-            # System bootstrap
             ASSUME_ALWAYS_YES=yes pkg bootstrap
             pkg update
             pkg upgrade -y
-            # Base dependencies
             pkg install -y \
               bash \
               sudo \
               libev \
               cmake \
               llvm11 \
+              postgresql17-server \
+              postgresql17-contrib \
               zstd \
               liblz4 \
               bzip2 \
@@ -174,7 +233,8 @@ jobs:
               hs-pandoc \
               texlive-base \
               texlive-texmf \
-              graphviz
+              graphviz \
+              pkgconf
 
       - name: Build Project
         shell: freebsd {0}
@@ -183,3 +243,17 @@ jobs:
           cd $GITHUB_WORKSPACE/build
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} "$GITHUB_WORKSPACE"
           make -j$(sysctl -n hw.ncpu)
+
+      - name: Run Tests
+        shell: freebsd {0}
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          bash ./testsuite.sh
+
+      - name: Upload pgexporter log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pgexporter-log-freebsd-${{ matrix.compiler }}-${{ matrix.build_type }}
+          path: ${GITHUB_WORKSPACE}/build/log/pgexporter.log
+          retention-days: 7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 message(STATUS "pgexporter ${VERSION_STRING}")
 
 set(generation TRUE)
+set(check TRUE)
 
 include(CheckCCompilerFlag)
 include(CheckCSourceCompiles)
@@ -61,6 +62,34 @@ endif ()
 CHECK_C_COMPILER_FLAG("-std=c17" COMPILER_SUPPORTS_C17)
 if(NOT COMPILER_SUPPORTS_C17)
   message(FATAL_ERROR "The compiler ${CMAKE_C_COMPILER} has no C17 support. Please use a different C compiler.")
+endif()
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+    set(HOMEBREW_PREFIX "/opt/homebrew")
+  else()
+    set(HOMEBREW_PREFIX "/usr/local")
+  endif()
+  
+  message(STATUS "Detected macOS with Homebrew prefix: ${HOMEBREW_PREFIX}")
+  
+  set(CMAKE_PREFIX_PATH "${HOMEBREW_PREFIX}" ${CMAKE_PREFIX_PATH})
+  include_directories("${HOMEBREW_PREFIX}/include")
+  link_directories("${HOMEBREW_PREFIX}/lib")
+  
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_DARWIN_C_SOURCE -I${HOMEBREW_PREFIX}/include")
+endif()
+
+find_package(Check)
+if (CHECK_FOUND)
+  message(STATUS "check found")
+  add_library(Check::check SHARED IMPORTED)
+  set_target_properties(Check::check PROPERTIES
+    IMPORTED_LOCATION ${CHECK_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${CHECK_INCLUDE_DIR})
+else ()
+  set(check FALSE)
+  message(STATUS "check needed. The test suite process will be skipped.")
 endif()
 
 find_package(ZLIB)
@@ -169,3 +198,4 @@ file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/src/")
 add_subdirectory(doc)
 add_subdirectory(src)
 add_subdirectory(extensions)
+add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,91 @@
+#
+# Copyright (C) 2025 The pgexporter community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Find Check framework
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(CHECK check)
+
+if (CHECK_FOUND)
+  set(SOURCES
+    tsclient.c
+    testcases/pgexporter_test_1.c
+    testcases/pgexporter_test_2.c
+    testcases/pgexporter_test_3.c
+    runner.c
+  )
+
+  add_compile_options(-O0)
+  add_compile_options(-DDEBUG)
+  
+  if (CMAKE_BUILD_TYPE MATCHES Debug)
+    if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+      if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+        if (NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+          add_compile_options(-fsanitize=address)
+          add_compile_options(-fsanitize=undefined)
+          add_compile_options(-fno-sanitize-recover=all)
+          add_compile_options(-fsanitize=float-divide-by-zero)
+          add_compile_options(-fsanitize=float-cast-overflow)
+          add_compile_options(-fno-sanitize=null)
+          add_compile_options(-fno-sanitize=alignment)
+
+          set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS_DEBUG} -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow -fno-sanitize=null -fno-sanitize=alignment")
+        endif()
+      endif()
+    endif()
+  endif()
+
+  add_executable(pgexporter_test ${SOURCES})
+  target_include_directories(pgexporter_test PRIVATE ${CMAKE_SOURCE_DIR}/src/include)
+  target_include_directories(pgexporter_test PRIVATE ${CMAKE_SOURCE_DIR}/test/include)
+  target_include_directories(pgexporter_test PRIVATE ${CHECK_INCLUDE_DIRS})
+
+  if(EXISTS "/etc/debian_version")
+    target_link_libraries(pgexporter_test ${CHECK_LIBRARIES} subunit pthread rt m pgexporter)
+  elseif(APPLE)
+    target_link_libraries(pgexporter_test ${CHECK_LIBRARIES} m pgexporter)
+  else()
+    target_link_libraries(pgexporter_test ${CHECK_LIBRARIES} pthread rt m pgexporter)
+  endif()
+
+  target_compile_options(pgexporter_test PRIVATE ${CHECK_CFLAGS_OTHER})
+  target_link_directories(pgexporter_test PRIVATE ${CHECK_LIBRARY_DIRS})
+
+  add_custom_target(custom_clean
+    COMMAND ${CMAKE_COMMAND} -E remove -f *.o pgexporter_test
+    COMMENT "Cleaning up..."
+  )
+else()
+  message(STATUS "Check framework not found - tests will be skipped")
+endif()
+
+configure_file(
+  "${CMAKE_SOURCE_DIR}/test/testsuite.sh"
+  "${CMAKE_BINARY_DIR}/testsuite.sh"
+  COPYONLY
+)

--- a/test/include/tsclient.h
+++ b/test/include/tsclient.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2025 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PGEXPORTER_TSCLIENT_H
+#define PGEXPORTER_TSCLIENT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <json.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define BUFFER_SIZE 8192
+
+#define PGEXPORTER_LOG_FILE_TRAIL      "/log/pgexporter.log"
+#define PGEXPORTER_EXECUTABLE_TRAIL    "/src/pgexporter-cli"
+#define PGEXPORTER_CONFIGURATION_TRAIL "/pgexporter-testsuite/conf/pgexporter.conf"
+
+extern char project_directory[BUFFER_SIZE];
+
+/**
+ * Initialize the tsclient API
+ * @param base_dir path to base
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tsclient_init(char* base_dir);
+
+/**
+ * Destroy the tsclient (must be used after pgexporter_tsclient_init)
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tsclient_destroy();
+
+/**
+ * Execute ping command on the server
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tsclient_execute_ping();
+
+/**
+ * Execute shutdown command on the server
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tsclient_execute_shutdown();
+
+/**
+ * Execute status command on the server
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tsclient_execute_status();
+
+/**
+ * Test database connection establishment
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tsclient_test_db_connection();
+
+/**
+ * Test PostgreSQL version query directly
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tsclient_test_version_query();
+
+/**
+ * Test extension path setup
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tsclient_test_extension_path();
+
+/**
+ * Test HTTP metrics endpoint functionality
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tsclient_test_http_metrics();
+
+/**
+ * Test bridge endpoint functionality
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tsclient_test_bridge_endpoint();
+
+/**
+ * Test extension detection functionality
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tsclient_test_extension_detection();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/test/runner.c
+++ b/test/runner.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <tsclient.h>
+
+#include "testcases/pgexporter_test_1.h"
+#include "testcases/pgexporter_test_2.h"
+#include "testcases/pgexporter_test_3.h"
+
+int
+main(int argc, char* argv[])
+{
+
+   if (argc != 2)
+   {
+      printf("Usage: %s <project_directory>\n", argv[0]);
+      return 1;
+   }
+
+   int number_failed;
+   Suite* s1;
+   Suite* s2;
+   Suite* s3;
+   SRunner* sr;
+
+   if (pgexporter_tsclient_init(argv[1]))
+   {
+      goto done;
+   }
+
+   s1 = pgexporter_test1_suite();
+   s2 = pgexporter_test2_suite();
+   s3 = pgexporter_test3_suite();
+
+   sr = srunner_create(s1);
+   srunner_add_suite(sr, s2);
+   srunner_add_suite(sr, s3);
+
+   srunner_run_all(sr, CK_VERBOSE);
+   number_failed = srunner_ntests_failed(sr);
+   srunner_free(sr);
+
+done:
+   pgexporter_tsclient_destroy();
+
+   return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test/testcases/pgexporter_test_1.c
+++ b/test/testcases/pgexporter_test_1.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <tsclient.h>
+
+#include "pgexporter_test_1.h"
+
+// Test that pgexporter daemon starts and responds to ping
+START_TEST(test_pgexporter_ping)
+{
+   int found = 0;
+   found = !pgexporter_tsclient_execute_ping();
+   ck_assert_msg(found, "pgexporter ping failed");
+}
+END_TEST
+
+// Test that pgexporter responds to status command
+START_TEST(test_pgexporter_status)
+{
+   int found = 0;
+   found = !pgexporter_tsclient_execute_status();
+   ck_assert_msg(found, "pgexporter status failed");
+}
+END_TEST
+
+Suite*
+pgexporter_test1_suite()
+{
+   Suite* s;
+   TCase* tc_core;
+
+   s = suite_create("pgexporter_test1");
+
+   tc_core = tcase_create("Core");
+
+   tcase_set_timeout(tc_core, 60);
+   tcase_add_test(tc_core, test_pgexporter_ping);
+   tcase_add_test(tc_core, test_pgexporter_status);
+   suite_add_tcase(s, tc_core);
+
+   return s;
+}

--- a/test/testcases/pgexporter_test_1.h
+++ b/test/testcases/pgexporter_test_1.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PGEXPORTER_TEST1_H
+#define PGEXPORTER_TEST1_H
+
+#include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * Set up a suite of test cases for pgexporter core daemon operations
+ * @return The result
+ */
+Suite*
+pgexporter_test1_suite();
+
+#endif // PGEXPORTER_TEST1_H

--- a/test/testcases/pgexporter_test_2.c
+++ b/test/testcases/pgexporter_test_2.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <tsclient.h>
+
+#include "pgexporter_test_2.h"
+
+// Test database connection establishment
+START_TEST(test_pgexporter_db_connection)
+{
+   int found = 0;
+   found = !pgexporter_tsclient_test_db_connection();
+   ck_assert_msg(found, "database connection test failed");
+}
+END_TEST
+
+// Test direct PostgreSQL version query 
+START_TEST(test_pgexporter_version_query)
+{
+   int found = 0;
+   found = !pgexporter_tsclient_test_version_query();
+   ck_assert_msg(found, "PostgreSQL version query test failed");
+}
+END_TEST
+
+// Test extension path setup
+START_TEST(test_pgexporter_extension_path)
+{
+   int found = 0;
+   found = !pgexporter_tsclient_test_extension_path();
+   ck_assert_msg(found, "extension path setup test failed");
+}
+END_TEST
+
+Suite*
+pgexporter_test2_suite()
+{
+   Suite* s;
+   TCase* tc_core;
+
+   s = suite_create("pgexporter_test2");
+
+   tc_core = tcase_create("Core");
+
+   tcase_set_timeout(tc_core, 60);
+   tcase_add_test(tc_core, test_pgexporter_db_connection);
+   tcase_add_test(tc_core, test_pgexporter_version_query);
+   tcase_add_test(tc_core, test_pgexporter_extension_path);
+   suite_add_tcase(s, tc_core);
+
+   return s;
+}

--- a/test/testcases/pgexporter_test_2.h
+++ b/test/testcases/pgexporter_test_2.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PGEXPORTER_TEST2_H
+#define PGEXPORTER_TEST2_H
+
+#include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * Set up a suite of test cases for pgexporter database operations
+ * @return The result
+ */
+Suite*
+pgexporter_test2_suite();
+
+#endif // PGEXPORTER_TEST2_H

--- a/test/testcases/pgexporter_test_3.c
+++ b/test/testcases/pgexporter_test_3.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <tsclient.h>
+
+#include "pgexporter_test_3.h"
+
+START_TEST(test_pgexporter_http_metrics)
+{
+   int found = 0;
+   found = !pgexporter_tsclient_test_http_metrics();
+   ck_assert_msg(found, "pgexporter HTTP metrics test failed");
+}
+END_TEST
+
+START_TEST(test_pgexporter_bridge_endpoint)
+{
+   int found = 0;
+   found = !pgexporter_tsclient_test_bridge_endpoint();
+   ck_assert_msg(found, "pgexporter bridge endpoint test failed");
+}
+END_TEST
+
+START_TEST(test_pgexporter_extension_detection)
+{
+   int found = 0;
+   found = !pgexporter_tsclient_test_extension_detection();
+   ck_assert_msg(found, "pgexporter extension detection test failed");
+}
+END_TEST
+
+// Test that shutdown command works (this should be last test)
+START_TEST(test_pgexporter_shutdown)
+{
+   int found = 0;
+   found = !pgexporter_tsclient_execute_shutdown();
+   ck_assert_msg(found, "pgexporter shutdown failed");
+}
+END_TEST
+
+Suite*
+pgexporter_test3_suite()
+{
+   Suite* s;
+   TCase* tc_core;
+
+   s = suite_create("pgexporter_test3");
+
+   tc_core = tcase_create("Core");
+
+   tcase_set_timeout(tc_core, 60);
+   tcase_add_test(tc_core, test_pgexporter_bridge_endpoint);
+   tcase_add_test(tc_core, test_pgexporter_http_metrics);
+   tcase_add_test(tc_core, test_pgexporter_extension_detection);
+
+   tcase_add_test(tc_core, test_pgexporter_shutdown);
+
+   suite_add_tcase(s, tc_core);
+
+   return s;
+}

--- a/test/testcases/pgexporter_test_3.h
+++ b/test/testcases/pgexporter_test_3.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGEXPORTER_TEST3_H
+#define PGEXPORTER_TEST3_H
+
+#include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * Set up a suite of test cases for pgexporter HTTP functionality
+ * @return The result
+ */
+Suite*
+pgexporter_test3_suite();
+
+#endif // PGEXPORTER_TEST3_H

--- a/test/testsuite.sh
+++ b/test/testsuite.sh
@@ -1,0 +1,665 @@
+#!/bin/bash
+#
+# Copyright (C) 2025 The pgexporter community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set -e
+
+OS=$(uname)
+
+THIS_FILE=$(realpath "$0")
+FILE_OWNER=$(ls -l "$THIS_FILE" | awk '{print $3}')
+USER=$(whoami)
+WAIT_TIMEOUT=5
+
+PORT=5432
+PGPASSWORD="password"
+
+PROJECT_DIRECTORY=$(pwd)
+EXECUTABLE_DIRECTORY=$(pwd)/src
+TEST_DIRECTORY=$(pwd)/test
+
+LOG_DIRECTORY=$(pwd)/log
+PGCTL_LOG_FILE=$LOG_DIRECTORY/logfile
+PGEXPORTER_LOG_FILE=$LOG_DIRECTORY/pgexporter.log
+
+POSTGRES_OPERATION_DIR=$(pwd)/pgexporter-postgresql
+DATA_DIRECTORY=$POSTGRES_OPERATION_DIR/data
+
+PGEXPORTER_OPERATION_DIR=$(pwd)/pgexporter-testsuite
+CONFIGURATION_DIRECTORY=$PGEXPORTER_OPERATION_DIR/conf
+
+PSQL_USER=$USER
+if [ "$OS" = "FreeBSD" ]; then
+  PSQL_USER=postgres
+fi
+
+########################### UTILS ############################
+is_port_in_use() {
+   local port=$1
+   if [[ "$OS" == "Linux" ]]; then
+      ss -tuln | grep $port >/dev/null 2>&1
+   elif [[ "$OS" == "Darwin" ]]; then
+      lsof -i:$port >/dev/null 2>&1
+   elif [[ "$OS" == "FreeBSD" ]]; then
+      sockstat -4 -l | grep $port >/dev/null 2>&1
+   fi
+   return $?
+}
+
+next_available_port() {
+   local port=$1
+   while true; do
+      is_port_in_use $port
+      if [ $? -ne 0 ]; then
+         echo "$port"
+         return 0
+      else
+         port=$((port + 1))
+      fi
+   done
+}
+
+wait_for_server_ready() {
+   local start_time=$SECONDS
+   while true; do
+      pg_isready -h localhost -p $PORT
+      if [ $? -eq 0 ]; then
+         echo "postgres is ready for accepting responses"
+         return 0
+      fi
+      if [ $(($SECONDS - $start_time)) -gt $WAIT_TIMEOUT ]; then
+         echo "waiting for server timed out"
+         return 1
+      fi
+
+      # Avoid busy-waiting
+      sleep 1
+   done
+}
+
+function sed_i() {
+   if [[ "$OS" == "Darwin" || "$OS" == "FreeBSD" ]]; then
+      sed -i '' -E "$@"
+   else
+      sed -i -E "$@"
+   fi
+}
+
+##############################################################
+
+############### CHECK POSTGRES DEPENDENCIES ##################
+check_inidb() {
+   if which initdb >/dev/null 2>&1; then
+      echo "check initdb in path ... ok"
+      return 0
+   else
+      echo "check initdb in path ... not present"
+      return 1
+   fi
+}
+
+check_pg_ctl() {
+   if which pg_ctl >/dev/null 2>&1; then
+      echo "check pg_ctl in path ... ok"
+      return 0
+   else
+      echo "check pg_ctl in path ... not ok"
+      return 1
+   fi
+}
+
+stop_pgctl(){
+   echo "Attempting to stop PostgreSQL..."
+   set +e  # Allow failures here since server might already be stopped
+   if [[ "$OS" == "FreeBSD" ]]; then
+      su - postgres -c "$PGCTL_PATH -D $DATA_DIRECTORY -l $PGCTL_LOG_FILE stop"
+      stop_result=$?
+   else
+      pg_ctl -D $DATA_DIRECTORY -l $PGCTL_LOG_FILE stop
+      stop_result=$?
+   fi
+   
+   if [ $stop_result -ne 0 ]; then
+      echo "PostgreSQL stop returned code $stop_result (may have been already stopped)"
+   else
+      echo "PostgreSQL stopped successfully"
+   fi
+   set -e
+}
+
+run_as_postgres() {
+  if [[ "$OS" == "FreeBSD" ]]; then
+    su - postgres -c "$*"
+  else
+    eval "$@"
+  fi
+}
+
+check_psql() {
+   if which psql >/dev/null 2>&1; then
+      echo "check psql in path ... ok"
+      return 0
+   else
+      echo "check psql in path ... not present"
+      return 1
+   fi
+}
+
+check_postgres_version() {
+   version=$(psql --version | awk '{print $3}' | sed -E 's/^([0-9]+(\.[0-9]+)?).*/\1/')
+   major_version=$(echo "$version" | cut -d'.' -f1)
+   required_major_version=$1
+   if [ "$major_version" -ge "$required_major_version" ]; then
+      echo "check postgresql version: $version ... ok"
+      return 0
+   else
+      echo "check postgresql version: $version ... not ok"
+      return 1
+   fi
+}
+
+check_system_requirements() {
+   echo -e "\e[34mCheck System Requirements \e[0m"
+   echo "check system os ... $OS"
+   check_inidb
+   if [ $? -ne 0 ]; then
+      exit 1
+   fi
+   check_pg_ctl
+   if [ $? -ne 0 ]; then
+      exit 1
+   fi
+   check_psql
+   if [ $? -ne 0 ]; then
+      exit 1
+   fi
+   check_postgres_version 17
+   if [ $? -ne 0 ]; then
+      exit 1
+   fi
+   echo ""
+}
+
+initialize_log_files() {
+   echo -e "\e[34mInitialize Test logfiles \e[0m"
+   mkdir -p $LOG_DIRECTORY
+   echo "create log directory ... $LOG_DIRECTORY"
+   touch $PGEXPORTER_LOG_FILE
+   echo "create log file ... $PGEXPORTER_LOG_FILE"
+   touch $PGCTL_LOG_FILE
+   echo "create log file ... $PGCTL_LOG_FILE"
+   echo ""
+}
+##############################################################
+
+##################### POSTGRES OPERATIONS ####################
+create_cluster() {
+   local port=$1
+   echo -e "\e[34mInitializing Cluster \e[0m"
+
+   if [ "$OS" = "FreeBSD" ]; then
+    mkdir -p "$POSTGRES_OPERATION_DIR"
+    mkdir -p "$DATA_DIRECTORY"
+    mkdir -p $CONFIGURATION_DIRECTORY
+    if ! pw user show postgres >/dev/null 2>&1; then
+        pw groupadd -n postgres -g 770
+        pw useradd -n postgres -u 770 -g postgres -d /var/db/postgres -s /bin/sh
+    fi
+    chown postgres:postgres $PGCTL_LOG_FILE
+    chown -R postgres:postgres "$DATA_DIRECTORY"
+    chown -R postgres:postgres $CONFIGURATION_DIRECTORY
+
+   fi
+
+   echo $DATA_DIRECTORY
+   
+   INITDB_PATH=$(command -v initdb)
+
+   if [ -z "$INITDB_PATH" ]; then
+      echo "Error: initdb not found!" >&2
+      exit 1
+   fi
+   run_as_postgres "$INITDB_PATH -k -D $DATA_DIRECTORY"
+   echo "initdb exit code: $?"
+   echo "initialize database ... ok"
+   set +e
+   echo "setting postgresql.conf"
+
+   error_out=$(sed_i "s/^#[[:space:]]*password_encryption[[:space:]]*=[[:space:]]*(md5|scram-sha-256)/password_encryption = scram-sha-256/" "$DATA_DIRECTORY/postgresql.conf" 2>&1)
+
+   if [ $? -ne 0 ]; then
+      echo "setting password_encryption ... $error_out"
+      clean
+      exit 1
+   else
+      echo "setting password_encryption ... scram-sha-256"
+   fi
+   error_out=$(sed_i "s|#unix_socket_directories = '/var/run/postgresql'|unix_socket_directories = '/tmp'|" $DATA_DIRECTORY/postgresql.conf 2>&1)
+   if [ $? -ne 0 ]; then
+      echo "setting unix_socket_directories ... $error_out"
+      clean
+      exit 1
+   else
+      echo "setting unix_socket_directories ... '/tmp'"
+   fi
+   error_out=$(sed_i "s/#port = 5432/port = $port/" $DATA_DIRECTORY/postgresql.conf 2>&1)
+   if [ $? -ne 0 ]; then
+      echo "setting port ... $error_out"
+      clean
+      exit 1
+   else
+      echo "setting port ... $port"
+   fi
+   error_out=$(sed_i "s/#wal_level = replica/wal_level = replica/" $DATA_DIRECTORY/postgresql.conf 2>&1)
+   if [ $? -ne 0 ]; then
+      echo "setting wal_level ... $error_out"
+      clean
+      exit 1
+   else
+      echo "setting wal_level ... replica"
+   fi
+
+   LOG_ABS_PATH=$(realpath "$LOG_DIRECTORY")
+   sed_i "s/^#*logging_collector.*/logging_collector = on/" "$DATA_DIRECTORY/postgresql.conf"
+   sed_i "s/^#*log_destination.*/log_destination = 'stderr'/" "$DATA_DIRECTORY/postgresql.conf"
+   sed_i "s|^#*log_directory.*|log_directory = '$LOG_ABS_PATH'|" "$DATA_DIRECTORY/postgresql.conf"
+   sed_i "s/^#*log_filename.*/log_filename = 'logfile'/" "$DATA_DIRECTORY/postgresql.conf"
+
+   # If any of the above settings are missing, append them
+   grep -q "^logging_collector" "$DATA_DIRECTORY/postgresql.conf" || echo "logging_collector = on" >> "$DATA_DIRECTORY/postgresql.conf"
+   grep -q "^log_destination" "$DATA_DIRECTORY/postgresql.conf" || echo "log_destination = 'stderr'" >> "$DATA_DIRECTORY/postgresql.conf"
+   grep -q "^log_directory" "$DATA_DIRECTORY/postgresql.conf" || echo "log_directory = '$LOG_ABS_PATH'" >> "$DATA_DIRECTORY/postgresql.conf"
+   grep -q "^log_filename" "$DATA_DIRECTORY/postgresql.conf" || echo "log_filename = 'logfile'" >> "$DATA_DIRECTORY/postgresql.conf"
+
+   set -e
+   echo ""
+}
+
+initialize_hba_configuration() {
+   echo -e "\e[34mCreate HBA Configuration \e[0m"
+   echo "
+    local   all              all                                     trust
+    local   replication      all                                     trust
+    host    postgres         pgexporter      127.0.0.1/32            scram-sha-256
+    host    postgres         pgexporter      ::1/128                 scram-sha-256
+    " >$DATA_DIRECTORY/pg_hba.conf
+   echo "initialize hba configuration at $DATA_DIRECTORY/pg_hba.conf ... ok"
+   echo ""
+}
+
+initialize_cluster() {
+   echo -e "\e[34mInitializing Cluster \e[0m"
+   set +e
+   PGCTL_PATH=$(command -v pg_ctl)
+   if [ -z "$PGCTL_PATH" ]; then
+      echo "Error: pg_ctl not found!" >&2
+      exit 1
+   fi
+   run_as_postgres "$PGCTL_PATH -D $DATA_DIRECTORY -l $PGCTL_LOG_FILE start"
+   if [ $? -ne 0 ]; then
+      echo "PostgreSQL failed to start. Printing log:"
+      cat $PGCTL_LOG_FILE
+      clean
+      exit 1
+   fi
+   pg_isready -h localhost -p $PORT
+   if [ $? -eq 0 ]; then
+      echo "postgres server is accepting requests ... ok"
+   else
+      echo "postgres server is not accepting response ... not ok"
+      clean
+      exit 1
+   fi
+   err_out=$(psql -h /tmp -p $PORT -U $PSQL_USER -d postgres -c "CREATE USER pgexporter WITH PASSWORD '$PGPASSWORD';" 2>&1)
+   if [ $? -ne 0 ]; then
+      echo "create user pgexporter ... $err_out"
+      stop_pgctl
+      clean
+      exit 1
+   else
+      echo "create user pgexporter ... ok"
+   fi
+   err_out=$(psql -h /tmp -p $PORT -U $PSQL_USER -d postgres -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;" 2>&1)
+   if [ $? -ne 0 ]; then
+      echo "create extension pg_stat_statements ... $err_out"
+      echo "Warning: pg_stat_statements extension not available"
+   else
+      echo "create extension pg_stat_statements ... ok"
+   fi
+   err_out=$(psql -h /tmp -p $PORT -U $PSQL_USER -d postgres -c "GRANT pg_monitor TO pgexporter;" 2>&1)
+   if [ $? -ne 0 ]; then
+      echo "grant pg_monitor to pgexporter ... $err_out"
+      stop_pgctl
+      clean
+      exit 1
+   else
+      echo "grant pg_monitor to pgexporter ... ok"
+   fi
+   set -e
+   stop_pgctl
+   echo ""
+}
+
+clean_logs() {
+   if [ -d $LOG_DIRECTORY ]; then
+      rm -r $LOG_DIRECTORY
+      echo "remove log directory $LOG_DIRECTORY ... ok"
+   else
+      echo "$LOG_DIRECTORY not present ... ok"
+   fi
+}
+
+clean() {
+   echo -e "\e[34mClean Test Resources \e[0m"
+   if [ -d $POSTGRES_OPERATION_DIR ]; then
+      rm -r $POSTGRES_OPERATION_DIR
+      echo "remove postgres operations directory $POSTGRES_OPERATION_DIR ... ok"
+   else
+      echo "$POSTGRES_OPERATION_DIR not present ... ok"
+   fi
+
+   if [ -d $PGEXPORTER_OPERATION_DIR ]; then
+      rm -r $PGEXPORTER_OPERATION_DIR
+      echo "remove pgexporter operations directory $PGEXPORTER_OPERATION_DIR ... ok"
+   else
+      echo "$PGEXPORTER_OPERATION_DIR not present ... ok"
+   fi
+}
+
+##############################################################
+
+#################### PGEXPORTER OPERATIONS #####################
+pgexporter_initialize_configuration() {
+   echo -e "\e[34mInitialize pgexporter configuration files \e[0m"
+   mkdir -p $CONFIGURATION_DIRECTORY
+   echo "create configuration directory $CONFIGURATION_DIRECTORY ... ok"
+   touch $CONFIGURATION_DIRECTORY/pgexporter.conf $CONFIGURATION_DIRECTORY/pgexporter_users.conf
+   echo "create pgexporter.conf and pgexporter_users.conf inside $CONFIGURATION_DIRECTORY ... ok"
+   cat <<EOF >$CONFIGURATION_DIRECTORY/pgexporter.conf
+[pgexporter]
+host = localhost
+metrics = 5002
+bridge = 5003
+bridge_endpoints = localhost:5002
+
+log_type = file
+log_level = debug5
+log_path = $PGEXPORTER_LOG_FILE
+
+unix_socket_dir = /tmp/
+
+[primary]
+host = localhost
+port = $PORT
+user = pgexporter
+EOF
+   echo "add test configuration to pgexporter.conf ... ok"
+   if [[ "$OS" == "FreeBSD" ]]; then
+    chown -R postgres:postgres $CONFIGURATION_DIRECTORY
+    chown -R postgres:postgres $PGEXPORTER_LOG_FILE
+   fi
+   
+   echo "=== DEBUG: Creating master key ==="
+   run_as_postgres "$EXECUTABLE_DIRECTORY/pgexporter-admin master-key -P $PGPASSWORD" || true
+   master_key_result=$?
+   echo "Master key creation result: $master_key_result"
+   
+   echo "=== DEBUG: Adding user to config ==="
+   run_as_postgres "$EXECUTABLE_DIRECTORY/pgexporter-admin -f $CONFIGURATION_DIRECTORY/pgexporter_users.conf -U pgexporter -P $PGPASSWORD user add"
+   user_add_result=$?
+   echo "User add result: $user_add_result"
+   
+   echo "=== DEBUG: Verifying users config file ==="
+   if [[ -f "$CONFIGURATION_DIRECTORY/pgexporter_users.conf" ]]; then
+      echo "Users config file exists"
+      run_as_postgres "ls -la $CONFIGURATION_DIRECTORY/pgexporter_users.conf"
+      file_size=$(run_as_postgres "wc -c < $CONFIGURATION_DIRECTORY/pgexporter_users.conf")
+      echo "Users config file size: $file_size bytes"
+      if [[ $file_size -eq 0 ]]; then
+         echo "file exists but is empty"
+         exit 1
+      fi
+   else
+      echo "ERROR: Users config file missing!"
+      echo "Expected: $CONFIGURATION_DIRECTORY/pgexporter_users.conf"
+      run_as_postgres "ls -la $CONFIGURATION_DIRECTORY/"
+      exit 1
+   fi
+   
+   echo "add user pgexporter to pgexporter_users.conf file ... ok"
+   echo ""
+}
+
+test_bridge_endpoint_with_curl() {
+   echo -e "\e[34mTesting Bridge Endpoint with curl \e[0m"
+   
+   echo "=== Bridge Endpoint curl Test on $OS ==="
+   echo "Testing direct connectivity to bridge endpoint using curl"
+   
+   # Test if bridge port is listening
+   echo "Checking if bridge port 5003 is listening..."
+   if [[ "$OS" == "Linux" ]]; then
+      ss -tuln | grep :5003 || echo "Port 5003 not found in ss output"
+   elif [[ "$OS" == "Darwin" ]]; then
+      lsof -i :5003 || echo "Port 5003 not found in lsof output"
+      netstat -an | grep :5003 || echo "Port 5003 not found in netstat output"
+   elif [[ "$OS" == "FreeBSD" ]]; then
+      sockstat -l | grep :5003 || echo "Port 5003 not found in sockstat output"
+      netstat -an | grep :5003 || echo "Port 5003 not found in netstat output"
+   fi
+   
+   # Test curl connectivity to bridge endpoint
+   echo "Testing curl to bridge endpoint..."
+   set +e  # Allow curl to fail without stopping the script
+   
+   # Create a temporary file for curl output
+   CURL_OUTPUT_FILE="$LOG_DIRECTORY/bridge_curl_output.txt"
+   
+   # Check if timeout command exists (not available on macOS by default)
+   if command -v timeout >/dev/null 2>&1; then
+      timeout 15 curl -v --connect-timeout 10 --max-time 30 http://localhost:5003/metrics > "$CURL_OUTPUT_FILE" 2>&1
+      CURL_EXIT_CODE=$?
+   else
+      # macOS and other systems without timeout - use curl's built-in timeouts
+      curl -v --connect-timeout 10 --max-time 30 http://localhost:5003/metrics > "$CURL_OUTPUT_FILE" 2>&1
+      CURL_EXIT_CODE=$?
+   fi
+   
+   echo "Curl exit code: $CURL_EXIT_CODE"
+   echo "=== Curl output ==="
+   cat "$CURL_OUTPUT_FILE"
+   echo "=== End curl output ==="
+   
+   # Check response content
+   if [ $CURL_EXIT_CODE -eq 0 ]; then
+      echo "SUCCESS: curl connected to bridge endpoint on $OS"
+      echo "Response size: $(wc -c < "$CURL_OUTPUT_FILE") bytes"
+      echo "Response lines: $(wc -l < "$CURL_OUTPUT_FILE") lines"
+      
+      # Check for expected content
+      if grep -q "pgexporter_state" "$CURL_OUTPUT_FILE"; then
+         echo "SUCCESS: Found expected pgexporter_state metric in bridge response"
+      else
+         echo "WARNING: pgexporter_state metric not found in bridge response"
+         echo "First 500 chars of bridge response:"
+         head -c 500 "$CURL_OUTPUT_FILE"
+      fi
+      
+      # Check for endpoint-specific metrics (bridge format)
+      if grep -q "endpoint=" "$CURL_OUTPUT_FILE"; then
+         echo "SUCCESS: Found endpoint labels in bridge response (expected bridge format)"
+      else
+         echo "WARNING: No endpoint labels found - may not be bridge format"
+      fi
+   else
+      echo "ERROR: curl failed to connect to bridge endpoint on $OS (exit code: $CURL_EXIT_CODE)"
+      
+      # Test if main metrics endpoint works as fallback
+      echo "Testing if main metrics endpoint works..."
+      MAIN_CURL_OUTPUT_FILE="$LOG_DIRECTORY/main_curl_output.txt"
+      
+      # Use same timeout handling for main endpoint
+      if command -v timeout >/dev/null 2>&1; then
+         timeout 10 curl -v --connect-timeout 5 --max-time 15 http://localhost:5002/metrics > "$MAIN_CURL_OUTPUT_FILE" 2>&1
+         MAIN_CURL_EXIT_CODE=$?
+      else
+         curl -v --connect-timeout 5 --max-time 15 http://localhost:5002/metrics > "$MAIN_CURL_OUTPUT_FILE" 2>&1
+         MAIN_CURL_EXIT_CODE=$?
+      fi
+      echo "Main endpoint curl exit code: $MAIN_CURL_EXIT_CODE"
+      
+      if [ $MAIN_CURL_EXIT_CODE -eq 0 ]; then
+         echo "SUCCESS: Main metrics endpoint works"
+         echo "Main response size: $(wc -c < "$MAIN_CURL_OUTPUT_FILE") bytes"
+         if grep -q "pgexporter_state" "$MAIN_CURL_OUTPUT_FILE"; then
+            echo "SUCCESS: Found pgexporter_state in main endpoint"
+         fi
+      else
+         echo "ERROR: Main metrics endpoint also failed"
+         echo "Main endpoint curl output:"
+         cat "$MAIN_CURL_OUTPUT_FILE" 2>/dev/null || echo "No main response file"
+      fi
+   fi
+   
+   # Show process status
+   echo "=== Process status ==="
+   ps aux | grep pgexporter | grep -v grep || echo "No pgexporter processes found"
+   
+   # Show system info
+   echo "=== System info ==="
+   echo "OS: $OS"
+   uname -a
+   if [[ "$OS" == "FreeBSD" ]]; then
+      freebsd-version 2>/dev/null || echo "FreeBSD version not available"
+   fi
+   
+   set -e  # Re-enable exit on error
+   echo ""
+}
+
+execute_testcases() {
+   echo -e "\e[34mExecute Testcases \e[0m"
+   set +e
+   run_as_postgres "pg_ctl -D $DATA_DIRECTORY -l $PGCTL_LOG_FILE start"
+   pg_isready -h localhost -p $PORT
+   if [ $? -eq 0 ]; then
+      echo "postgres server accepting requests ... ok"
+   else
+      echo "postgres server is not accepting response ... not ok"
+      stop_pgctl
+      clean
+      exit 1
+   fi
+   echo "starting pgexporter server in daemon mode"
+   
+   echo "=== DEBUG: Final config verification before starting pgexporter ==="
+   run_as_postgres "ls -la $CONFIGURATION_DIRECTORY/"
+   echo "Contents of pgexporter.conf:"
+   run_as_postgres "cat $CONFIGURATION_DIRECTORY/pgexporter.conf"
+   echo "Users config file status:"
+   if [[ -f "$CONFIGURATION_DIRECTORY/pgexporter_users.conf" ]]; then
+      run_as_postgres "ls -la $CONFIGURATION_DIRECTORY/pgexporter_users.conf"
+      run_as_postgres "wc -c $CONFIGURATION_DIRECTORY/pgexporter_users.conf"
+   else
+      echo "ERROR: Users config file missing at execution time!"
+      exit 1
+   fi
+   
+   run_as_postgres "$EXECUTABLE_DIRECTORY/pgexporter -c $CONFIGURATION_DIRECTORY/pgexporter.conf -u $CONFIGURATION_DIRECTORY/pgexporter_users.conf -d"
+   
+   # Wait a moment for pgexporter to start
+   sleep 3
+   
+   # Test bridge endpoint with curl before running unit tests
+   test_bridge_endpoint_with_curl
+   
+   ### RUN TESTCASES ###
+   run_as_postgres $TEST_DIRECTORY/pgexporter_test $PROJECT_DIRECTORY
+   if [ $? -ne 0 ]; then
+      # Kill pgexporter if tests failed
+      pkill -f pgexporter || true
+      stop_pgctl
+      clean
+      exit 1
+   fi
+   
+   pkill -f pgexporter || true
+   echo "pgexporter server stopped ... ok"
+   stop_pgctl
+   set -e
+   echo ""
+}
+
+##############################################################
+
+run_tests() {
+   # Check if the user is pgexporter
+   if [ "$FILE_OWNER" == "$USER" ]; then
+      ## Postgres operations
+      check_system_requirements
+
+      initialize_log_files
+
+      PORT=$(next_available_port $PORT)
+      create_cluster $PORT
+
+      initialize_hba_configuration
+      initialize_cluster
+
+      ## pgexporter operations
+      pgexporter_initialize_configuration
+      execute_testcases
+      # clean cluster
+      clean
+   else
+      echo "user should be $FILE_OWNER"
+      exit 1
+   fi
+}
+
+usage() {
+   echo "Usage: $0 [sub-command]"
+   echo "Subcommand:"
+   echo " clean           clean up test suite environment"
+   exit 1
+}
+
+if [ $# -gt 1 ]; then
+   usage # More than one argument, show usage and exit
+elif [ $# -eq 1 ]; then
+   if [ "$1" == "clean" ]; then
+      # If the parameter is 'clean', run clean_function
+      clean
+      clean_logs
+   else
+      echo "Invalid parameter: $1"
+      usage # If an invalid parameter is provided, show usage and exit
+   fi
+else
+   # If no arguments are provided, run function_without_param
+   run_tests
+fi

--- a/test/tsclient.c
+++ b/test/tsclient.c
@@ -1,0 +1,819 @@
+/*
+ * Copyright (C) 2025 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* pgexporter */
+#include <pgexporter.h>
+#include <configuration.h>
+#include <extension.h>
+#include <http.h>
+#include <json.h>
+#include <logging.h>
+#include <management.h>
+#include <memory.h>
+#include <network.h>
+#include <queries.h>
+#include <security.h>
+#include <shmem.h>
+#include <utils.h>
+#include <value.h>
+#include <tsclient.h>
+
+/* system */
+#include <err.h>
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+
+char project_directory[BUFFER_SIZE];
+
+static int check_output_outcome(int socket);
+static int get_connection();
+static char* get_configuration_path();
+
+int
+pgexporter_tsclient_init(char* base_dir)
+{
+    struct configuration* config = NULL;
+    int ret;
+    size_t size;
+    char* configuration_path = NULL;
+    char* users_path = NULL;
+
+    memset(project_directory, 0, sizeof(project_directory));
+    memcpy(project_directory, base_dir, strlen(base_dir));
+
+    configuration_path = get_configuration_path();
+
+    pgexporter_memory_init();
+
+    size = sizeof(struct configuration);
+    if (pgexporter_create_shared_memory(size, HUGEPAGE_OFF, &shmem))
+    {
+        goto error;
+    }
+
+    pgexporter_init_configuration(shmem);
+    config = (struct configuration*)shmem;
+
+    // Read configuration file
+    if (configuration_path != NULL)
+    {
+        if (pgexporter_read_configuration(shmem, configuration_path))
+        {
+            goto error;
+        }
+    }
+    else
+    {
+        goto error;
+    }
+
+    users_path = (char*)malloc(strlen(project_directory) + strlen("/pgexporter-testsuite/conf/pgexporter_users.conf") + 1);
+    strcpy(users_path, project_directory);
+    strcat(users_path, "/pgexporter-testsuite/conf/pgexporter_users.conf");
+    
+    ret = pgexporter_read_users_configuration(shmem, users_path);
+    if (ret != 0)
+    {
+        printf("Failed to read users configuration: %s (ret=%d)\n", users_path, ret);
+        goto error;
+    }
+
+    // Initialize logging (from main.c around line 570)
+    if (pgexporter_init_logging())
+    {
+        goto error;
+    }
+
+    if (pgexporter_start_logging())
+    {
+        goto error;
+    }
+
+    // Validate configurations (from main.c around line 580)
+    if (pgexporter_validate_configuration(shmem))
+    {
+        printf("Configuration validation failed\n");
+        goto error;
+    }
+
+    if (pgexporter_validate_users_configuration(shmem))
+    {
+        printf("Users configuration validation failed\n");
+        goto error;
+    }
+
+    free(configuration_path);
+    free(users_path);
+    return 0;
+    
+error:
+    free(configuration_path);
+    free(users_path);
+    return 1;
+}
+
+int
+pgexporter_tsclient_destroy()
+{
+    size_t size;
+
+    pgexporter_stop_logging();
+    
+    size = sizeof(struct configuration);
+    pgexporter_destroy_shared_memory(shmem, size);
+    
+    pgexporter_memory_destroy();
+    
+    return 0;
+}
+
+int
+pgexporter_tsclient_execute_ping()
+{
+    int socket = -1;
+    
+    socket = get_connection();
+    
+    if (!pgexporter_socket_isvalid(socket))
+    {
+        goto error;
+    }
+    
+    if (pgexporter_management_request_ping(NULL, socket, MANAGEMENT_COMPRESSION_NONE, MANAGEMENT_ENCRYPTION_NONE, MANAGEMENT_OUTPUT_FORMAT_JSON))
+    {
+        goto error;
+    }
+
+    if (check_output_outcome(socket))
+    {
+        goto error;
+    }
+
+    pgexporter_disconnect(socket);
+    return 0;
+    
+error:
+    pgexporter_disconnect(socket);
+    return 1;
+}
+
+int
+pgexporter_tsclient_execute_shutdown()
+{
+    int socket = -1;
+    
+    socket = get_connection();
+    
+    if (!pgexporter_socket_isvalid(socket))
+    {
+        goto error;
+    }
+    
+    if (pgexporter_management_request_shutdown(NULL, socket, MANAGEMENT_COMPRESSION_NONE, MANAGEMENT_ENCRYPTION_NONE, MANAGEMENT_OUTPUT_FORMAT_JSON))
+    {
+        goto error;
+    }
+
+    if (check_output_outcome(socket))
+    {
+        goto error;
+    }
+
+    pgexporter_disconnect(socket);
+    return 0;
+    
+error:
+    pgexporter_disconnect(socket);
+    return 1;
+}
+
+int
+pgexporter_tsclient_execute_status()
+{
+    int socket = -1;
+    
+    socket = get_connection();
+    
+    if (!pgexporter_socket_isvalid(socket))
+    {
+        goto error;
+    }
+    
+    if (pgexporter_management_request_status(NULL, socket, MANAGEMENT_COMPRESSION_NONE, MANAGEMENT_ENCRYPTION_NONE, MANAGEMENT_OUTPUT_FORMAT_JSON))
+    {
+        goto error;
+    }
+
+    if (check_output_outcome(socket))
+    {
+        goto error;
+    }
+
+    pgexporter_disconnect(socket);
+    return 0;
+    
+error:
+    pgexporter_disconnect(socket);
+    return 1;
+}
+
+int
+pgexporter_tsclient_test_db_connection()
+{
+    struct configuration* config;
+    int connected_servers = 0;
+
+    config = (struct configuration*)shmem;
+
+    printf("=== Testing database connections ===\n");
+    printf("Number of configured servers: %d\n", config->number_of_servers);
+    printf("Number of configured users: %d\n", config->number_of_users);
+    
+    // Print debug info
+    for (int i = 0; i < config->number_of_servers; i++)
+    {
+        printf("Server %d: name='%s', host='%s', port=%d, user='%s'\n", 
+               i, config->servers[i].name, config->servers[i].host, 
+               config->servers[i].port, config->servers[i].username);
+    }
+    
+    printf("Calling pgexporter_open_connections()...\n");
+    pgexporter_open_connections();
+    printf("pgexporter_open_connections() completed\n");
+
+    // Check results (from main.c around line 750)
+    for (int i = 0; i < config->number_of_servers; i++)
+    {
+        printf("Server %s: fd=%d, state=%d, version=%d.%d\n", 
+               config->servers[i].name, config->servers[i].fd, config->servers[i].state,
+               config->servers[i].version, config->servers[i].minor_version);
+        
+        if (config->servers[i].fd != -1)
+        {
+            connected_servers++;
+            printf("  -> Connected successfully\n");
+        }
+        else
+        {
+            printf("  -> Connection failed\n");
+        }
+    }
+
+    printf("Total connected servers: %d/%d\n", connected_servers, config->number_of_servers);
+    
+    pgexporter_close_connections();
+    return (connected_servers > 0) ? 0 : 1;
+}
+
+int
+pgexporter_tsclient_test_version_query()
+{
+    struct configuration* config;
+    struct query* query = NULL;
+    struct tuple* current = NULL;
+    int ret = 1;
+    int server_tested = 0;
+
+    config = (struct configuration*)shmem;
+
+    printf("=== Testing PostgreSQL version query ===\n");
+    
+    printf("Opening connections...\n");
+    pgexporter_open_connections();
+
+    // Test version query on first available server (from main.c pattern)
+    for (int i = 0; i < config->number_of_servers && !server_tested; i++)
+    {
+        if (config->servers[i].fd != -1)
+        {
+            printf("Testing version query on server %s (fd=%d)...\n", 
+                   config->servers[i].name, config->servers[i].fd);
+            
+            if (pgexporter_query_version(i, &query) == 0 && query != NULL)
+            {
+                current = query->tuples;
+                if (current != NULL)
+                {
+                    printf("PostgreSQL Version: %s.%s\n", 
+                           pgexporter_get_column(0, current),
+                           pgexporter_get_column(1, current));
+                    ret = 0;
+                    server_tested = 1;
+                }
+                else
+                {
+                    printf("No version data returned from query\n");
+                }
+                pgexporter_free_query(query);
+            }
+            else
+            {
+                printf("Failed to execute version query\n");
+            }
+        }
+        else
+        {
+            printf("Server %s not connected (fd=%d)\n", config->servers[i].name, config->servers[i].fd);
+        }
+    }
+
+    if (!server_tested)
+    {
+        printf("No servers available for version query test\n");
+    }
+
+    pgexporter_close_connections();
+    return ret;
+}
+
+int
+pgexporter_tsclient_test_extension_path()
+{
+    struct configuration* config;
+    char* bin_path = NULL;
+    int ret = 1;
+
+    config = (struct configuration*)shmem;
+
+    printf("=== Testing extension path setup ===\n");
+    
+    // Use real program path from project directory (from main.c around line 650)
+    char* program_path = NULL;
+    program_path = pgexporter_append(program_path, project_directory);
+    program_path = pgexporter_append(program_path, "/src/pgexporter");
+    
+    printf("Using program path: %s\n", program_path);
+    
+    if (pgexporter_setup_extensions_path(config, program_path, &bin_path) == 0)
+    {
+        if (bin_path != NULL && strlen(bin_path) > 0)
+        {
+            printf("Extension path setup successful: %s\n", bin_path);
+            ret = 0;
+        }
+        else
+        {
+            printf("Extension path setup returned success but path is empty\n");
+        }
+    }
+    else
+    {
+        printf("Extension path setup failed\n");
+    }
+
+    // Print paths for debugging
+    if (bin_path != NULL)
+    {
+        printf("Final extension path: %s\n", bin_path);
+        free(bin_path);
+    }
+    else
+    {
+        printf("Extension path is NULL\n");
+    }
+    
+    printf("Configured extensions path: %s\n", config->extensions_path);
+
+    free(program_path);
+    return ret;
+}
+
+static int 
+check_output_outcome(int socket)
+{
+    struct json* read = NULL;
+    struct json* outcome = NULL;
+
+    if (pgexporter_management_read_json(NULL, socket, NULL, NULL, &read))
+    {
+        goto error;
+    }
+    
+    if (!pgexporter_json_contains_key(read, MANAGEMENT_CATEGORY_OUTCOME))
+    {
+        goto error;
+    }
+
+    outcome = (struct json*)pgexporter_json_get(read, MANAGEMENT_CATEGORY_OUTCOME);
+    if (!pgexporter_json_contains_key(outcome, MANAGEMENT_ARGUMENT_STATUS) || !(bool)pgexporter_json_get(outcome, MANAGEMENT_ARGUMENT_STATUS))
+    {
+        goto error;
+    }
+
+    pgexporter_json_destroy(read);
+    return 0;
+    
+error:
+    pgexporter_json_destroy(read);
+    return 1;
+}
+
+static int
+get_connection()
+{
+    int socket = -1;
+    struct configuration* config;
+
+    config = (struct configuration*)shmem;
+    
+    if (pgexporter_connect_unix_socket(config->unix_socket_dir, MAIN_UDS, &socket))
+    {
+        return -1;
+    }
+    
+    return socket;
+}
+
+static char*
+get_configuration_path()
+{
+   char* configuration_path = NULL;
+   int project_directory_length = strlen(project_directory);
+   int configuration_trail_length = strlen(PGEXPORTER_CONFIGURATION_TRAIL);
+
+   configuration_path = (char*)calloc(project_directory_length + configuration_trail_length + 1, sizeof(char));
+
+   memcpy(configuration_path, project_directory, project_directory_length);
+   memcpy(configuration_path + project_directory_length, PGEXPORTER_CONFIGURATION_TRAIL, configuration_trail_length);
+
+   return configuration_path;
+}
+
+int
+pgexporter_tsclient_test_http_metrics()
+{
+    struct http* http = NULL;
+    struct configuration* config;
+    char* response_body = NULL;
+    size_t response_size = 0;
+    char* line = NULL;
+    char* saveptr = NULL;
+    char* last_line = NULL;
+    bool found_first_metric = false;
+    bool found_version_metric = false;
+    int postgresql_version = 0;
+    int ret = 1;
+
+    config = (struct configuration*)shmem;
+
+    printf("=== Testing HTTP /metrics endpoint ===\n");
+    printf("Attempting to connect to localhost:%d\n", config->metrics);
+
+    if (pgexporter_http_connect("localhost", config->metrics, false, &http))
+    {
+        printf("ERROR: Failed to connect to HTTP endpoint localhost:%d\n", config->metrics);
+        goto error;
+    }
+    printf("Successfully connected to HTTP endpoint\n");
+
+    printf("Executing HTTP GET /metrics request\n");
+    if (pgexporter_http_get(http, "localhost", "/metrics"))
+    {
+        printf("ERROR: Failed to execute HTTP GET /metrics\n");
+        goto error;
+    }
+    printf("HTTP GET request completed\n");
+
+    if (http->body == NULL)
+    {
+        printf("ERROR: HTTP response body is NULL\n");
+        goto error;
+    }
+    printf("HTTP response body received\n");
+
+    response_body = strdup(http->body);
+    if (response_body == NULL)
+    {
+        printf("ERROR: Failed to duplicate response body\n");
+        goto error;
+    }
+
+    response_size = strlen(response_body);
+    printf("Response size: %zu bytes\n", response_size);
+
+    if (response_size == 0)
+    {
+        printf("ERROR: Response size is 0\n");
+        goto error;
+    }
+
+    printf("Parsing response for core metrics\n");
+    line = strtok_r(response_body, "\n", &saveptr);
+    while (line != NULL)
+    {
+        if (pgexporter_starts_with(line, "pgexporter_state 1"))
+        {
+            found_first_metric = true;
+            printf("Found first core metric: %s\n", line);
+        }
+
+        if (pgexporter_starts_with(line, "pgexporter_postgresql_version"))
+        {
+            char* version_start = strstr(line, "version=\"");
+            if (version_start != NULL)
+            {
+                version_start += 9;
+                char* version_end = strchr(version_start, '"');
+                if (version_end != NULL)
+                {
+                    *version_end = '\0';
+                    postgresql_version = atoi(version_start);
+                    found_version_metric = true;
+                    printf("Found PostgreSQL version metric: version=%d\n", postgresql_version);
+                    *version_end = '"';
+                }
+            }
+        }
+
+        last_line = line;
+        line = strtok_r(NULL, "\n", &saveptr);
+    }
+
+    if (last_line != NULL)
+    {
+        printf("Last line of response: %s\n", last_line);
+    }
+
+    printf("Validating metrics\n");
+    if (!found_first_metric)
+    {
+        printf("ERROR: Failed to find first core metric (pgexporter_state)\n");
+        goto error;
+    }
+
+    if (!found_version_metric)
+    {
+        printf("ERROR: Failed to find PostgreSQL version metric\n");
+        goto error;
+    }
+
+    if (postgresql_version != 17)
+    {
+        printf("ERROR: Expected PostgreSQL version 17, got %d\n", postgresql_version);
+        goto error;
+    }
+
+    printf("HTTP metrics test completed successfully\n");
+    ret = 0;
+
+error:
+    if (http != NULL)
+    {
+        pgexporter_http_disconnect(http);
+        pgexporter_http_destroy(http);
+    }
+    free(response_body);
+    return ret;
+}
+
+int
+pgexporter_tsclient_test_bridge_endpoint()
+{
+   printf("DEBUG: Bridge test function entry\n");
+   fflush(stdout);
+   
+   struct http* http = NULL;
+   struct configuration* config;
+   char* response_body = NULL;
+   size_t response_size = 0;
+   char* line = NULL;
+   char* saveptr = NULL;
+   char* last_line = NULL;
+   bool found_first_metric = false;
+   bool found_version_metric = false;
+   int postgresql_version = 0;
+   int ret = 1;
+
+   printf("DEBUG: Getting config pointer\n");
+   fflush(stdout);
+   
+   config = (struct configuration*)shmem;
+   
+   if (config == NULL)
+   {
+       printf("ERROR: config is NULL\n");
+       return 1;
+   }
+   
+   printf("DEBUG: Config loaded successfully\n");
+   fflush(stdout);
+
+   printf("=== Testing bridge endpoint ===\n");
+   printf("Bridge port from config: %d\n", config->bridge);
+   
+   if (config->bridge == 0)
+   {
+       printf("ERROR: Bridge port is 0, bridge not configured\n");
+       return 1;
+   }
+   
+   printf("Attempting to connect to localhost:%d\n", config->bridge);
+
+   if (pgexporter_http_connect("localhost", config->bridge, false, &http))
+   {
+       printf("ERROR: Failed to connect to bridge endpoint localhost:%d\n", config->bridge);
+       printf("Is bridge endpoint running and configured?\n");
+       goto error;
+   }
+   printf("Successfully connected to bridge endpoint\n");
+
+   printf("Executing HTTP GET /metrics request\n");
+   if (pgexporter_http_get(http, "localhost", "/metrics"))
+   {
+       printf("ERROR: Failed to execute HTTP GET /metrics\n");
+       goto error;
+   }
+   printf("HTTP GET request completed\n");
+
+   if (http->body == NULL)
+   {
+       printf("ERROR: HTTP response body is NULL\n");
+       goto error;
+   }
+   printf("HTTP response body received\n");
+
+   response_body = strdup(http->body);
+   if (response_body == NULL)
+   {
+       printf("ERROR: Failed to duplicate response body\n");
+       goto error;
+   }
+
+   response_size = strlen(response_body);
+   printf("Response size: %zu bytes\n", response_size);
+
+   if (response_size == 0)
+   {
+       printf("ERROR: Response size is 0\n");
+       goto error;
+   }
+
+   printf("First 200 characters of response: %.200s\n", response_body);
+
+   printf("Parsing response for core metrics\n");
+   line = strtok_r(response_body, "\n", &saveptr);
+   while (line != NULL)
+   {
+       if (pgexporter_starts_with(line, "pgexporter_state{endpoint="))
+       {
+           found_first_metric = true;
+           printf("Found first core metric: %s\n", line);
+       }
+
+       if (pgexporter_starts_with(line, "pgexporter_postgresql_version{endpoint="))
+       {
+           char* version_start = strstr(line, "version=\"");
+           if (version_start != NULL)
+           {
+               version_start += 9;
+               char* version_end = strchr(version_start, '"');
+               if (version_end != NULL)
+               {
+                   *version_end = '\0';
+                   postgresql_version = atoi(version_start);
+                   found_version_metric = true;
+                   printf("Found PostgreSQL version metric: version=%d\n", postgresql_version);
+                   *version_end = '"';
+               }
+           }
+       }
+
+       last_line = line;
+       line = strtok_r(NULL, "\n", &saveptr);
+   }
+
+   if (last_line != NULL)
+   {
+       printf("Last line of response: %s\n", last_line);
+   }
+
+   printf("Validating metrics\n");
+   if (!found_first_metric)
+   {
+       printf("ERROR: Failed to find first core metric (pgexporter_state with endpoint label)\n");
+       goto error;
+   }
+   printf("First core metric validation passed\n");
+
+   if (!found_version_metric)
+   {
+       printf("ERROR: Failed to find PostgreSQL version metric with endpoint label\n");
+       goto error;
+   }
+   printf("PostgreSQL version metric found\n");
+
+   if (postgresql_version != 17)
+   {
+       printf("ERROR: Expected PostgreSQL version 17, got %d\n", postgresql_version);
+       goto error;
+   }
+   printf("PostgreSQL version validation passed\n");
+
+   printf("Bridge endpoint test completed successfully\n");
+   ret = 0;
+
+error:
+   printf("DEBUG: Bridge test cleanup\n");
+   fflush(stdout);
+   
+   if (http != NULL)
+   {
+       pgexporter_http_disconnect(http);
+       pgexporter_http_destroy(http);
+   }
+   free(response_body);
+   
+   printf("DEBUG: Bridge test returning %d\n", ret);
+   fflush(stdout);
+   
+   return ret;
+}
+
+int
+pgexporter_tsclient_test_extension_detection()
+{
+    struct configuration* config;
+    bool found_pg_stat_statements = false;
+    int ret = 1;
+
+    config = (struct configuration*)shmem;
+
+    printf("=== Testing extension detection ===\n");
+    printf("Number of configured servers: %d\n", config->number_of_servers);
+
+    if (config->number_of_servers == 0)
+    {
+        printf("ERROR: No servers configured\n");
+        goto error;
+    }
+
+    printf("Checking server 0 for extensions\n");
+    printf("Number of extensions on server 0: %d\n", config->servers[0].number_of_extensions);
+
+    for (int i = 0; i < config->servers[0].number_of_extensions; i++)
+    {
+        printf("Extension %d: name='%s', enabled=%s\n", 
+               i, 
+               config->servers[0].extensions[i].name,
+               config->servers[0].extensions[i].enabled ? "true" : "false");
+        
+        if (strcmp(config->servers[0].extensions[i].name, "pg_stat_statements") == 0)
+        {
+            found_pg_stat_statements = true;
+            printf("Found pg_stat_statements extension\n");
+            
+            if (config->servers[0].extensions[i].enabled)
+            {
+                printf("pg_stat_statements is enabled\n");
+            }
+            else
+            {
+                printf("WARNING: pg_stat_statements is not enabled\n");
+            }
+        }
+    }
+
+    if (!found_pg_stat_statements)
+    {
+        printf("ERROR: pg_stat_statements extension not found\n");
+        goto error;
+    }
+
+    printf("Extension detection test completed successfully\n");
+    ret = 0;
+
+error:
+    return ret;
+}


### PR DESCRIPTION
Addressing #235, Heres what is being done in the testsuite script (`.sh`):

1. setup pgexporter with configuration required and appropriate roles
2. `curl` and log the response to `:5002/metrics` and `:5003/metrics` (bridge)

Then in the test suite we have this:
1. test cases for status, ping to check if successful startup
2. check connection to postgres database, get the version query and validate it against the one installed in CI, check if `extension_path` is detected (not null/empty)
3. use `http_get` for requesting metrics on `5002/metrics` and `5003/metrics` and also validating for expected response by matching first few lines. Also detects if extension `pg_stat_statements` has been detected (it is installed in the script to the postgres database) before shutting down

We also save the logs as an artifact to check for issues incase something fails 