### PR TITLE
Add queries for pg_stat_statements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,7 @@ jobs:
               texlive-texmf \
               graphviz \
               pkgconf
+            dot -c
 
       - name: Build Project
         shell: freebsd {0}

--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -552,48 +552,6 @@
     {
       "queries": [
         {
-          "query": "SELECT calls, query FROM pg_stat_statements ORDER BY calls DESC LIMIT 10;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of times the SQL query is executed."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_calls",
-      "sort": "data",
-      "collector": "stat_statements_calls"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT rows, query FROM pg_stat_statements ORDER BY rows DESC LIMIT 10;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of rows the SQL query affects."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_rows",
-      "sort": "data",
-      "collector": "stat_statements_rows"
-    },
-    {
-      "queries": [
-        {
           "query": "SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;",
           "version": 10,
           "columns": [
@@ -983,65 +941,6 @@
       ],
       "tag": "pg_shmem_allocations",
       "collector": "shmem_size"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT total_exec_time, query FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 10;",
-          "columns": [
-            {
-              "type": "gauge",
-              "description": "Milliseconds taken by the sql query to execute."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_total_exec_time",
-      "collector": "stat_statements_total_exec_time"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT plans, query FROM pg_stat_statements ORDER BY plans desc LIMIT 10;",
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of times the sql query is planned."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_plans",
-      "sort": "data",
-      "collector": "stat_statements_plans"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT wal_bytes, query FROM pg_stat_statements ORDER BY wal_bytes desc LIMIT 10;",
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Bytes occupied in WAL."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_wal_bytes",
-      "sort": "data",
-      "collector": "stat_statements_wal_bytes"
     }
   ]
 }

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -552,48 +552,6 @@
     {
       "queries": [
         {
-          "query": "SELECT calls, query FROM pg_stat_statements ORDER BY calls DESC LIMIT 10;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of times the SQL query is executed."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_calls",
-      "sort": "data",
-      "collector": "stat_statements_calls"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT rows, query FROM pg_stat_statements ORDER BY rows DESC LIMIT 10;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of rows the SQL query affects."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_rows",
-      "sort": "data",
-      "collector": "stat_statements_rows"
-    },
-    {
-      "queries": [
-        {
           "query": "SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;",
           "version": 10,
           "columns": [
@@ -792,68 +750,6 @@
       ],
       "tag": "pg_shmem_allocations",
       "collector": "shmem_size"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT total_exec_time, query FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "gauge",
-              "description": "Milliseconds taken by the sql query to execute."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_total_exec_time",
-      "collector": "stat_statements_total_exec_time"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT plans, query FROM pg_stat_statements ORDER BY plans desc LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of times the sql query is planned."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_plans",
-      "sort": "data",
-      "collector": "stat_statements_plans"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT wal_bytes, query FROM pg_stat_statements ORDER BY wal_bytes desc LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Bytes occupied in WAL."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_wal_bytes",
-      "sort": "data",
-      "collector": "stat_statements_wal_bytes"
     },
     {
       "queries": [

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -552,48 +552,6 @@
     {
       "queries": [
         {
-          "query": "SELECT calls, query FROM pg_stat_statements ORDER BY calls DESC LIMIT 10;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of times the SQL query is executed."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_calls",
-      "sort": "data",
-      "collector": "stat_statements_calls"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT rows, query FROM pg_stat_statements ORDER BY rows DESC LIMIT 10;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of rows the SQL query affects."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_rows",
-      "sort": "data",
-      "collector": "stat_statements_rows"
-    },
-    {
-      "queries": [
-        {
           "query": "SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;",
           "version": 10,
           "columns": [
@@ -792,68 +750,6 @@
       ],
       "tag": "pg_shmem_allocations",
       "collector": "shmem_size"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT total_exec_time, query FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "gauge",
-              "description": "Milliseconds taken by the sql query to execute."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_total_exec_time",
-      "collector": "stat_statements_total_exec_time"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT plans, query FROM pg_stat_statements ORDER BY plans desc LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of times the sql query is planned."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_plans",
-      "sort": "data",
-      "collector": "stat_statements_plans"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT wal_bytes, query FROM pg_stat_statements ORDER BY wal_bytes desc LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Bytes occupied in WAL."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_wal_bytes",
-      "sort": "data",
-      "collector": "stat_statements_wal_bytes"
     },
     {
       "queries": [

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -510,48 +510,6 @@
     {
       "queries": [
         {
-          "query": "SELECT calls, query FROM pg_stat_statements ORDER BY calls DESC LIMIT 10;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of times the SQL query is executed."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_calls",
-      "sort": "data",
-      "collector": "stat_statements_calls"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT rows, query FROM pg_stat_statements ORDER BY rows DESC LIMIT 10;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of rows the SQL query affects."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_rows",
-      "sort": "data",
-      "collector": "stat_statements_rows"
-    },
-    {
-      "queries": [
-        {
           "query": "SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;",
           "version": 10,
           "columns": [
@@ -718,68 +676,6 @@
       ],
       "tag": "pg_shmem_allocations",
       "collector": "shmem_size"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT total_exec_time, query FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "gauge",
-              "description": "Milliseconds taken by the sql query to execute."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_total_exec_time",
-      "collector": "stat_statements_total_exec_time"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT plans, query FROM pg_stat_statements ORDER BY plans desc LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of times the sql query is planned."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_plans",
-      "sort": "data",
-      "collector": "stat_statements_plans"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT wal_bytes, query FROM pg_stat_statements ORDER BY wal_bytes desc LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Bytes occupied in WAL."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_wal_bytes",
-      "sort": "data",
-      "collector": "stat_statements_wal_bytes"
     },
     {
       "queries": [

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -475,48 +475,6 @@
     {
       "queries": [
         {
-          "query": "SELECT calls, query FROM pg_stat_statements ORDER BY calls DESC LIMIT 10;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of times the SQL query is executed."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_calls",
-      "sort": "data",
-      "collector": "stat_statements_calls"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT rows, query FROM pg_stat_statements ORDER BY rows DESC LIMIT 10;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of rows the SQL query affects."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_rows",
-      "sort": "data",
-      "collector": "stat_statements_rows"
-    },
-    {
-      "queries": [
-        {
           "query": "SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;",
           "version": 10,
           "columns": [
@@ -683,68 +641,6 @@
       ],
       "tag": "pg_shmem_allocations",
       "collector": "shmem_size"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT total_exec_time, query FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "gauge",
-              "description": "Milliseconds taken by the sql query to execute."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_total_exec_time",
-      "collector": "stat_statements_total_exec_time"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT plans, query FROM pg_stat_statements ORDER BY plans desc LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Number of times the sql query is planned."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_plans",
-      "sort": "data",
-      "collector": "stat_statements_plans"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT wal_bytes, query FROM pg_stat_statements ORDER BY wal_bytes desc LIMIT 10;",
-          "version": 13,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Bytes occupied in WAL."
-            },
-            {
-              "name": "query",
-              "type": "label"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_statements_wal_bytes",
-      "sort": "data",
-      "collector": "stat_statements_wal_bytes"
     },
     {
       "queries": [

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -503,38 +503,6 @@ metrics:
     sort: data
     collector: stat_user_functions
 
-# Top 10 most executed SQL query per server
-  - queries:
-    - query: SELECT calls, query
-              FROM pg_stat_statements
-              ORDER BY calls DESC
-              LIMIT 10;
-      version: 10
-      columns:
-        - type: counter
-          description: Number of times the SQL query is executed.
-        - name: query
-          type: label
-    tag: pg_stat_statements_calls
-    sort: data
-    collector: stat_statements_calls
-
-# Top 10 most rows affecting SQL queries
-  - queries:
-    - query: SELECT rows, query
-              FROM pg_stat_statements
-              ORDER BY rows DESC
-              LIMIT 10;
-      version: 10
-      columns:
-        - type: counter
-          description: Number of rows the SQL query affects.
-        - name: query
-          type: label
-    tag: pg_stat_statements_rows
-    sort: data
-    collector: stat_statements_rows
-
 # Number of streaming WAL connections per application.
   - queries:
     - query: SELECT COUNT(*), application_name
@@ -870,47 +838,3 @@ metrics:
           description: Histogram of shared memory sizes.
     tag: pg_shmem_allocations
     collector: shmem_size
-
-# Top 10 slowest executing queries
-  - queries:
-    - query: SELECT total_exec_time, query
-              FROM pg_stat_statements
-              ORDER BY total_exec_time DESC
-              LIMIT 10;
-      columns:
-        - type: gauge
-          description: Milliseconds taken by the sql query to execute.
-        - name: query
-          type: label
-    tag: pg_stat_statements_total_exec_time
-    collector: stat_statements_total_exec_time
-
-# Top 10 planned queries
-  - queries:
-    - query: SELECT plans, query
-              FROM pg_stat_statements
-              ORDER BY plans desc
-              LIMIT 10;
-      columns:
-        - type: counter
-          description: Number of times the sql query is planned.
-        - name: query
-          type: label
-    tag: pg_stat_statements_plans
-    sort: data
-    collector: stat_statements_plans
-
-# Top 10 queries taking up most WAL space
-  - queries:
-    - query: SELECT wal_bytes, query
-              FROM pg_stat_statements
-              ORDER BY wal_bytes desc
-              LIMIT 10;
-      columns:
-        - type: counter
-          description: Bytes occupied in WAL.
-        - name: query
-          type: label
-    tag: pg_stat_statements_wal_bytes
-    sort: data
-    collector: stat_statements_wal_bytes

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -503,38 +503,6 @@ metrics:
     sort: data
     collector: stat_user_functions
 
-# Top 10 most executed SQL query per server
-  - queries:
-    - query: SELECT calls, query
-              FROM pg_stat_statements
-              ORDER BY calls DESC
-              LIMIT 10;
-      version: 10
-      columns:
-        - type: counter
-          description: Number of times the SQL query is executed.
-        - name: query
-          type: label
-    tag: pg_stat_statements_calls
-    sort: data
-    collector: stat_statements_calls
-
-# Top 10 most rows affecting SQL queries
-  - queries:
-    - query: SELECT rows, query
-              FROM pg_stat_statements
-              ORDER BY rows DESC
-              LIMIT 10;
-      version: 10
-      columns:
-        - type: counter
-          description: Number of rows the SQL query affects.
-        - name: query
-          type: label
-    tag: pg_stat_statements_rows
-    sort: data
-    collector: stat_statements_rows
-
 # Number of streaming WAL connections per application.
   - queries:
     - query: SELECT COUNT(*), application_name
@@ -716,53 +684,6 @@ metrics:
           description: Histogram of shared memory sizes.
     tag: pg_shmem_allocations
     collector: shmem_size
-
-# Top 10 slowest executing queries
-  - queries:
-    - query: SELECT total_exec_time, query
-              FROM pg_stat_statements
-              ORDER BY total_exec_time DESC
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: gauge
-          description: Milliseconds taken by the sql query to execute.
-        - name: query
-          type: label
-    tag: pg_stat_statements_total_exec_time
-    collector: stat_statements_total_exec_time
-
-# Top 10 planned queries
-  - queries:
-    - query: SELECT plans, query
-              FROM pg_stat_statements
-              ORDER BY plans desc
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: counter
-          description: Number of times the sql query is planned.
-        - name: query
-          type: label
-    tag: pg_stat_statements_plans
-    sort: data
-    collector: stat_statements_plans
-
-# Top 10 queries taking up most WAL space
-  - queries:
-    - query: SELECT wal_bytes, query
-              FROM pg_stat_statements
-              ORDER BY wal_bytes desc
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: counter
-          description: Bytes occupied in WAL.
-        - name: query
-          type: label
-    tag: pg_stat_statements_wal_bytes
-    sort: data
-    collector: stat_statements_wal_bytes
 
 #
 # PostgreSQL 14

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -503,38 +503,6 @@ metrics:
     sort: data
     collector: stat_user_functions
 
-# Top 10 most executed SQL query per server
-  - queries:
-    - query: SELECT calls, query
-              FROM pg_stat_statements
-              ORDER BY calls DESC
-              LIMIT 10;
-      version: 10
-      columns:
-        - type: counter
-          description: Number of times the SQL query is executed.
-        - name: query
-          type: label
-    tag: pg_stat_statements_calls
-    sort: data
-    collector: stat_statements_calls
-
-# Top 10 most rows affecting SQL queries
-  - queries:
-    - query: SELECT rows, query
-              FROM pg_stat_statements
-              ORDER BY rows DESC
-              LIMIT 10;
-      version: 10
-      columns:
-        - type: counter
-          description: Number of rows the SQL query affects.
-        - name: query
-          type: label
-    tag: pg_stat_statements_rows
-    sort: data
-    collector: stat_statements_rows
-
 # Number of streaming WAL connections per application.
   - queries:
     - query: SELECT COUNT(*), application_name
@@ -716,53 +684,6 @@ metrics:
           description: Histogram of shared memory sizes.
     tag: pg_shmem_allocations
     collector: shmem_size
-
-# Top 10 slowest executing queries
-  - queries:
-    - query: SELECT total_exec_time, query
-              FROM pg_stat_statements
-              ORDER BY total_exec_time DESC
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: gauge
-          description: Milliseconds taken by the sql query to execute.
-        - name: query
-          type: label
-    tag: pg_stat_statements_total_exec_time
-    collector: stat_statements_total_exec_time
-
-# Top 10 planned queries
-  - queries:
-    - query: SELECT plans, query
-              FROM pg_stat_statements
-              ORDER BY plans desc
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: counter
-          description: Number of times the sql query is planned.
-        - name: query
-          type: label
-    tag: pg_stat_statements_plans
-    sort: data
-    collector: stat_statements_plans
-
-# Top 10 queries taking up most WAL space
-  - queries:
-    - query: SELECT wal_bytes, query
-              FROM pg_stat_statements
-              ORDER BY wal_bytes desc
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: counter
-          description: Bytes occupied in WAL.
-        - name: query
-          type: label
-    tag: pg_stat_statements_wal_bytes
-    sort: data
-    collector: stat_statements_wal_bytes
 
 #
 # PostgreSQL 14

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -469,38 +469,6 @@ metrics:
     sort: data
     collector: stat_user_functions
 
-# Top 10 most executed SQL query per server
-  - queries:
-    - query: SELECT calls, query
-              FROM pg_stat_statements
-              ORDER BY calls DESC
-              LIMIT 10;
-      version: 10
-      columns:
-        - type: counter
-          description: Number of times the SQL query is executed.
-        - name: query
-          type: label
-    tag: pg_stat_statements_calls
-    sort: data
-    collector: stat_statements_calls
-
-# Top 10 most rows affecting SQL queries
-  - queries:
-    - query: SELECT rows, query
-              FROM pg_stat_statements
-              ORDER BY rows DESC
-              LIMIT 10;
-      version: 10
-      columns:
-        - type: counter
-          description: Number of rows the SQL query affects.
-        - name: query
-          type: label
-    tag: pg_stat_statements_rows
-    sort: data
-    collector: stat_statements_rows
-
 # Number of streaming WAL connections per application.
   - queries:
     - query: SELECT COUNT(*), application_name
@@ -657,53 +625,6 @@ metrics:
           description: Histogram of shared memory sizes.
     tag: pg_shmem_allocations
     collector: shmem_size
-
-# Top 10 slowest executing queries
-  - queries:
-    - query: SELECT total_exec_time, query
-              FROM pg_stat_statements
-              ORDER BY total_exec_time DESC
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: gauge
-          description: Milliseconds taken by the sql query to execute.
-        - name: query
-          type: label
-    tag: pg_stat_statements_total_exec_time
-    collector: stat_statements_total_exec_time
-
-# Top 10 planned queries
-  - queries:
-    - query: SELECT plans, query
-              FROM pg_stat_statements
-              ORDER BY plans desc
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: counter
-          description: Number of times the sql query is planned.
-        - name: query
-          type: label
-    tag: pg_stat_statements_plans
-    sort: data
-    collector: stat_statements_plans
-
-# Top 10 queries taking up most WAL space
-  - queries:
-    - query: SELECT wal_bytes, query
-              FROM pg_stat_statements
-              ORDER BY wal_bytes desc
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: counter
-          description: Bytes occupied in WAL.
-        - name: query
-          type: label
-    tag: pg_stat_statements_wal_bytes
-    sort: data
-    collector: stat_statements_wal_bytes
 
 #
 # PostgreSQL 14

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -441,38 +441,6 @@ metrics:
     sort: data
     collector: stat_user_functions
 
-# Top 10 most executed SQL query per server
-  - queries:
-    - query: SELECT calls, query
-              FROM pg_stat_statements
-              ORDER BY calls DESC
-              LIMIT 10;
-      version: 10
-      columns:
-        - type: counter
-          description: Number of times the SQL query is executed.
-        - name: query
-          type: label
-    tag: pg_stat_statements_calls
-    sort: data
-    collector: stat_statements_calls
-
-# Top 10 most rows affecting SQL queries
-  - queries:
-    - query: SELECT rows, query
-              FROM pg_stat_statements
-              ORDER BY rows DESC
-              LIMIT 10;
-      version: 10
-      columns:
-        - type: counter
-          description: Number of rows the SQL query affects.
-        - name: query
-          type: label
-    tag: pg_stat_statements_rows
-    sort: data
-    collector: stat_statements_rows
-
 # Number of streaming WAL connections per application.
   - queries:
     - query: SELECT COUNT(*), application_name
@@ -629,53 +597,6 @@ metrics:
           description: Histogram of shared memory sizes.
     tag: pg_shmem_allocations
     collector: shmem_size
-
-# Top 10 slowest executing queries
-  - queries:
-    - query: SELECT total_exec_time, query
-              FROM pg_stat_statements
-              ORDER BY total_exec_time DESC
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: gauge
-          description: Milliseconds taken by the sql query to execute.
-        - name: query
-          type: label
-    tag: pg_stat_statements_total_exec_time
-    collector: stat_statements_total_exec_time
-
-# Top 10 planned queries
-  - queries:
-    - query: SELECT plans, query
-              FROM pg_stat_statements
-              ORDER BY plans desc
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: counter
-          description: Number of times the sql query is planned.
-        - name: query
-          type: label
-    tag: pg_stat_statements_plans
-    sort: data
-    collector: stat_statements_plans
-
-# Top 10 queries taking up most WAL space
-  - queries:
-    - query: SELECT wal_bytes, query
-              FROM pg_stat_statements
-              ORDER BY wal_bytes desc
-              LIMIT 10;
-      version: 13
-      columns:
-        - type: counter
-          description: Bytes occupied in WAL.
-        - name: query
-          type: label
-    tag: pg_stat_statements_wal_bytes
-    sort: data
-    collector: stat_statements_wal_bytes
 
 #
 # PostgreSQL 14

--- a/extensions/pg_stat_statements.yaml
+++ b/extensions/pg_stat_statements.yaml
@@ -28,14 +28,438 @@
 
 extension: pg_stat_statements
 metrics:
-  - metric: queries
+
+#
+# Extension Version 1.8
+# Added: Planning statistics, WAL metrics, execution timing separation
+#
+
+  # Most executed queries - monitoring query frequency
+  - metric: most_executed
     queries:
-      - query: SELECT queryid, calls, total_exec_time FROM pg_stat_statements;
+      - query: SELECT calls, query FROM pg_stat_statements ORDER BY calls DESC LIMIT 10;
+        version: "1.8"
+        columns:
+          - name: calls
+            type: gauge
+            description: Number of times the SQL query is executed
+          - name: query
+            type: label
+
+  # Most planned queries
+  - metric: most_planned
+    queries:
+      - query: SELECT plans, query FROM pg_stat_statements ORDER BY plans DESC LIMIT 10;
+        version: "1.8"
+        columns:
+          - name: plans
+            type: gauge
+            description: Number of times the sql query is planned
+          - name: query
+            type: label
+
+  # Most row-affecting queries - data volume impact
+  - metric: most_rows
+    queries:
+      - query: SELECT rows, query FROM pg_stat_statements ORDER BY rows DESC LIMIT 10;
+        version: "1.8"
+        columns:
+          - name: rows
+            type: gauge
+            description: Number of rows the SQL query affects
+          - name: query
+            type: label
+
+  # Slowest queries by execution time
+  - metric: slowest_execution
+    queries:
+      - query: SELECT total_exec_time, query FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 10;
+        version: "1.8"
+        columns:
+          - name: total_exec_time
+            type: gauge
+            description: Milliseconds taken by the sql query to execute
+          - name: query
+            type: label
+
+  # Highest WAL generating queries
+  - metric: highest_wal
+    queries:
+      - query: SELECT wal_bytes, query FROM pg_stat_statements ORDER BY wal_bytes DESC LIMIT 10;
+        version: "1.8"
+        columns:
+          - name: wal_bytes
+            type: gauge
+            description: Bytes occupied in WAL
+          - name: query
+            type: label
+
+  # Planning statistics with detailed metrics - query optimization insights
+  - metric: planning_stats
+    queries:
+      - query: SELECT queryid, plans, total_plan_time, mean_plan_time, query FROM pg_stat_statements WHERE plans > 0 ORDER BY total_plan_time DESC LIMIT 10;
         version: "1.8"
         columns:
           - name: queryid
             type: label
-          - name: calls
-            type: counter
+          - name: plans
+            type: gauge
+            description: Number of times the query has been planned
+          - name: total_plan_time
+            type: gauge
+            description: Total planning time in milliseconds
+          - name: mean_plan_time
+            type: gauge
+            description: Mean planning time in milliseconds
+          - name: query
+            type: label
+
+  # Execution time with detailed metrics - identify performance bottlenecks
+  - metric: exec_time_detailed
+    queries:
+      - query: SELECT queryid, total_exec_time, mean_exec_time, query FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 10;
+        version: "1.8"
+        columns:
+          - name: queryid
+            type: label
           - name: total_exec_time
-            type: counter
+            type: gauge
+            description: Total execution time in milliseconds
+          - name: mean_exec_time
+            type: gauge
+            description: Mean execution time in milliseconds
+          - name: query
+            type: label
+
+  # I/O intensive queries - disk access patterns
+  - metric: io_stats
+    queries:
+      - query: SELECT queryid, shared_blks_hit, shared_blks_read, shared_blks_written, local_blks_read, local_blks_written, temp_blks_read, temp_blks_written, query FROM pg_stat_statements WHERE shared_blks_read + local_blks_read + temp_blks_read > 0 ORDER BY (shared_blks_read + local_blks_read + temp_blks_read) DESC LIMIT 10;
+        version: "1.8"
+        columns:
+          - name: queryid
+            type: label
+          - name: shared_blks_hit
+            type: gauge
+            description: Total shared blocks hit in buffer cache
+          - name: shared_blks_read
+            type: gauge
+            description: Total shared blocks read from disk
+          - name: shared_blks_written
+            type: gauge
+            description: Total shared blocks written to disk
+          - name: local_blks_read
+            type: gauge
+            description: Total local blocks read from disk
+          - name: local_blks_written
+            type: gauge
+            description: Total local blocks written to disk
+          - name: temp_blks_read
+            type: gauge
+            description: Total temp blocks read from disk
+          - name: temp_blks_written
+            type: gauge
+            description: Total temp blocks written to disk
+          - name: query
+            type: label
+
+  # Basic I/O timing (generic blk_read_time/blk_write_time)
+  - metric: io_timing
+    queries:
+      - query: SELECT queryid, blk_read_time, blk_write_time, query FROM pg_stat_statements WHERE blk_read_time + blk_write_time > 0 ORDER BY (blk_read_time + blk_write_time) DESC LIMIT 10;
+        version: "1.8"
+        columns:
+          - name: queryid
+            type: label
+          - name: blk_read_time
+            type: gauge
+            description: Time spent reading blocks in milliseconds
+          - name: blk_write_time
+            type: gauge
+            description: Time spent writing blocks in milliseconds
+          - name: query
+            type: label
+
+  # Query performance summary
+  - metric: performance_summary
+    queries:
+      - query: SELECT COUNT(*) as total_queries, SUM(calls) as total_calls, SUM(total_exec_time) as total_exec_time, AVG(mean_exec_time) as avg_mean_time FROM pg_stat_statements;
+        version: "1.8"
+        columns:
+          - name: total_queries
+            type: gauge
+            description: Total number of distinct queries tracked
+          - name: total_calls
+            type: gauge
+            description: Total number of query executions
+          - name: total_exec_time
+            type: gauge
+            description: Total execution time across all queries in milliseconds
+          - name: avg_mean_time
+            type: gauge
+            description: Average mean execution time in milliseconds
+
+  # Extension metadata - basic tracking
+  - metric: extension_info
+    queries:
+      - query: SELECT COUNT(*) as tracked_queries FROM pg_stat_statements;
+        version: "1.8"
+        columns:
+          - name: tracked_queries
+            type: gauge
+            description: Number of queries currently tracked by pg_stat_statements
+
+#
+# Extension Version 1.9
+# Added: Query hierarchy (toplevel field), pg_stat_statements_info view
+#
+
+  # Top-level vs nested queries - query hierarchy analysis
+  - metric: query_hierarchy
+    queries:
+      - query: SELECT toplevel, COUNT(*) as query_count, SUM(calls) as total_calls, SUM(total_exec_time) as total_time FROM pg_stat_statements GROUP BY toplevel;
+        version: "1.9"
+        columns:
+          - name: toplevel
+            type: label
+            description: Whether queries are top-level (true) or nested (false)
+          - name: query_count
+            type: gauge
+            description: Number of distinct queries
+          - name: total_calls
+            type: gauge
+            description: Total query executions
+          - name: total_time
+            type: gauge
+            description: Total execution time in milliseconds
+
+  # Extension metadata with pg_stat_statements_info
+  - metric: extension_metadata
+    queries:
+      - query: SELECT dealloc, stats_reset FROM pg_stat_statements_info;
+        version: "1.9"
+        columns:
+          - name: dealloc
+            type: gauge
+            description: Number of deallocations of query entries
+          - name: stats_reset
+            type: label
+            description: Time when statistics were last reset
+
+  # Top-level vs nested performance comparison
+  - metric: hierarchy_performance
+    queries:
+      - query: SELECT toplevel, AVG(mean_exec_time) as avg_mean_exec_time, AVG(mean_plan_time) as avg_mean_plan_time, SUM(wal_bytes) as total_wal_bytes FROM pg_stat_statements GROUP BY toplevel;
+        version: "1.9"
+        columns:
+          - name: toplevel
+            type: label
+          - name: avg_mean_exec_time
+            type: gauge
+            description: Average mean execution time for query type
+          - name: avg_mean_plan_time
+            type: gauge
+            description: Average mean planning time for query type
+          - name: total_wal_bytes
+            type: gauge
+            description: Total WAL bytes generated by query type
+
+#
+# Extension Version 1.10
+# Added: JIT compilation metrics, separate temp block I/O timing
+#
+
+  # Detailed I/O timing - separate temp block timing
+  - metric: detailed_io_timing
+    queries:
+      - query: SELECT queryid, blk_read_time, blk_write_time, temp_blk_read_time, temp_blk_write_time, query FROM pg_stat_statements WHERE blk_read_time + blk_write_time + temp_blk_read_time + temp_blk_write_time > 0 ORDER BY (blk_read_time + blk_write_time + temp_blk_read_time + temp_blk_write_time) DESC LIMIT 10;
+        version: "1.10"
+        columns:
+          - name: queryid
+            type: label
+          - name: blk_read_time
+            type: gauge
+            description: Time spent reading blocks in milliseconds
+          - name: blk_write_time
+            type: gauge
+            description: Time spent writing blocks in milliseconds
+          - name: temp_blk_read_time
+            type: gauge
+            description: Time spent reading temp blocks in milliseconds
+          - name: temp_blk_write_time
+            type: gauge
+            description: Time spent writing temp blocks in milliseconds
+          - name: query
+            type: label
+
+  # JIT compilation statistics
+  - metric: jit_stats
+    queries:
+      - query: SELECT queryid, jit_functions, jit_generation_time, jit_inlining_count, jit_inlining_time, jit_optimization_count, jit_optimization_time, jit_emission_count, jit_emission_time, query FROM pg_stat_statements WHERE jit_functions > 0 ORDER BY jit_generation_time DESC LIMIT 10;
+        version: "1.10"
+        columns:
+          - name: queryid
+            type: label
+          - name: jit_functions
+            type: gauge
+            description: Number of functions JIT-compiled
+          - name: jit_generation_time
+            type: gauge
+            description: Time spent generating JIT code in milliseconds
+          - name: jit_inlining_count
+            type: gauge
+            description: Number of times functions were inlined
+          - name: jit_inlining_time
+            type: gauge
+            description: Time spent inlining in milliseconds
+          - name: jit_optimization_count
+            type: gauge
+            description: Number of times functions were optimized
+          - name: jit_optimization_time
+            type: gauge
+            description: Time spent optimizing in milliseconds
+          - name: jit_emission_count
+            type: gauge
+            description: Number of times code was emitted
+          - name: jit_emission_time
+            type: gauge
+            description: Time spent emitting JIT code in milliseconds
+          - name: query
+            type: label
+
+  # JIT performance summary
+  - metric: jit_summary
+    queries:
+      - query: SELECT COUNT(*) as jit_enabled_queries, SUM(jit_functions) as total_jit_functions, SUM(jit_generation_time) as total_jit_time, AVG(jit_generation_time) as avg_jit_time FROM pg_stat_statements WHERE jit_functions > 0;
+        version: "1.10"
+        columns:
+          - name: jit_enabled_queries
+            type: gauge
+            description: Number of queries that used JIT compilation
+          - name: total_jit_functions
+            type: gauge
+            description: Total number of functions JIT-compiled
+          - name: total_jit_time
+            type: gauge
+            description: Total time spent on JIT compilation in milliseconds
+          - name: avg_jit_time
+            type: gauge
+            description: Average JIT compilation time in milliseconds
+
+#
+# Extension Version 1.11
+# Added: Granular I/O timing by storage type, JIT deform operations, statistics reset tracking
+#
+
+  # Granular I/O timing - separate by storage type
+  - metric: granular_io_timing
+    queries:
+      - query: SELECT queryid, shared_blk_read_time, shared_blk_write_time, local_blk_read_time, local_blk_write_time, temp_blk_read_time, temp_blk_write_time, query FROM pg_stat_statements WHERE shared_blk_read_time + shared_blk_write_time + local_blk_read_time + local_blk_write_time + temp_blk_read_time + temp_blk_write_time > 0 ORDER BY (shared_blk_read_time + shared_blk_write_time + local_blk_read_time + local_blk_write_time + temp_blk_read_time + temp_blk_write_time) DESC LIMIT 10;
+        version: "1.11"
+        columns:
+          - name: queryid
+            type: label
+          - name: shared_blk_read_time
+            type: gauge
+            description: Time spent reading shared blocks in milliseconds
+          - name: shared_blk_write_time
+            type: gauge
+            description: Time spent writing shared blocks in milliseconds
+          - name: local_blk_read_time
+            type: gauge
+            description: Time spent reading local blocks in milliseconds
+          - name: local_blk_write_time
+            type: gauge
+            description: Time spent writing local blocks in milliseconds
+          - name: temp_blk_read_time
+            type: gauge
+            description: Time spent reading temp blocks in milliseconds
+          - name: temp_blk_write_time
+            type: gauge
+            description: Time spent writing temp blocks in milliseconds
+          - name: query
+            type: label
+
+  # JIT deform statistics - tuple deforming operations
+  - metric: jit_deform_stats
+    queries:
+      - query: SELECT queryid, jit_deform_count, jit_deform_time, jit_functions, jit_generation_time + jit_inlining_time + jit_optimization_time + jit_emission_time + jit_deform_time as total_jit_time, query FROM pg_stat_statements WHERE jit_deform_count > 0 ORDER BY jit_deform_time DESC LIMIT 10;
+        version: "1.11"
+        columns:
+          - name: queryid
+            type: label
+          - name: jit_deform_count
+            type: gauge
+            description: Number of tuple deforming operations JIT-compiled
+          - name: jit_deform_time
+            type: gauge
+            description: Time spent on JIT tuple deforming in milliseconds
+          - name: jit_functions
+            type: gauge
+            description: Number of functions JIT-compiled
+          - name: total_jit_time
+            type: gauge
+            description: Total time spent on all JIT operations in milliseconds
+          - name: query
+            type: label
+
+  # Statistics reset tracking
+  - metric: stats_reset_info
+    queries:
+      - query: SELECT queryid, stats_since, minmax_stats_since, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_since))::bigint as seconds_since_reset, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - minmax_stats_since))::bigint as seconds_since_minmax_reset, query FROM pg_stat_statements WHERE stats_since IS NOT NULL ORDER BY stats_since DESC LIMIT 10;
+        version: "1.11"
+        columns:
+          - name: queryid
+            type: label
+          - name: stats_since
+            type: label
+            description: Time when query statistics collection started
+          - name: minmax_stats_since
+            type: label
+            description: Time when min/max statistics were last reset
+          - name: seconds_since_reset
+            type: gauge
+            description: Seconds since statistics were last reset
+          - name: seconds_since_minmax_reset
+            type: gauge
+            description: Seconds since min/max statistics were last reset
+          - name: query
+            type: label
+
+  # Advanced JIT summary with deform operations
+  - metric: advanced_jit_summary
+    queries:
+      - query: SELECT COUNT(*) as jit_enabled_queries, SUM(jit_functions) as total_jit_functions, SUM(jit_deform_count) as total_deform_ops, SUM(jit_generation_time + jit_inlining_time + jit_optimization_time + jit_emission_time + jit_deform_time) as total_jit_time FROM pg_stat_statements WHERE jit_functions > 0;
+        version: "1.11"
+        columns:
+          - name: jit_enabled_queries
+            type: gauge
+            description: Number of queries that used JIT compilation
+          - name: total_jit_functions
+            type: gauge
+            description: Total number of functions JIT-compiled
+          - name: total_deform_ops
+            type: gauge
+            description: Total number of JIT tuple deform operations
+          - name: total_jit_time
+            type: gauge
+            description: Total time spent on all JIT operations in milliseconds
+
+  # I/O timing summary by storage type
+  - metric: io_timing_summary
+    queries:
+      - query: SELECT SUM(shared_blk_read_time + shared_blk_write_time) as shared_io_time, SUM(local_blk_read_time + local_blk_write_time) as local_io_time, SUM(temp_blk_read_time + temp_blk_write_time) as temp_io_time, COUNT(*) as queries_with_io FROM pg_stat_statements WHERE shared_blk_read_time + shared_blk_write_time + local_blk_read_time + local_blk_write_time + temp_blk_read_time + temp_blk_write_time > 0;
+        version: "1.11"
+        columns:
+          - name: shared_io_time
+            type: gauge
+            description: Total time spent on shared block I/O in milliseconds
+          - name: local_io_time
+            type: gauge
+            description: Total time spent on local block I/O in milliseconds
+          - name: temp_io_time
+            type: gauge
+            description: Total time spent on temp block I/O in milliseconds
+          - name: queries_with_io
+            type: gauge
+            description: Number of queries that performed I/O operations

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -521,38 +521,6 @@ extern "C" {
         "    sort: data\n" \
         "    collector: stat_user_functions\n" \
         "\n" \
-        "# Top 10 most executed SQL query per server\n" \
-        "  - queries:\n" \
-        "    - query: SELECT calls, query\n" \
-        "              FROM pg_stat_statements\n" \
-        "              ORDER BY calls DESC\n" \
-        "              LIMIT 10;\n" \
-        "      version: 10\n" \
-        "      columns:\n" \
-        "        - type: counter\n" \
-        "          description: Number of times the SQL query is executed.\n" \
-        "        - name: query\n" \
-        "          type: label\n" \
-        "    tag: pg_stat_statements_calls\n" \
-        "    sort: data\n" \
-        "    collector: stat_statements_calls\n" \
-        "\n" \
-        "# Top 10 most rows affecting SQL queries\n" \
-        "  - queries:\n" \
-        "    - query: SELECT rows, query\n" \
-        "              FROM pg_stat_statements\n" \
-        "              ORDER BY rows DESC\n" \
-        "              LIMIT 10;\n" \
-        "      version: 10\n" \
-        "      columns:\n" \
-        "        - type: counter\n" \
-        "          description: Number of rows the SQL query affects.\n" \
-        "        - name: query\n" \
-        "          type: label\n" \
-        "    tag: pg_stat_statements_rows\n" \
-        "    sort: data\n" \
-        "    collector: stat_statements_rows\n" \
-        "\n" \
         "# Number of streaming WAL connections per application.\n" \
         "  - queries:\n" \
         "    - query: SELECT COUNT(*), application_name\n" \
@@ -709,53 +677,6 @@ extern "C" {
         "          description: Histogram of shared memory sizes.\n" \
         "    tag: pg_shmem_allocations\n" \
         "    collector: shmem_size\n" \
-        "\n" \
-        "# Top 10 slowest executing queries\n" \
-        "  - queries:\n" \
-        "    - query: SELECT total_exec_time, query\n" \
-        "              FROM pg_stat_statements\n" \
-        "              ORDER BY total_exec_time DESC\n" \
-        "              LIMIT 10;\n" \
-        "      version: 13\n" \
-        "      columns:\n" \
-        "        - type: gauge\n" \
-        "          description: Milliseconds taken by the sql query to execute.\n" \
-        "        - name: query\n" \
-        "          type: label\n" \
-        "    tag: pg_stat_statements_total_exec_time\n" \
-        "    collector: stat_statements_total_exec_time\n" \
-        "\n" \
-        "# Top 10 planned queries\n" \
-        "  - queries:\n" \
-        "    - query: SELECT plans, query\n" \
-        "              FROM pg_stat_statements\n" \
-        "              ORDER BY plans desc\n" \
-        "              LIMIT 10;\n" \
-        "      version: 13\n" \
-        "      columns:\n" \
-        "        - type: counter\n" \
-        "          description: Number of times the sql query is planned.\n" \
-        "        - name: query\n" \
-        "          type: label\n" \
-        "    tag: pg_stat_statements_plans\n" \
-        "    sort: data\n" \
-        "    collector: stat_statements_plans\n" \
-        "\n" \
-        "# Top 10 queries taking up most WAL space\n" \
-        "  - queries:\n" \
-        "    - query: SELECT wal_bytes, query\n" \
-        "              FROM pg_stat_statements\n" \
-        "              ORDER BY wal_bytes desc\n" \
-        "              LIMIT 10;\n" \
-        "      version: 13\n" \
-        "      columns:\n" \
-        "        - type: counter\n" \
-        "          description: Bytes occupied in WAL.\n" \
-        "        - name: query\n" \
-        "          type: label\n" \
-        "    tag: pg_stat_statements_wal_bytes\n" \
-        "    sort: data\n" \
-        "    collector: stat_statements_wal_bytes\n" \
         "\n" \
         "#\n" \
         "# PostgreSQL 14\n" \

--- a/src/libpgexporter/extension.c
+++ b/src/libpgexporter/extension.c
@@ -311,8 +311,8 @@ pgexporter_load_extension_yamls(struct configuration* config)
          }
          else
          {
-            pgexporter_log_debug("Skipping disabled extension: %s",
-                                 config->servers[server].extensions[i].name);
+            pgexporter_log_info("Extension %s not enabled for metrics on: %s",
+                                config->servers[server].extensions[i].name, config->servers[server].name);
          }
       }
    }


### PR DESCRIPTION

Addressing #248 
Added comprehensive metrics coverage for pg_stat_statements extension across versions from 1.8 (Default version of the minimum postgres version supported by `pgexporter`):

Heres what majorly changed across them:

**Version 1.8**: Planning statistics, WAL metrics, execution timing separation  
**Version 1.9**: Query hierarchy (toplevel field), pg_stat_statements_info view  
**Version 1.10**: JIT compilation metrics, separate temp block I/O timing  
**Version 1.11**: Detailed I/O timing by storage type, JIT deform operations, statistics reset tracking

These are majorly what I found relevant for pgexporter, some help/advice from AI as well and comments on the core postgres pg_stat_statements for motivation of updates.  I have also documented the diffs accross the versions [here](https://github.com/bassamadnan/pg_ext_tracker/tree/main/pg_stat_statements/docker/pg_ext_diffs).

PTAL @jesperpedersen @resyfer 