### PR TITLE
Add metrics for PostGIS

### DIFF
--- a/extensions/postgis.yaml
+++ b/extensions/postgis.yaml
@@ -1,0 +1,233 @@
+#
+# Copyright (C) 2025 The pgexporter community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+extension: postgis
+metrics:
+
+#
+# PostGIS core spatial extension metrics - compatible across PostgreSQL 13-17
+#
+  # Spatial table inventory - core metrics for spatial data monitoring
+  - metric: spatial_tables
+    queries:
+      - query: SELECT COUNT(*) as geometry_tables, (SELECT COUNT(*) FROM geography_columns) as geography_tables, (SELECT COUNT(*) FROM spatial_ref_sys) as srid_count;
+        version: "3.0"
+        columns:
+          - name: geometry_tables
+            type: gauge
+            description: Number of tables with geometry columns
+          - name: geography_tables
+            type: gauge
+            description: Number of tables with geography columns
+          - name: srid_count
+            type: gauge
+            description: Total number of spatial reference systems available
+
+  # SRID usage statistics - identify most commonly used coordinate systems
+  - metric: srid_usage
+    queries:
+      - query: SELECT srid, COUNT(*) as usage_count FROM geometry_columns GROUP BY srid ORDER BY usage_count DESC LIMIT 10;
+        version: "3.0"
+        columns:
+          - name: srid
+            type: label
+            description: Spatial Reference System Identifier
+          - name: usage_count
+            type: gauge
+            description: Number of geometry columns using this SRID
+
+  # Geometry column details - comprehensive spatial column information
+  - metric: geometry_columns_detail
+    queries:
+      - query: SELECT f_table_schema, f_table_name, f_geometry_column, coord_dimension, srid, type as geometry_type FROM geometry_columns ORDER BY f_table_schema, f_table_name LIMIT 50;
+        version: "3.0"
+        columns:
+          - name: f_table_schema
+            type: label
+            description: Schema name containing the spatial table
+          - name: f_table_name
+            type: label
+            description: Table name containing geometry column
+          - name: f_geometry_column
+            type: label
+            description: Name of the geometry column
+          - name: coord_dimension
+            type: gauge
+            description: Coordinate dimensions (2D, 3D, etc.)
+          - name: srid
+            type: label
+            description: Spatial Reference System ID for this column
+          - name: geometry_type
+            type: label
+            description: Geometry type (POINT, POLYGON, LINESTRING, etc.)
+
+  # Geography column details - geographic coordinate system columns
+  - metric: geography_columns_detail
+    queries:
+      - query: SELECT f_table_schema, f_table_name, f_geography_column, coord_dimension, srid, type as geography_type FROM geography_columns ORDER BY f_table_schema, f_table_name LIMIT 50;
+        version: "3.0"
+        columns:
+          - name: f_table_schema
+            type: label
+            description: Schema name containing the geographic table
+          - name: f_table_name
+            type: label
+            description: Table name containing geography column
+          - name: f_geography_column
+            type: label
+            description: Name of the geography column
+          - name: coord_dimension
+            type: gauge
+            description: Coordinate dimensions for geography
+          - name: srid
+            type: label
+            description: Spatial Reference System ID (typically 4326 for WGS84)
+          - name: geography_type
+            type: label
+            description: Geography type (POINT, POLYGON, etc.)
+
+  # Spatial index monitoring - critical for PostGIS performance
+  - metric: spatial_indexes
+    queries:
+      - query: SELECT schemaname, tablename, indexname, indexdef FROM pg_indexes WHERE indexdef LIKE '%gist%' AND (indexdef LIKE '%geometry%' OR indexdef LIKE '%geography%') ORDER BY schemaname, tablename LIMIT 25;
+        version: "3.0"
+        columns:
+          - name: schemaname
+            type: label
+            description: Schema containing the spatial index
+          - name: tablename
+            type: label
+            description: Table with spatial index
+          - name: indexname
+            type: label
+            description: Name of the spatial index
+          - name: indexdef
+            type: label
+            description: Index definition showing GIST and column details
+
+  # Spatial index count summary - performance monitoring overview
+  - metric: spatial_index_summary
+    queries:
+      - query: SELECT COUNT(*) as total_spatial_indexes, COUNT(*) FILTER (WHERE indexdef LIKE '%geometry%') as geometry_indexes, COUNT(*) FILTER (WHERE indexdef LIKE '%geography%') as geography_indexes FROM pg_indexes WHERE indexdef LIKE '%gist%' AND (indexdef LIKE '%geometry%' OR indexdef LIKE '%geography%');
+        version: "3.0"
+        columns:
+          - name: total_spatial_indexes
+            type: gauge
+            description: Total number of spatial GIST indexes
+          - name: geometry_indexes
+            type: gauge
+            description: Number of GIST indexes on geometry columns
+          - name: geography_indexes
+            type: gauge
+            description: Number of GIST indexes on geography columns
+
+  # Geometry type distribution - understanding spatial data variety
+  - metric: geometry_type_stats
+    queries:
+      - query: SELECT type as geometry_type, COUNT(*) as column_count FROM geometry_columns GROUP BY type ORDER BY column_count DESC;
+        version: "3.0"
+        columns:
+          - name: geometry_type
+            type: label
+            description: Type of geometry (POINT, POLYGON, LINESTRING, etc.)
+          - name: column_count
+            type: gauge
+            description: Number of columns with this geometry type
+
+  # Coordinate dimension analysis - 2D vs 3D spatial data
+  - metric: coordinate_dimensions
+    queries:
+      - query: SELECT coord_dimension, COUNT(*) as column_count FROM geometry_columns GROUP BY coord_dimension ORDER BY coord_dimension;
+        version: "3.0"
+        columns:
+          - name: coord_dimension
+            type: gauge
+            description: Number of coordinate dimensions
+          - name: column_count
+            type: gauge
+            description: Number of columns with this dimension count
+
+  # Schema-level spatial distribution - identify spatial data hotspots
+  - metric: schema_spatial_stats
+    queries:
+      - query: SELECT f_table_schema, COUNT(*) as geometry_columns, COUNT(DISTINCT f_table_name) as spatial_tables, COUNT(DISTINCT srid) as unique_srids FROM geometry_columns GROUP BY f_table_schema ORDER BY geometry_columns DESC;
+        version: "3.0"
+        columns:
+          - name: f_table_schema
+            type: label
+            description: Database schema name
+          - name: geometry_columns
+            type: gauge
+            description: Number of geometry columns in this schema
+          - name: spatial_tables
+            type: gauge
+            description: Number of tables with spatial data in schema
+          - name: unique_srids
+            type: gauge
+            description: Number of different SRIDs used in schema
+
+  # Common SRID reference - identify standard coordinate systems in use
+  - metric: common_srids
+    queries:
+      - query: SELECT srid, auth_name, auth_srid, CASE WHEN srid = 4326 THEN 'WGS84' WHEN srid = 3857 THEN 'Web Mercator' WHEN srid = 4269 THEN 'NAD83' ELSE 'Other' END as srid_type FROM spatial_ref_sys WHERE srid IN (SELECT DISTINCT srid FROM geometry_columns) ORDER BY srid;
+        version: "3.0"
+        columns:
+          - name: srid
+            type: label
+            description: Spatial Reference System Identifier
+          - name: auth_name
+            type: label
+            description: Authority name (EPSG, etc.)
+          - name: auth_srid
+            type: label
+            description: Authority SRID code
+          - name: srid_type
+            type: label
+            description: Common name for well-known SRIDs
+
+  # Spatial data size analysis - storage utilization monitoring
+  - metric: spatial_storage_stats
+    queries:
+      - query: SELECT gc.f_table_schema, gc.f_table_name, gc.f_geometry_column, gc.type as geometry_type, pg_size_pretty(pg_total_relation_size(quote_ident(gc.f_table_schema)||'.'||quote_ident(gc.f_table_name))) as table_size FROM geometry_columns gc ORDER BY pg_total_relation_size(quote_ident(gc.f_table_schema)||'.'||quote_ident(gc.f_table_name)) DESC LIMIT 10;
+        version: "3.0"
+        columns:
+          - name: f_table_schema
+            type: label
+            description: Schema name
+          - name: f_table_name
+            type: label
+            description: Table name with spatial data
+          - name: f_geometry_column
+            type: label
+            description: Geometry column name
+          - name: geometry_type
+            type: label
+            description: Type of spatial data stored
+          - name: table_size
+            type: label
+            description: Table size including indexes

--- a/extensions/postgis_raster.yaml
+++ b/extensions/postgis_raster.yaml
@@ -1,0 +1,246 @@
+#
+# Copyright (C) 2025 The pgexporter community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+extension: postgis_raster
+metrics:
+
+#
+# PostGIS raster extension metrics - compatible across PostgreSQL 13-17
+#
+
+  # Raster table inventory - basic count of raster tables in the system
+  - metric: raster_table_count
+    queries:
+      - query: SELECT COUNT(*) as raster_table_count FROM raster_columns;
+        version: "3.0"
+        columns:
+          - name: raster_table_count
+            type: gauge
+            description: Total number of tables containing raster columns
+
+  # Raster columns basic information - core raster metadata
+  - metric: raster_columns_info
+    queries:
+      - query: SELECT r_table_schema, r_table_name, r_raster_column, srid, num_bands FROM raster_columns ORDER BY r_table_schema, r_table_name;
+        version: "3.0"
+        columns:
+          - name: r_table_schema
+            type: label
+            description: Schema containing the raster table
+          - name: r_table_name
+            type: label
+            description: Table name containing raster column
+          - name: r_raster_column
+            type: label
+            description: Name of the raster column
+          - name: srid
+            type: label
+            description: Spatial Reference System ID for the raster
+          - name: num_bands
+            type: gauge
+            description: Number of bands in the raster
+
+  # SRID distribution - spatial reference systems used by rasters
+  - metric: raster_srid_distribution
+    queries:
+      - query: SELECT srid, COUNT(*) as raster_count FROM raster_columns GROUP BY srid ORDER BY raster_count DESC;
+        version: "3.0"
+        columns:
+          - name: srid
+            type: label
+            description: Spatial Reference System ID
+          - name: raster_count
+            type: gauge
+            description: Number of raster tables using this SRID
+
+  # Band count statistics - raster complexity analysis
+  - metric: raster_band_stats
+    queries:
+      - query: SELECT num_bands, COUNT(*) as table_count FROM raster_columns GROUP BY num_bands ORDER BY num_bands;
+        version: "3.0"
+        columns:
+          - name: num_bands
+            type: gauge
+            description: Number of bands in raster
+          - name: table_count
+            type: gauge
+            description: Number of tables with this band count
+
+  # Pixel type analysis - data type distribution
+  - metric: raster_pixel_types
+    queries:
+      - query: SELECT unnest(pixel_types) as pixel_type, COUNT(*) as usage_count FROM raster_columns GROUP BY unnest(pixel_types) ORDER BY usage_count DESC;
+        version: "3.0"
+        columns:
+          - name: pixel_type
+            type: label
+            description: Pixel data type (8BUI, 16BSI, 32BF, etc.)
+          - name: usage_count
+            type: gauge
+            description: Number of raster columns using this pixel type
+
+  # NoData value statistics - missing data analysis
+  - metric: raster_nodata_stats
+    queries:
+      - query: SELECT unnest(nodata_values) as nodata_value, COUNT(*) as usage_count FROM raster_columns WHERE nodata_values IS NOT NULL GROUP BY unnest(nodata_values) ORDER BY usage_count DESC;
+        version: "3.0"
+        columns:
+          - name: nodata_value
+            type: gauge
+            description: NoData value used to represent missing data
+          - name: usage_count
+            type: gauge
+            description: Number of raster columns using this NoData value
+
+  # Raster overview count - pyramid/overview monitoring
+  - metric: raster_overview_count
+    queries:
+      - query: SELECT COUNT(*) as overview_count FROM raster_overviews;
+        version: "3.0"
+        columns:
+          - name: overview_count
+            type: gauge
+            description: Total number of raster overviews/pyramids defined
+
+  # Overview factor distribution - pyramid detail analysis
+  - metric: raster_overview_factors
+    queries:
+      - query: SELECT overview_factor, COUNT(*) as overview_count FROM raster_overviews GROUP BY overview_factor ORDER BY overview_factor;
+        version: "3.0"
+        columns:
+          - name: overview_factor
+            type: gauge
+            description: Overview reduction factor (2, 4, 8, etc.)
+          - name: overview_count
+            type: gauge
+            description: Number of overviews with this factor
+
+  # Storage type distribution - in-database vs out-of-database analysis
+  - metric: raster_storage_types
+    queries:
+      - query: SELECT CASE WHEN out_db THEN 'out-of-database' ELSE 'in-database' END as storage_type, COUNT(*) as table_count FROM raster_columns GROUP BY out_db ORDER BY table_count DESC;
+        version: "3.0"
+        columns:
+          - name: storage_type
+            type: label
+            description: Raster storage location (in-database or out-of-database)
+          - name: table_count
+            type: gauge
+            description: Number of raster tables using this storage type
+
+  # Raster alignment and blocking constraints - data organization analysis
+  - metric: raster_constraints
+    queries:
+      - query: SELECT same_alignment, regular_blocking, COUNT(*) as table_count FROM raster_columns GROUP BY same_alignment, regular_blocking ORDER BY table_count DESC;
+        version: "3.0"
+        columns:
+          - name: same_alignment
+            type: gauge
+            description: Whether rasters share same alignment (1=yes, 0=no)
+          - name: regular_blocking
+            type: gauge
+            description: Whether rasters use regular blocking (1=yes, 0=no)
+          - name: table_count
+            type: gauge
+            description: Number of tables with these constraint settings
+
+  # Schema-level raster distribution - organizational analysis
+  - metric: raster_schema_distribution
+    queries:
+      - query: SELECT r_table_schema, COUNT(*) as raster_table_count, COUNT(DISTINCT srid) as unique_srids, AVG(num_bands) as avg_bands FROM raster_columns GROUP BY r_table_schema ORDER BY raster_table_count DESC;
+        version: "3.0"
+        columns:
+          - name: r_table_schema
+            type: label
+            description: Database schema name
+          - name: raster_table_count
+            type: gauge
+            description: Number of raster tables in this schema
+          - name: unique_srids
+            type: gauge
+            description: Number of different SRIDs used in schema
+          - name: avg_bands
+            type: gauge
+            description: Average number of bands per raster in schema
+
+  # System-wide raster aggregates - overall statistics
+  - metric: raster_system_stats
+    queries:
+      - query: SELECT COUNT(*) as total_raster_tables, COUNT(DISTINCT srid) as unique_srids, AVG(num_bands) as avg_bands_per_table, COUNT(DISTINCT r_table_schema) as schemas_with_rasters, COUNT(*) FILTER (WHERE NOT out_db) as in_database_tables, COUNT(*) FILTER (WHERE same_alignment) as aligned_tables FROM raster_columns;
+        version: "3.0"
+        columns:
+          - name: total_raster_tables
+            type: gauge
+            description: Total number of raster tables in system
+          - name: unique_srids
+            type: gauge
+            description: Number of unique spatial reference systems used
+          - name: avg_bands_per_table
+            type: gauge
+            description: Average number of bands across all raster tables
+          - name: schemas_with_rasters
+            type: gauge
+            description: Number of schemas containing raster data
+          - name: in_database_tables
+            type: gauge
+            description: Number of rasters stored in-database
+          - name: aligned_tables
+            type: gauge
+            description: Number of rasters with same alignment constraint
+
+  # Raster scale/resolution analysis - spatial resolution monitoring
+  - metric: raster_scale_stats
+    queries:
+      - query: SELECT scale_x, scale_y, COUNT(*) as table_count FROM raster_columns WHERE scale_x IS NOT NULL AND scale_y IS NOT NULL GROUP BY scale_x, scale_y ORDER BY table_count DESC;
+        version: "3.0"
+        columns:
+          - name: scale_x
+            type: gauge
+            description: Pixel width in spatial units
+          - name: scale_y
+            type: gauge
+            description: Pixel height in spatial units
+          - name: table_count
+            type: gauge
+            description: Number of tables with this scale/resolution
+
+  # Block size distribution - tiling configuration analysis
+  - metric: raster_block_sizes
+    queries:
+      - query: SELECT blocksize_x, blocksize_y, COUNT(*) as table_count FROM raster_columns WHERE blocksize_x IS NOT NULL AND blocksize_y IS NOT NULL GROUP BY blocksize_x, blocksize_y ORDER BY table_count DESC;
+        version: "3.0"
+        columns:
+          - name: blocksize_x
+            type: gauge
+            description: Raster tile width in pixels
+          - name: blocksize_y
+            type: gauge
+            description: Raster tile height in pixels
+          - name: table_count
+            type: gauge
+            description: Number of tables using this block size configuration

--- a/extensions/postgis_topology.yaml
+++ b/extensions/postgis_topology.yaml
@@ -1,0 +1,254 @@
+#
+# Copyright (C) 2025 The pgexporter community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+extension: postgis_topology
+metrics:
+
+#
+# PostGIS topology extension metrics - compatible across PostgreSQL 13-17
+#
+
+  # Topology inventory - basic count and details of defined topologies
+  - metric: topology_inventory
+    queries:
+      - query: SELECT COUNT(*) as topology_count FROM topology.topology;
+        version: "3.0"
+        columns:
+          - name: topology_count
+            type: gauge
+            description: Total number of topologies defined in the system
+
+  # Topology details - comprehensive information about each topology
+  - metric: topology_details
+    queries:
+      - query: SELECT id, name, srid, precision, hasz FROM topology.topology ORDER BY id;
+        version: "3.0"
+        columns:
+          - name: id
+            type: label
+            description: Unique topology identifier
+          - name: name
+            type: label
+            description: Topology name
+          - name: srid
+            type: label
+            description: Spatial Reference System ID for the topology
+          - name: precision
+            type: gauge
+            description: Topology coordinate precision
+          - name: hasz
+            type: gauge
+            description: Whether topology supports Z coordinates (1=yes, 0=no)
+
+  # Node counts per topology - monitoring topology node elements
+  - metric: topology_node_counts
+    queries:
+      - query: SELECT t.name as topology_name, t.srid, COALESCE(pst.n_live_tup, 0) as live_node_count, COALESCE(pst.n_tup_ins, 0) as inserted_nodes, COALESCE(pst.n_tup_upd, 0) as updated_nodes, COALESCE(pst.n_tup_del, 0) as deleted_nodes FROM topology.topology t LEFT JOIN pg_stat_user_tables pst ON pst.schemaname = t.name AND pst.relname = 'node' ORDER BY t.id;
+        version: "3.0"
+        columns:
+          - name: topology_name
+            type: label
+            description: Topology name
+          - name: srid
+            type: label
+            description: Spatial Reference System ID
+          - name: live_node_count
+            type: gauge
+            description: Current number of live nodes in topology
+          - name: inserted_nodes
+            type: gauge
+            description: Total number of nodes inserted since statistics reset
+          - name: updated_nodes
+            type: gauge
+            description: Total number of node updates since statistics reset
+          - name: deleted_nodes
+            type: gauge
+            description: Total number of nodes deleted since statistics reset
+
+  # Edge counts per topology - monitoring topology edge elements
+  - metric: topology_edge_counts
+    queries:
+      - query: SELECT t.name as topology_name, t.srid, COALESCE(pst.n_live_tup, 0) as live_edge_count, COALESCE(pst.n_tup_ins, 0) as inserted_edges FROM topology.topology t LEFT JOIN pg_stat_user_tables pst ON pst.schemaname = t.name AND pst.relname = 'edge_data' ORDER BY t.id;
+        version: "3.0"
+        columns:
+          - name: topology_name
+            type: label
+            description: Topology name
+          - name: srid
+            type: label
+            description: Spatial Reference System ID
+          - name: live_edge_count
+            type: gauge
+            description: Current number of live edges in topology
+          - name: inserted_edges
+            type: gauge
+            description: Total number of edges inserted since statistics reset
+
+  # Face counts per topology - monitoring topology face elements
+  - metric: topology_face_counts
+    queries:
+      - query: SELECT t.name as topology_name, t.srid, COALESCE(pst.n_live_tup, 0) as live_face_count, COALESCE(pst.n_tup_ins, 0) as inserted_faces FROM topology.topology t LEFT JOIN pg_stat_user_tables pst ON pst.schemaname = t.name AND pst.relname = 'face' ORDER BY t.id;
+        version: "3.0"
+        columns:
+          - name: topology_name
+            type: label
+            description: Topology name
+          - name: srid
+            type: label
+            description: Spatial Reference System ID
+          - name: live_face_count
+            type: gauge
+            description: Current number of live faces in topology
+          - name: inserted_faces
+            type: gauge
+            description: Total number of faces inserted since statistics reset
+
+  # Combined topology primitives - all topology elements in single query
+  - metric: topology_primitives_summary
+    queries:
+      - query: SELECT t.name as topology_name, t.srid, t.precision, COALESCE(nodes.n_live_tup, 0) as node_count, COALESCE(edges.n_live_tup, 0) as edge_count, COALESCE(faces.n_live_tup, 0) as face_count, COALESCE(nodes.n_live_tup, 0) + COALESCE(edges.n_live_tup, 0) + COALESCE(faces.n_live_tup, 0) as total_primitives FROM topology.topology t LEFT JOIN pg_stat_user_tables nodes ON nodes.schemaname = t.name AND nodes.relname = 'node' LEFT JOIN pg_stat_user_tables edges ON edges.schemaname = t.name AND edges.relname = 'edge_data' LEFT JOIN pg_stat_user_tables faces ON faces.schemaname = t.name AND faces.relname = 'face' ORDER BY t.id;
+        version: "3.0"
+        columns:
+          - name: topology_name
+            type: label
+            description: Topology name
+          - name: srid
+            type: label
+            description: Spatial Reference System ID
+          - name: precision
+            type: gauge
+            description: Topology coordinate precision
+          - name: node_count
+            type: gauge
+            description: Number of nodes in topology
+          - name: edge_count
+            type: gauge
+            description: Number of edges in topology
+          - name: face_count
+            type: gauge
+            description: Number of faces in topology
+          - name: total_primitives
+            type: gauge
+            description: Total number of topology primitives (nodes + edges + faces)
+
+  # System-wide topology statistics - aggregated metrics across all topologies
+  - metric: topology_system_stats
+    queries:
+      - query: SELECT COUNT(*) as total_topologies, COUNT(DISTINCT t.srid) as unique_srids, AVG(t.precision) as avg_precision, SUM(COALESCE(nodes.n_live_tup, 0)) as total_nodes, SUM(COALESCE(edges.n_live_tup, 0)) as total_edges, SUM(COALESCE(faces.n_live_tup, 0)) as total_faces FROM topology.topology t LEFT JOIN pg_stat_user_tables nodes ON nodes.schemaname = t.name AND nodes.relname = 'node' LEFT JOIN pg_stat_user_tables edges ON edges.schemaname = t.name AND edges.relname = 'edge_data' LEFT JOIN pg_stat_user_tables faces ON faces.schemaname = t.name AND faces.relname = 'face';
+        version: "3.0"
+        columns:
+          - name: total_topologies
+            type: gauge
+            description: Total number of topologies in the system
+          - name: unique_srids
+            type: gauge
+            description: Number of unique spatial reference systems used
+          - name: avg_precision
+            type: gauge
+            description: Average coordinate precision across all topologies
+          - name: total_nodes
+            type: gauge
+            description: Total number of nodes across all topologies
+          - name: total_edges
+            type: gauge
+            description: Total number of edges across all topologies
+          - name: total_faces
+            type: gauge
+            description: Total number of faces across all topologies
+
+  # SRID distribution - spatial reference system usage analysis
+  - metric: topology_srid_distribution
+    queries:
+      - query: SELECT t.srid, COUNT(*) as topology_count, SUM(COALESCE(nodes.n_live_tup, 0)) as total_nodes_for_srid, SUM(COALESCE(edges.n_live_tup, 0)) as total_edges_for_srid FROM topology.topology t LEFT JOIN pg_stat_user_tables nodes ON nodes.schemaname = t.name AND nodes.relname = 'node' LEFT JOIN pg_stat_user_tables edges ON edges.schemaname = t.name AND edges.relname = 'edge_data' GROUP BY t.srid ORDER BY topology_count DESC;
+        version: "3.0"
+        columns:
+          - name: srid
+            type: label
+            description: Spatial Reference System ID
+          - name: topology_count
+            type: gauge
+            description: Number of topologies using this SRID
+          - name: total_nodes_for_srid
+            type: gauge
+            description: Total nodes across all topologies using this SRID
+          - name: total_edges_for_srid
+            type: gauge
+            description: Total edges across all topologies using this SRID
+
+  # Topology health and activity status - operational monitoring
+  - metric: topology_health
+    queries:
+      - query: SELECT t.name as topology_name, t.srid, CASE WHEN nodes.relname IS NOT NULL THEN 'YES' ELSE 'NO' END as has_node_table, CASE WHEN edges.relname IS NOT NULL THEN 'YES' ELSE 'NO' END as has_edge_table, CASE WHEN faces.relname IS NOT NULL THEN 'YES' ELSE 'NO' END as has_face_table, COALESCE(nodes.n_live_tup, 0) as current_node_count, COALESCE(edges.n_live_tup, 0) as current_edge_count, CASE WHEN COALESCE(nodes.n_live_tup, 0) + COALESCE(edges.n_live_tup, 0) = 0 THEN 'EMPTY' WHEN COALESCE(nodes.n_live_tup, 0) > 0 AND COALESCE(edges.n_live_tup, 0) = 0 THEN 'NODES_ONLY' WHEN COALESCE(nodes.n_live_tup, 0) > 0 AND COALESCE(edges.n_live_tup, 0) > 0 THEN 'ACTIVE' ELSE 'UNKNOWN' END as topology_status FROM topology.topology t LEFT JOIN pg_stat_user_tables nodes ON nodes.schemaname = t.name AND nodes.relname = 'node' LEFT JOIN pg_stat_user_tables edges ON edges.schemaname = t.name AND edges.relname = 'edge_data' LEFT JOIN pg_stat_user_tables faces ON faces.schemaname = t.name AND faces.relname = 'face' ORDER BY t.id;
+        version: "3.0"
+        columns:
+          - name: topology_name
+            type: label
+            description: Topology name
+          - name: srid
+            type: label
+            description: Spatial Reference System ID
+          - name: has_node_table
+            type: label
+            description: Whether topology has a node table (YES/NO)
+          - name: has_edge_table
+            type: label
+            description: Whether topology has an edge table (YES/NO)
+          - name: has_face_table
+            type: label
+            description: Whether topology has a face table (YES/NO)
+          - name: current_node_count
+            type: gauge
+            description: Current number of nodes in topology
+          - name: current_edge_count
+            type: gauge
+            description: Current number of edges in topology
+          - name: topology_status
+            type: label
+            description: Topology activity status (EMPTY/NODES_ONLY/ACTIVE/UNKNOWN)
+
+  # Topology storage utilization - disk usage monitoring
+  - metric: topology_storage_stats
+    queries:
+      - query: SELECT t.name as topology_name, pg_size_pretty(COALESCE((SELECT pg_total_relation_size(t.name||'.node')), 0) + COALESCE((SELECT pg_total_relation_size(t.name||'.edge_data')), 0) + COALESCE((SELECT pg_total_relation_size(t.name||'.face')), 0)) as total_topology_size, pg_size_pretty(COALESCE((SELECT pg_total_relation_size(t.name||'.node')), 0)) as node_table_size, pg_size_pretty(COALESCE((SELECT pg_total_relation_size(t.name||'.edge_data')), 0)) as edge_table_size, pg_size_pretty(COALESCE((SELECT pg_total_relation_size(t.name||'.face')), 0)) as face_table_size FROM topology.topology t ORDER BY t.id;
+        version: "3.0"
+        columns:
+          - name: topology_name
+            type: label
+            description: Topology name
+          - name: total_topology_size
+            type: label
+            description: Total disk space used by topology (human readable)
+          - name: node_table_size
+            type: label
+            description: Disk space used by node table (human readable)
+          - name: edge_table_size
+            type: label
+            description: Disk space used by edge table (human readable)
+          - name: face_table_size
+            type: label
+            description: Disk space used by face table (human readable)


### PR DESCRIPTION
Addressing #282, Added metrics for PostGIS ecosystem (the main extensions), these include:

1. PostGIS - Gemoetry/geograbhy table counts, SRID distribution, information about coordination system usage, spatial indexes etc.- [Link](https://github.com/bassamadnan/pg_ext_tracker/blob/6c05031d7f450e39d18f1ed42cd283846decf7cf/postgis/verify.sh) to test cases where I verify that these work.
2. `postgis_topology` - the extension itself builds on top of the core `postgis`, which now includes advanced topology primitives (node, edge and face counts per topology), SRID distribution for those and their status and storage utilization. [Link](postgis_topology/topology_analyze_tests) to tests. Had to verify that these work since they use `pg_stat_user_tables`  so I had personally forced an `ANALYZE` trigger.
3. `postgis_raster` - The extension is used for  raste/image data (satellite, elevation, weather etc), the metrics are basic tbale counts, pixle type distribution, pyramid monitoring for performance checks.

There are 3-4 more extensions of `postgis` itself like `postgis_sanetizer` etc, but I think these are the ones used the most. PostGIS 3.0 is default version of pg13 and to this day PostGIS operates on 3.x.x, I had checked schema changes accross the minor versions, abit of source code on their [official](https://trac.osgeo.org/postgis/) repository, the extension seems fairly stable and hasn't had much of change for whatever purposes `pgexporter` is concerned.