### PR TITLE
Use array to store metric names

### DIFF
--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -73,6 +73,7 @@ extern "C" {
 #define NUMBER_OF_ENDPOINTS    32
 #define NUMBER_OF_EXTENSIONS   64
 #define NUMBER_OF_DATABASES    64
+#define NUMBER_OF_METRIC_NAMES 256
 
 #define STATE_FREE        0
 #define STATE_IN_USE      1
@@ -409,6 +410,7 @@ struct configuration
    int number_of_collectors;     /**< Number of total collectors */
    int number_of_endpoints;      /**< The number of endpoints */
    int number_of_extensions;     /**< Number of loaded extensions */
+   int number_of_metric_names;   /**< Number of unique metric names */
 
    char metrics_path[MAX_PATH]; /**< The metrics path */
 
@@ -418,13 +420,13 @@ struct configuration
    atomic_ulong logging_fatal; /**< Logging: FATAL */
 
    char collectors[NUMBER_OF_COLLECTORS][MAX_COLLECTOR_LENGTH]; /**< List of collectors in total */
+   char metric_names[NUMBER_OF_METRIC_NAMES][MISC_LENGTH];      /**< List of all the metric names */
    struct server servers[NUMBER_OF_SERVERS];                    /**< The servers */
    struct user users[NUMBER_OF_USERS];                          /**< The users */
    struct user admins[NUMBER_OF_ADMINS];                        /**< The admins */
    struct prometheus prometheus[NUMBER_OF_METRICS];             /**< The Prometheus metrics */
    struct endpoint endpoints[NUMBER_OF_ENDPOINTS];              /**< The Prometheus metrics */
    struct extension_metrics extensions[NUMBER_OF_EXTENSIONS];   /**< Extension metrics by extension */
-   struct art* metric_names;                                    /**< Store all the metric names in ART as keys */
 } __attribute__((aligned(64)));
 
 #ifdef __cplusplus

--- a/src/libpgexporter/configuration.c
+++ b/src/libpgexporter/configuration.c
@@ -103,6 +103,8 @@ pgexporter_init_configuration(void* shm)
 
    config->metrics = -1;
    config->cache = true;
+   config->number_of_metric_names = 0;
+   memset(config->metric_names, 0, sizeof(config->metric_names));
 
    config->bridge = -1;
    config->bridge_cache_max_age = 300;

--- a/src/main.c
+++ b/src/main.c
@@ -661,23 +661,12 @@ main(int argc, char** argv)
       exit(1);
    }
 
-   /* ART for metrics */
-   if (pgexporter_art_create(&config->metric_names))
-   {
-      warnx("pgexporter: Failed to initialize metric names ART");
-   #ifdef HAVE_SYSTEMD
-      sd_notify(0, "STATUS=Failed to initialize metric names ART");
-   #endif
-      exit(1);
-   }
-
    /* Internal Metrics Collectors YAML File, not to be used with YAML/JSON  */
    if (json_path == NULL && yaml_path == NULL)
    {
 
       if (pgexporter_read_internal_yaml_metrics(config, true))
       {
-         pgexporter_art_destroy(config->metric_names);
 #ifdef HAVE_SYSTEMD
          sd_notify(0, "STATUS=Invalid core metrics");
 #endif
@@ -753,7 +742,6 @@ main(int argc, char** argv)
 
       if (pgexporter_read_metrics_configuration(shmem))
       {
-         pgexporter_art_destroy(config->metric_names);
 #ifdef HAVE_SYSTEMD
          sd_notify(0, "STATUS=Invalid metrics YAML");
 #endif
@@ -766,7 +754,6 @@ main(int argc, char** argv)
 
       if (pgexporter_read_json_metrics_configuration(shmem))
       {
-         pgexporter_art_destroy(config->metric_names);
 #ifdef HAVE_SYSTEMD
          sd_notify(0, "STATUS=Invalid metrics JSON");
 #endif
@@ -1141,7 +1128,6 @@ main(int argc, char** argv)
    pgexporter_free_pg_query_alts(config);
    pgexporter_free_extension_query_alts(config);
 
-   pgexporter_art_destroy(config->metric_names);
    pgexporter_destroy_shared_memory(shmem, shmem_size);
    pgexporter_destroy_shared_memory(prometheus_cache_shmem,
                                     prometheus_cache_shmem_size);


### PR DESCRIPTION
Since ART is a structure which grows dynamically, we use an array of fixed size to store them and temporaily create the ART while comparing names.