### PR TITLE
[#288] Replace strncpy with snprintf to ensure null termination.

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -446,7 +446,7 @@ main(int argc, char** argv)
 
          config->log_type = PGEXPORTER_LOGGING_TYPE_FILE;
          memset(&config->log_path[0], 0, MISC_LENGTH);
-         memcpy(&config->log_path[0], logfile, MIN(MISC_LENGTH - 1, strlen(logfile)));
+         snprintf(&config->log_path[0], MISC_LENGTH, "%s", logfile);
       }
 
       if (pgexporter_start_logging())
@@ -477,7 +477,7 @@ main(int argc, char** argv)
 
             config->log_type = PGEXPORTER_LOGGING_TYPE_FILE;
             memset(&config->log_path[0], 0, MISC_LENGTH);
-            memcpy(&config->log_path[0], logfile, MIN(MISC_LENGTH - 1, strlen(logfile)));
+            snprintf(&config->log_path[0], MISC_LENGTH, "%s", logfile);
          }
 
          if (pgexporter_start_logging())
@@ -1191,16 +1191,13 @@ get_config_key_result(char* config_key, struct json* j, uintptr_t* r, int32_t ou
    if (part_count == 1)
    {
       // Single key: config_key
-      strncpy(key, parts[0], MISC_LENGTH - 1);
-      key[MISC_LENGTH - 1] = '\0';
+      snprintf(key, MISC_LENGTH, "%s", parts[0]);
    }
    else if (part_count == 2)
    {
       // Two parts: section.key
-      strncpy(section, parts[0], MISC_LENGTH - 1);
-      section[MISC_LENGTH - 1] = '\0';
-      strncpy(key, parts[1], MISC_LENGTH - 1);
-      key[MISC_LENGTH - 1] = '\0';
+      snprintf(section, MISC_LENGTH, "%s", parts[0]);
+      snprintf(key, MISC_LENGTH, "%s", parts[1]);
 
       // Treat "pgexporter" as the main section (empty)
       if (!strcasecmp(section, PGEXPORTER_MAIN_INI_SECTION))
@@ -1211,12 +1208,9 @@ get_config_key_result(char* config_key, struct json* j, uintptr_t* r, int32_t ou
    else if (part_count == 3)
    {
       // Three parts: section.context.key
-      strncpy(section, parts[0], MISC_LENGTH - 1);
-      section[MISC_LENGTH - 1] = '\0';
-      strncpy(context, parts[1], MISC_LENGTH - 1);
-      context[MISC_LENGTH - 1] = '\0';
-      strncpy(key, parts[2], MISC_LENGTH - 1);
-      key[MISC_LENGTH - 1] = '\0';
+      snprintf(section, MISC_LENGTH, "%s", parts[0]);
+      snprintf(context, MISC_LENGTH, "%s", parts[1]);
+      snprintf(key, MISC_LENGTH, "%s", parts[2]);
    }
 
    response = (struct json*)pgexporter_json_get(j, MANAGEMENT_CATEGORY_RESPONSE);

--- a/src/libpgexporter/configuration.c
+++ b/src/libpgexporter/configuration.c
@@ -214,7 +214,7 @@ pgexporter_read_configuration(void* shm, char* filename)
                   }
 
                   memset(&srv, 0, sizeof(struct server));
-                  memcpy(&srv.name, &section, strlen(section));
+                  snprintf(&srv.name[0], MISC_LENGTH, "%s", section);
                   srv.fd = -1;
                   srv.extension = true;
                   srv.state = SERVER_UNKNOWN;
@@ -1224,8 +1224,8 @@ pgexporter_read_users_configuration(void* shm, char* filename)
             if (strlen(username) < MAX_USERNAME_LENGTH &&
                 strlen(password) < MAX_PASSWORD_LENGTH)
             {
-               memcpy(&config->users[index].username, username, strlen(username));
-               memcpy(&config->users[index].password, password, strlen(password));
+               snprintf(&config->users[index].username[0], MAX_USERNAME_LENGTH, "%s", username);
+               snprintf(&config->users[index].password[0], MAX_PASSWORD_LENGTH, "%s", password);
             }
             else
             {
@@ -1401,8 +1401,8 @@ pgexporter_read_admins_configuration(void* shm, char* filename)
             if (strlen(username) < MAX_USERNAME_LENGTH &&
                 strlen(password) < MAX_PASSWORD_LENGTH)
             {
-               memcpy(&config->admins[index].username, username, strlen(username));
-               memcpy(&config->admins[index].password, password, strlen(password));
+               snprintf(&config->admins[index].username[0], MAX_USERNAME_LENGTH, "%s", username);
+               snprintf(&config->admins[index].password[0], MAX_PASSWORD_LENGTH, "%s", password);
             }
             else
             {
@@ -2499,8 +2499,8 @@ extract_key_value(char* str, char** key, char** value)
       k = calloc(1, strlen(left) + 1);
       v = calloc(1, strlen(right) + 1);
 
-      memcpy(k, left, strlen(left));
-      memcpy(v, right, strlen(right));
+      snprintf(k, strlen(left) + 1, "%s", left);
+      snprintf(v, strlen(right) + 1, "%s", right);
 
       *key = k;
       *value = v;
@@ -3173,7 +3173,7 @@ as_endpoints(char* str, struct configuration* config, bool reload)
 
          if (!found)
          {
-            strncpy(config->endpoints[idx].host, host, MISC_LENGTH);
+            snprintf(config->endpoints[idx].host, MISC_LENGTH, "%s", host);
             config->endpoints[idx].port = atoi(port);
 
             pgexporter_log_trace("Bridge Endpoint %d | Host: %s, Port: %s", idx, host, port);

--- a/src/libpgexporter/extension.c
+++ b/src/libpgexporter/extension.c
@@ -53,8 +53,7 @@ pgexporter_setup_extensions_path(struct configuration* config, const char* argv0
    {
       /* Development build - use build/extensions directory */
       char temp_path[MAX_PATH];
-      strncpy(temp_path, local_bin_path, MAX_PATH - 1);
-      temp_path[MAX_PATH - 1] = '\0';
+      snprintf(temp_path, MAX_PATH, "%s", local_bin_path);
 
       /* Remove the executable name to get directory */
       char* last_slash = strrchr(temp_path, '/');

--- a/src/libpgexporter/network.c
+++ b/src/libpgexporter/network.c
@@ -182,7 +182,7 @@ pgexporter_bind_unix_socket(const char* directory, const char* file, int* fd)
    memset(&buf, 0, sizeof(buf));
    snprintf(&buf[0], sizeof(buf), "%s/%s", directory, file);
 
-   strncpy(addr.sun_path, &buf[0], sizeof(addr.sun_path) - 1);
+   snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", &buf[0]);
    unlink(&buf[0]);
 
    if (bind(*fd, (struct sockaddr*)&addr, sizeof(addr)) == -1)
@@ -242,7 +242,7 @@ pgexporter_connect(const char* hostname, int port, int* fd)
    config = (struct configuration*)shmem;
 
    memset(&sport, 0, sizeof(sport));
-   sprintf(&sport[0], "%d", port);
+   snprintf(&sport[0], sizeof(sport), "%d", port);
 
    /* Connect to server */
    memset(&hints, 0, sizeof hints);
@@ -377,7 +377,7 @@ pgexporter_connect_unix_socket(const char* directory, const char* file, int* fd)
    memset(&buf, 0, sizeof(buf));
    snprintf(&buf[0], sizeof(buf), "%s/%s", directory, file);
 
-   strncpy(addr.sun_path, &buf[0], sizeof(addr.sun_path) - 1);
+   snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", &buf[0]);
 
    if (connect(*fd, (struct sockaddr*)&addr, sizeof(addr)) == -1)
    {
@@ -577,7 +577,7 @@ bind_host(const char* hostname, int port, int** fds, int* length)
 
    sport = malloc(6);
    memset(sport, 0, 6);
-   sprintf(sport, "%d", port);
+   snprintf(sport, 6, "%d", port);
 
    /* Find all SOCK_STREAM addresses */
    memset(&hints, 0, sizeof hints);

--- a/src/libpgexporter/prometheus.c
+++ b/src/libpgexporter/prometheus.c
@@ -1835,7 +1835,7 @@ custom_metrics(SSL* client_ssl, int client_fd)
                temp->sort_type = prom->sort_type;
             }
 
-            strncpy(temp->database, database, DB_NAME_LENGTH - 1);
+            snprintf(temp->database, DB_NAME_LENGTH, "%s", database);
 
             free(names);
             names = NULL;
@@ -1930,7 +1930,7 @@ parse_list(char* list_str, char** strs, int* n_strs)
     * then this starts from `c1`, and goes for `len - 2`, so till `cn`, so the
     * `data` string becomes `c1,c2,c3,...,cn`
     */
-   strncpy(data, list_str + 1, len - 2);
+   snprintf(data, len - 1, "%.*s", (int)(len - 2), list_str + 1);
 
    p = strtok(data, ",");
    while (p)
@@ -2556,7 +2556,7 @@ send_chunk(SSL* client_ssl, int client_fd, char* data)
 
    memset(m, 0, 20);
 
-   sprintf(m, "%zX\r\n", strlen(data));
+   snprintf(m, 20, "%zX\r\n", strlen(data));
 
    m = pgexporter_vappend(m, 2,
                           data,

--- a/src/libpgexporter/queries.c
+++ b/src/libpgexporter/queries.c
@@ -697,13 +697,13 @@ query_execute(int server, char* qs, char* tag, int columns, char* names[], struc
    memset(q, 0, sizeof(struct query));
 
    q->number_of_columns = cols;
-   memcpy(&q->tag[0], tag, strlen(tag));
+   snprintf(&q->tag[0], MISC_LENGTH, "%s", tag);
 
    for (int i = 0; i < cols; i++)
    {
       if (names != NULL)
       {
-         memcpy(&q->names[i][0], names[i], strlen(names[i]));
+         snprintf(&q->names[i][0], MISC_LENGTH, "%s", names[i]);
       }
       else
       {
@@ -712,7 +712,7 @@ query_execute(int server, char* qs, char* tag, int columns, char* names[], struc
             goto error;
          }
 
-         memcpy(&q->names[i][0], name, strlen(name));
+         snprintf(&q->names[i][0], MISC_LENGTH, "%s", name);
 
          free(name);
          name = NULL;
@@ -947,9 +947,8 @@ pgexporter_detect_extensions(int server)
 
       extension_idx = config->servers[server].number_of_extensions;
 
-      strncpy(config->servers[server].extensions[extension_idx].name,
-              pgexporter_get_column(0, current),
-              MISC_LENGTH - 1);
+      snprintf(config->servers[server].extensions[extension_idx].name,
+               MISC_LENGTH, "%s", pgexporter_get_column(0, current));
       config->servers[server].extensions[extension_idx].name[MISC_LENGTH - 1] = '\0';
 
       if (pgexporter_parse_extension_version(pgexporter_get_column(1, current),
@@ -971,9 +970,8 @@ pgexporter_detect_extensions(int server)
                               config->servers[server].extensions[extension_idx].enabled ? "ENABLED" : "DISABLED");
       }
 
-      strncpy(config->servers[server].extensions[extension_idx].comment,
-              pgexporter_get_column(2, current),
-              MISC_LENGTH - 1);
+      snprintf(config->servers[server].extensions[extension_idx].comment,
+               MISC_LENGTH, "%s", pgexporter_get_column(2, current));
       config->servers[server].extensions[extension_idx].comment[MISC_LENGTH - 1] = '\0';
 
       config->servers[server].number_of_extensions++;
@@ -1033,9 +1031,8 @@ pgexporter_detect_databases(int server)
 
       db_idx = config->servers[server].number_of_databases;
 
-      strncpy((char*) &config->servers[server].databases[db_idx],
-              pgexporter_get_column(0, current), DB_NAME_LENGTH - 1);
-      config->servers[server].databases[db_idx][DB_NAME_LENGTH - 1] = '\0';
+      snprintf((char*) &config->servers[server].databases[db_idx],
+               DB_NAME_LENGTH, "%s", pgexporter_get_column(0, current));
 
       config->servers[server].number_of_databases++;
       current = current->next;

--- a/src/main.c
+++ b/src/main.c
@@ -511,7 +511,7 @@ main(int argc, char** argv)
 
             if (!found)
             {
-               strncpy(collectors[collector_idx++], collector, MAX_COLLECTOR_LENGTH - 1);
+               snprintf(collectors[collector_idx++], MAX_COLLECTOR_LENGTH, "%s", collector);
             }
          }
       }
@@ -657,7 +657,7 @@ main(int argc, char** argv)
       }
       configuration_path = "/etc/pgexporter/pgexporter.conf";
    }
-   memcpy(&config->configuration_path[0], configuration_path, MIN(strlen(configuration_path), MAX_PATH - 1));
+   snprintf(&config->configuration_path[0], MAX_PATH, "%s", configuration_path);
 
    /* Users Configuration File */
    if (users_path != NULL)
@@ -687,7 +687,7 @@ main(int argc, char** argv)
 #endif
          exit(1);
       }
-      memcpy(&config->users_path[0], users_path, MIN(strlen(users_path), MAX_PATH - 1));
+      snprintf(&config->users_path[0], MAX_PATH, "%s", users_path);
    }
    else
    {
@@ -695,7 +695,7 @@ main(int argc, char** argv)
       ret = pgexporter_read_users_configuration(shmem, users_path);
       if (ret == 0)
       {
-         memcpy(&config->users_path[0], users_path, MIN(strlen(users_path), MAX_PATH - 1));
+         snprintf(&config->users_path[0], MAX_PATH, "%s", users_path);
       }
    }
 
@@ -727,7 +727,7 @@ main(int argc, char** argv)
 #endif
          exit(1);
       }
-      memcpy(&config->admins_path[0], admins_path, MIN(strlen(admins_path), MAX_PATH - 1));
+      snprintf(&config->admins_path[0], MAX_PATH, "%s", admins_path);
    }
    else
    {
@@ -735,7 +735,7 @@ main(int argc, char** argv)
       ret = pgexporter_read_admins_configuration(shmem, admins_path);
       if (ret == 0)
       {
-         memcpy(&config->admins_path[0], admins_path, MIN(strlen(admins_path), MAX_PATH - 1));
+         snprintf(&config->admins_path[0], MAX_PATH, "%s", admins_path);
       }
    }
 
@@ -832,7 +832,7 @@ main(int argc, char** argv)
 
    if (yaml_path != NULL)
    {
-      memcpy(config->metrics_path, yaml_path, MIN(strlen(yaml_path), MAX_PATH - 1));
+      snprintf(config->metrics_path, MAX_PATH, "%s", yaml_path);
 
       if (pgexporter_read_metrics_configuration(shmem))
       {
@@ -844,7 +844,7 @@ main(int argc, char** argv)
    }
    else if (json_path != NULL)
    {
-      memcpy(config->metrics_path, json_path, MIN(strlen(json_path), MAX_PATH - 1));
+      snprintf(config->metrics_path, MAX_PATH, "%s", json_path);
 
       if (pgexporter_read_json_metrics_configuration(shmem))
       {
@@ -1899,9 +1899,7 @@ accept_management_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
 
    if (!fork())
    {
-      char* addr = malloc(strlen(address) + 1);
-      memset(addr, 0, strlen(address) + 1);
-      memcpy(addr, address, strlen(address));
+      char* addr = strdup(address);
 
       ev_loop_fork(loop);
       shutdown_ports();


### PR DESCRIPTION
 Replace all strncpy calls with snprintf to eliminate -Wstringop-truncation warnings and ensure strings are always properly null-terminated.