### PR TITLE
Detect duplicate metric names

### DIFF
--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -439,7 +439,7 @@
           ]
         }
       ],
-      "tag": "pg_db_conn",
+      "tag": "pg_db_conn_ssl",
       "sort": "data",
       "collector": "connections"
     },

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -439,7 +439,7 @@
           ]
         }
       ],
-      "tag": "pg_db_conn",
+      "tag": "pg_db_conn_ssl",
       "sort": "data",
       "collector": "connections"
     },

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -439,7 +439,7 @@
           ]
         }
       ],
-      "tag": "pg_db_conn",
+      "tag": "pg_db_conn_ssl",
       "sort": "data",
       "collector": "connections"
     },

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -397,7 +397,7 @@
           ]
         }
       ],
-      "tag": "pg_db_conn",
+      "tag": "pg_db_conn_ssl",
       "sort": "data",
       "collector": "connections"
     },

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -362,7 +362,7 @@
           ]
         }
       ],
-      "tag": "pg_db_conn",
+      "tag": "pg_db_conn_ssl",
       "sort": "data",
       "collector": "connections"
     },

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -416,7 +416,7 @@ metrics:
           type: label
         - type: gauge
           description: Number of DB connections with SSL.
-    tag: pg_db_conn
+    tag: pg_db_conn_ssl
     sort: data
     collector: connections
 

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -416,7 +416,7 @@ metrics:
           type: label
         - type: gauge
           description: Number of DB connections with SSL.
-    tag: pg_db_conn
+    tag: pg_db_conn_ssl
     sort: data
     collector: connections
 

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -416,7 +416,7 @@ metrics:
           type: label
         - type: gauge
           description: Number of DB connections with SSL.
-    tag: pg_db_conn
+    tag: pg_db_conn_ssl
     sort: data
     collector: connections
 

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -382,7 +382,7 @@ metrics:
           type: label
         - type: gauge
           description: Number of DB connections with SSL.
-    tag: pg_db_conn
+    tag: pg_db_conn_ssl
     sort: data
     collector: connections
 

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -336,7 +336,7 @@ metrics:
           type: label
         - type: gauge
           description: Number of database connections.
-    tag: pg_db_conn
+    tag: pg_db_conn_ssl
     sort: data
     collector: connections
 

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -434,7 +434,7 @@ extern "C" {
         "          type: label\n" \
         "        - type: gauge\n" \
         "          description: Number of DB connections with SSL.\n" \
-        "    tag: pg_db_conn\n" \
+        "    tag: pg_db_conn_ssl\n" \
         "    sort: data\n" \
         "    collector: connections\n" \
         "\n" \

--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -424,6 +424,7 @@ struct configuration
    struct prometheus prometheus[NUMBER_OF_METRICS];             /**< The Prometheus metrics */
    struct endpoint endpoints[NUMBER_OF_ENDPOINTS];              /**< The Prometheus metrics */
    struct extension_metrics extensions[NUMBER_OF_EXTENSIONS];   /**< Extension metrics by extension */
+   struct art* metric_names;                                    /**< Store all the metric names in ART as keys */
 } __attribute__((aligned(64)));
 
 #ifdef __cplusplus

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -840,6 +840,14 @@ pgexporter_backtrace(void);
 int
 pgexporter_os_kernel_version(char** os, int* kernel_major, int* kernel_minor, int* kernel_patch);
 
+/**
+ * Validate metric name contains only allowed characters
+ * @param name The metric name to validate
+ * @return true if valid, false otherwise
+ */
+bool
+pgexporter_is_valid_metric_name(char* name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgexporter/utils.c
+++ b/src/libpgexporter/utils.c
@@ -2721,3 +2721,35 @@ error:
    return 1;
 #endif
 }
+
+bool
+pgexporter_is_valid_metric_name(char* name)
+{
+   size_t len;
+   size_t i;
+
+   if (!name)
+   {
+      return false;
+   }
+
+   len = strlen(name);
+   if (len == 0)
+   {
+      return false;
+   }
+
+   for (i = 0; i < len; i++)
+   {
+      char c = name[i];
+      if (!((c >= 'a' && c <= 'z') ||
+            (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') ||
+            (c == '_')))
+      {
+         return false;
+      }
+   }
+
+   return true;
+}


### PR DESCRIPTION
Added logic for detecting duplicate metric names, this includes handling different queries based on the same version, validating before processing the file and maintaining a global (`configuration :: metric_name_trie`) list of metrics processed.

Also with this PR we can only read either the YAML/JSON files, or the internal metrics (not both together). Also changed `pg_db_conn` to `pg_db_conn_ssl` to resolve the name conflict.

