### PR TITLE
Add metrics from pg_stat_progress_vacuum

### DIFF
--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -942,6 +942,74 @@
       ],
       "tag": "pg_shmem_allocations",
       "collector": "shmem_size"
+    },
+    {
+      "queries": [
+        {
+          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "pid",
+              "type": "label"
+            },
+            {
+              "name": "datname",
+              "type": "label"
+            },
+            {
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "query",
+              "type": "label"
+            },
+            {
+              "name": "phase",
+              "type": "label"
+            },
+            {
+              "name": "heap_blks_total",
+              "type": "gauge",
+              "description": "Total heap blocks in table"
+            },
+            {
+              "name": "heap_blks_scanned",
+              "type": "gauge",
+              "description": "Heap blocks scanned"
+            },
+            {
+              "name": "heap_blks_vacuumed",
+              "type": "gauge",
+              "description": "Heap blocks vacuumed"
+            },
+            {
+              "name": "index_vacuum_count",
+              "type": "gauge",
+              "description": "Number of index vacuum cycles completed"
+            },
+            {
+              "name": "max_dead_tuples",
+              "type": "gauge",
+              "description": "Maximum dead tuples"
+            },
+            {
+              "name": "num_dead_tuples",
+              "type": "gauge",
+              "description": "Current dead tuples"
+            },
+            {
+              "name": "pct_scan_completed",
+              "type": "gauge",
+              "description": "Vacuum scan progress percentage"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_stat_progress_vacuum",
+      "sort": "data",
+      "collector": "vacuum_progress"
     }
   ]
 }

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -755,6 +755,74 @@
     {
       "queries": [
         {
+          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "pid",
+              "type": "label"
+            },
+            {
+              "name": "datname",
+              "type": "label"
+            },
+            {
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "query",
+              "type": "label"
+            },
+            {
+              "name": "phase",
+              "type": "label"
+            },
+            {
+              "name": "heap_blks_total",
+              "type": "gauge",
+              "description": "Total heap blocks in table"
+            },
+            {
+              "name": "heap_blks_scanned",
+              "type": "gauge",
+              "description": "Heap blocks scanned"
+            },
+            {
+              "name": "heap_blks_vacuumed",
+              "type": "gauge",
+              "description": "Heap blocks vacuumed"
+            },
+            {
+              "name": "index_vacuum_count",
+              "type": "gauge",
+              "description": "Number of index vacuum cycles completed"
+            },
+            {
+              "name": "max_dead_tuples",
+              "type": "gauge",
+              "description": "Maximum dead tuples"
+            },
+            {
+              "name": "num_dead_tuples",
+              "type": "gauge",
+              "description": "Current dead tuples"
+            },
+            {
+              "name": "pct_scan_completed",
+              "type": "gauge",
+              "description": "Vacuum scan progress percentage"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_stat_progress_vacuum",
+      "sort": "data",
+      "collector": "vacuum_progress"
+    },
+    {
+      "queries": [
+        {
           "query": "SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;",
           "columns": [
             {

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -755,6 +755,74 @@
     {
       "queries": [
         {
+          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "pid",
+              "type": "label"
+            },
+            {
+              "name": "datname",
+              "type": "label"
+            },
+            {
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "query",
+              "type": "label"
+            },
+            {
+              "name": "phase",
+              "type": "label"
+            },
+            {
+              "name": "heap_blks_total",
+              "type": "gauge",
+              "description": "Total heap blocks in table"
+            },
+            {
+              "name": "heap_blks_scanned",
+              "type": "gauge",
+              "description": "Heap blocks scanned"
+            },
+            {
+              "name": "heap_blks_vacuumed",
+              "type": "gauge",
+              "description": "Heap blocks vacuumed"
+            },
+            {
+              "name": "index_vacuum_count",
+              "type": "gauge",
+              "description": "Number of index vacuum cycles completed"
+            },
+            {
+              "name": "max_dead_tuples",
+              "type": "gauge",
+              "description": "Maximum dead tuples"
+            },
+            {
+              "name": "num_dead_tuples",
+              "type": "gauge",
+              "description": "Current dead tuples"
+            },
+            {
+              "name": "pct_scan_completed",
+              "type": "gauge",
+              "description": "Vacuum scan progress percentage"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_stat_progress_vacuum",
+      "sort": "data",
+      "collector": "vacuum_progress"
+    },
+    {
+      "queries": [
+        {
           "query": "SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;",
           "version": 14,
           "columns": [

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -680,6 +680,74 @@
     {
       "queries": [
         {
+          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "pid",
+              "type": "label"
+            },
+            {
+              "name": "datname",
+              "type": "label"
+            },
+            {
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "query",
+              "type": "label"
+            },
+            {
+              "name": "phase",
+              "type": "label"
+            },
+            {
+              "name": "heap_blks_total",
+              "type": "gauge",
+              "description": "Total heap blocks in table"
+            },
+            {
+              "name": "heap_blks_scanned",
+              "type": "gauge",
+              "description": "Heap blocks scanned"
+            },
+            {
+              "name": "heap_blks_vacuumed",
+              "type": "gauge",
+              "description": "Heap blocks vacuumed"
+            },
+            {
+              "name": "index_vacuum_count",
+              "type": "gauge",
+              "description": "Number of index vacuum cycles completed"
+            },
+            {
+              "name": "max_dead_tuples",
+              "type": "gauge",
+              "description": "Maximum dead tuples"
+            },
+            {
+              "name": "num_dead_tuples",
+              "type": "gauge",
+              "description": "Current dead tuples"
+            },
+            {
+              "name": "pct_scan_completed",
+              "type": "gauge",
+              "description": "Vacuum scan progress percentage"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_stat_progress_vacuum",
+      "sort": "data",
+      "collector": "vacuum_progress"
+    },
+    {
+      "queries": [
+        {
           "query": "SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;",
           "version": 14,
           "columns": [

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -645,6 +645,155 @@
     {
       "queries": [
         {
+          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "pid",
+              "type": "label"
+            },
+            {
+              "name": "datname",
+              "type": "label"
+            },
+            {
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "query",
+              "type": "label"
+            },
+            {
+              "name": "phase",
+              "type": "label"
+            },
+            {
+              "name": "heap_blks_total",
+              "type": "gauge",
+              "description": "Total heap blocks in table"
+            },
+            {
+              "name": "heap_blks_scanned",
+              "type": "gauge",
+              "description": "Heap blocks scanned"
+            },
+            {
+              "name": "heap_blks_vacuumed",
+              "type": "gauge",
+              "description": "Heap blocks vacuumed"
+            },
+            {
+              "name": "index_vacuum_count",
+              "type": "gauge",
+              "description": "Number of index vacuum cycles completed"
+            },
+            {
+              "name": "max_dead_tuples",
+              "type": "gauge",
+              "description": "Maximum dead tuples"
+            },
+            {
+              "name": "num_dead_tuples",
+              "type": "gauge",
+              "description": "Current dead tuples"
+            },
+            {
+              "name": "pct_scan_completed",
+              "type": "gauge",
+              "description": "Vacuum scan progress percentage"
+            }
+          ]
+        },
+        {
+          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuple_bytes, p.dead_tuple_bytes, p.num_dead_item_ids, p.indexes_total, p.indexes_processed, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed, CASE WHEN p.indexes_total > 0 THEN round(100 * p.indexes_processed / p.indexes_total, 2) ELSE 0 END AS pct_index_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
+          "version": 17,
+          "columns": [
+            {
+              "name": "pid",
+              "type": "label"
+            },
+            {
+              "name": "datname",
+              "type": "label"
+            },
+            {
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "query",
+              "type": "label"
+            },
+            {
+              "name": "phase",
+              "type": "label"
+            },
+            {
+              "name": "heap_blks_total",
+              "type": "gauge",
+              "description": "Total heap blocks in table"
+            },
+            {
+              "name": "heap_blks_scanned",
+              "type": "gauge",
+              "description": "Heap blocks scanned"
+            },
+            {
+              "name": "heap_blks_vacuumed",
+              "type": "gauge",
+              "description": "Heap blocks vacuumed"
+            },
+            {
+              "name": "index_vacuum_count",
+              "type": "gauge",
+              "description": "Number of index vacuum cycles completed"
+            },
+            {
+              "name": "max_dead_tuple_bytes",
+              "type": "gauge",
+              "description": "Maximum dead tuple bytes"
+            },
+            {
+              "name": "dead_tuple_bytes",
+              "type": "gauge",
+              "description": "Current dead tuple bytes"
+            },
+            {
+              "name": "num_dead_item_ids",
+              "type": "gauge",
+              "description": "Number of dead item identifiers"
+            },
+            {
+              "name": "indexes_total",
+              "type": "gauge",
+              "description": "Total number of indexes"
+            },
+            {
+              "name": "indexes_processed",
+              "type": "gauge",
+              "description": "Number of indexes processed"
+            },
+            {
+              "name": "pct_scan_completed",
+              "type": "gauge",
+              "description": "Vacuum scan progress percentage"
+            },
+            {
+              "name": "pct_index_completed",
+              "type": "gauge",
+              "description": "Index processing progress percentage"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_stat_progress_vacuum",
+      "sort": "data",
+      "collector": "vacuum_progress"
+    },
+    {
+      "queries": [
+        {
           "query": "SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;",
           "version": 14,
           "columns": [

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -840,3 +840,58 @@ metrics:
           description: Histogram of shared memory sizes.
     tag: pg_shmem_allocations
     collector: shmem_size
+
+# Vacuum progress information
+  - queries:
+    - query: SELECT
+                p.pid,
+                a.datname,
+                a.usename,
+                a.query,
+                p.phase,
+                p.heap_blks_total,
+                p.heap_blks_scanned,
+                p.heap_blks_vacuumed,
+                p.index_vacuum_count,
+                p.max_dead_tuples,
+                p.num_dead_tuples,
+                CASE WHEN p.heap_blks_total > 0
+                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
+                     ELSE 0
+                END AS pct_scan_completed
+              FROM pg_stat_progress_vacuum p
+              JOIN pg_stat_activity a USING (pid)
+              ORDER BY p.pid;
+      version: 13
+      columns:
+        - name: pid
+          type: label
+        - name: datname
+          type: label
+        - name: usename
+          type: label
+        - name: query
+          type: label
+        - name: phase
+          type: label
+        - name: heap_blks_total
+          type: gauge
+          description: Total heap blocks in table
+        - name: heap_blks_scanned
+          type: gauge
+          description: Heap blocks scanned
+        - name: heap_blks_vacuumed
+          type: gauge
+          description: Heap blocks vacuumed
+        - name: index_vacuum_count
+          type: gauge
+          description: Number of index vacuum cycles completed
+        - name: max_dead_tuples
+          type: gauge
+          description: Maximum dead tuples
+        - name: num_dead_tuples
+          type: gauge
+          description: Current dead tuples
+        - name: pct_scan_completed
+          type: gauge
+          description: Vacuum scan progress percentage

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -687,6 +687,60 @@ metrics:
     tag: pg_shmem_allocations
     collector: shmem_size
 
+# Vacuum progress information
+  - queries:
+    - query: SELECT
+                p.pid,
+                a.datname,
+                a.usename,
+                a.query,
+                p.phase,
+                p.heap_blks_total,
+                p.heap_blks_scanned,
+                p.heap_blks_vacuumed,
+                p.index_vacuum_count,
+                p.max_dead_tuples,
+                p.num_dead_tuples,
+                CASE WHEN p.heap_blks_total > 0
+                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
+                     ELSE 0
+                END AS pct_scan_completed
+              FROM pg_stat_progress_vacuum p
+              JOIN pg_stat_activity a USING (pid)
+              ORDER BY p.pid;
+      version: 13
+      columns:
+        - name: pid
+          type: label
+        - name: datname
+          type: label
+        - name: usename
+          type: label
+        - name: query
+          type: label
+        - name: phase
+          type: label
+        - name: heap_blks_total
+          type: gauge
+          description: Total heap blocks in table
+        - name: heap_blks_scanned
+          type: gauge
+          description: Heap blocks scanned
+        - name: heap_blks_vacuumed
+          type: gauge
+          description: Heap blocks vacuumed
+        - name: index_vacuum_count
+          type: gauge
+          description: Number of index vacuum cycles completed
+        - name: max_dead_tuples
+          type: gauge
+          description: Maximum dead tuples
+        - name: num_dead_tuples
+          type: gauge
+          description: Current dead tuples
+        - name: pct_scan_completed
+          type: gauge
+          description: Vacuum scan progress percentage
 #
 # PostgreSQL 14
 #

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -687,6 +687,60 @@ metrics:
     tag: pg_shmem_allocations
     collector: shmem_size
 
+# Vacuum progress information
+  - queries:
+    - query: SELECT
+                p.pid,
+                a.datname,
+                a.usename,
+                a.query,
+                p.phase,
+                p.heap_blks_total,
+                p.heap_blks_scanned,
+                p.heap_blks_vacuumed,
+                p.index_vacuum_count,
+                p.max_dead_tuples,
+                p.num_dead_tuples,
+                CASE WHEN p.heap_blks_total > 0
+                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
+                     ELSE 0
+                END AS pct_scan_completed
+              FROM pg_stat_progress_vacuum p
+              JOIN pg_stat_activity a USING (pid)
+              ORDER BY p.pid;
+      version: 13
+      columns:
+        - name: pid
+          type: label
+        - name: datname
+          type: label
+        - name: usename
+          type: label
+        - name: query
+          type: label
+        - name: phase
+          type: label
+        - name: heap_blks_total
+          type: gauge
+          description: Total heap blocks in table
+        - name: heap_blks_scanned
+          type: gauge
+          description: Heap blocks scanned
+        - name: heap_blks_vacuumed
+          type: gauge
+          description: Heap blocks vacuumed
+        - name: index_vacuum_count
+          type: gauge
+          description: Number of index vacuum cycles completed
+        - name: max_dead_tuples
+          type: gauge
+          description: Maximum dead tuples
+        - name: num_dead_tuples
+          type: gauge
+          description: Current dead tuples
+        - name: pct_scan_completed
+          type: gauge
+          description: Vacuum scan progress percentage
 #
 # PostgreSQL 14
 #

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -626,6 +626,60 @@ metrics:
     tag: pg_shmem_allocations
     collector: shmem_size
 
+# Vacuum progress information
+  - queries:
+    - query: SELECT
+                p.pid,
+                a.datname,
+                a.usename,
+                a.query,
+                p.phase,
+                p.heap_blks_total,
+                p.heap_blks_scanned,
+                p.heap_blks_vacuumed,
+                p.index_vacuum_count,
+                p.max_dead_tuples,
+                p.num_dead_tuples,
+                CASE WHEN p.heap_blks_total > 0
+                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
+                     ELSE 0
+                END AS pct_scan_completed
+              FROM pg_stat_progress_vacuum p
+              JOIN pg_stat_activity a USING (pid)
+              ORDER BY p.pid;
+      version: 13
+      columns:
+        - name: pid
+          type: label
+        - name: datname
+          type: label
+        - name: usename
+          type: label
+        - name: query
+          type: label
+        - name: phase
+          type: label
+        - name: heap_blks_total
+          type: gauge
+          description: Total heap blocks in table
+        - name: heap_blks_scanned
+          type: gauge
+          description: Heap blocks scanned
+        - name: heap_blks_vacuumed
+          type: gauge
+          description: Heap blocks vacuumed
+        - name: index_vacuum_count
+          type: gauge
+          description: Number of index vacuum cycles completed
+        - name: max_dead_tuples
+          type: gauge
+          description: Maximum dead tuples
+        - name: num_dead_tuples
+          type: gauge
+          description: Current dead tuples
+        - name: pct_scan_completed
+          type: gauge
+          description: Vacuum scan progress percentage
 #
 # PostgreSQL 14
 #

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -597,7 +597,135 @@ metrics:
           description: Histogram of shared memory sizes.
     tag: pg_shmem_allocations
     collector: shmem_size
+# Vacuum progress information
+  - queries:
+    - query: SELECT
+                p.pid,
+                a.datname,
+                a.usename,
+                a.query,
+                p.phase,
+                p.heap_blks_total,
+                p.heap_blks_scanned,
+                p.heap_blks_vacuumed,
+                p.index_vacuum_count,
+                p.max_dead_tuples,
+                p.num_dead_tuples,
+                CASE WHEN p.heap_blks_total > 0
+                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
+                     ELSE 0
+                END AS pct_scan_completed
+              FROM pg_stat_progress_vacuum p
+              JOIN pg_stat_activity a USING (pid)
+              ORDER BY p.pid;
+      version: 13
+      columns:
+        - name: pid
+          type: label
+        - name: datname
+          type: label
+        - name: usename
+          type: label
+        - name: query
+          type: label
+        - name: phase
+          type: label
+        - name: heap_blks_total
+          type: gauge
+          description: Total heap blocks in table
+        - name: heap_blks_scanned
+          type: gauge
+          description: Heap blocks scanned
+        - name: heap_blks_vacuumed
+          type: gauge
+          description: Heap blocks vacuumed
+        - name: index_vacuum_count
+          type: gauge
+          description: Number of index vacuum cycles completed
+        - name: max_dead_tuples
+          type: gauge
+          description: Maximum dead tuples
+        - name: num_dead_tuples
+          type: gauge
+          description: Current dead tuples
+        - name: pct_scan_completed
+          type: gauge
+          description: Vacuum scan progress percentage
 
+    - query: SELECT
+                p.pid,
+                a.datname,
+                a.usename,
+                a.query,
+                p.phase,
+                p.heap_blks_total,
+                p.heap_blks_scanned,
+                p.heap_blks_vacuumed,
+                p.index_vacuum_count,
+                p.max_dead_tuple_bytes,
+                p.dead_tuple_bytes,
+                p.num_dead_item_ids,
+                p.indexes_total,
+                p.indexes_processed,
+                CASE WHEN p.heap_blks_total > 0
+                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
+                     ELSE 0
+                END AS pct_scan_completed,
+                CASE WHEN p.indexes_total > 0
+                     THEN round(100 * p.indexes_processed / p.indexes_total, 2)
+                     ELSE 0
+                END AS pct_index_completed
+              FROM pg_stat_progress_vacuum p
+              JOIN pg_stat_activity a USING (pid)
+              ORDER BY p.pid;
+      version: 17
+      columns:
+        - name: pid
+          type: label
+        - name: datname
+          type: label
+        - name: usename
+          type: label
+        - name: query
+          type: label
+        - name: phase
+          type: label
+        - name: heap_blks_total
+          type: gauge
+          description: Total heap blocks in table
+        - name: heap_blks_scanned
+          type: gauge
+          description: Heap blocks scanned
+        - name: heap_blks_vacuumed
+          type: gauge
+          description: Heap blocks vacuumed
+        - name: index_vacuum_count
+          type: gauge
+          description: Number of index vacuum cycles completed
+        - name: max_dead_tuple_bytes
+          type: gauge
+          description: Maximum dead tuple bytes
+        - name: dead_tuple_bytes
+          type: gauge
+          description: Current dead tuple bytes
+        - name: num_dead_item_ids
+          type: gauge
+          description: Number of dead item identifiers
+        - name: indexes_total
+          type: gauge
+          description: Total number of indexes
+        - name: indexes_processed
+          type: gauge
+          description: Number of indexes processed
+        - name: pct_scan_completed
+          type: gauge
+          description: Vacuum scan progress percentage
+        - name: pct_index_completed
+          type: gauge
+          description: Index processing progress percentage
+    tag: pg_stat_progress_vacuum
+    sort: data
+    collector: vacuum_progress
 #
 # PostgreSQL 14
 #

--- a/doc/manual/user-11-prometheus.md
+++ b/doc/manual/user-11-prometheus.md
@@ -37,6 +37,7 @@
 * `pg_gss_auth`
 * `pg_encrypted_conn`
 * `pg_shmem_allocations`
+* `pg_stat_progress_vacuum`
 * `pg_stat_statements_total_exec_time`
 * `pg_stat_statements_plans`
 * `pg_stat_statements_wal_bytes`

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -678,6 +678,136 @@ extern "C" {
         "    tag: pg_shmem_allocations\n" \
         "    collector: shmem_size\n" \
         "\n" \
+        "# Vacuum progress information\n" \
+        "  - queries:\n" \
+        "    - query: SELECT\n" \
+        "                p.pid,\n" \
+        "                a.datname,\n" \
+        "                a.usename,\n" \
+        "                a.query,\n" \
+        "                p.phase,\n" \
+        "                p.heap_blks_total,\n" \
+        "                p.heap_blks_scanned,\n" \
+        "                p.heap_blks_vacuumed,\n" \
+        "                p.index_vacuum_count,\n" \
+        "                p.max_dead_tuples,\n" \
+        "                p.num_dead_tuples,\n" \
+        "                CASE WHEN p.heap_blks_total > 0\n" \
+        "                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)\n" \
+        "                     ELSE 0\n" \
+        "                END AS pct_scan_completed\n" \
+        "              FROM pg_stat_progress_vacuum p\n" \
+        "              JOIN pg_stat_activity a USING (pid)\n" \
+        "              ORDER BY p.pid;\n" \
+        "      version: 13\n" \
+        "      columns:\n" \
+        "        - name: pid\n" \
+        "          type: label\n" \
+        "        - name: datname\n" \
+        "          type: label\n" \
+        "        - name: usename\n" \
+        "          type: label\n" \
+        "        - name: query\n" \
+        "          type: label\n" \
+        "        - name: phase\n" \
+        "          type: label\n" \
+        "        - name: heap_blks_total\n" \
+        "          type: gauge\n" \
+        "          description: Total heap blocks in table\n" \
+        "        - name: heap_blks_scanned\n" \
+        "          type: gauge\n" \
+        "          description: Heap blocks scanned\n" \
+        "        - name: heap_blks_vacuumed\n" \
+        "          type: gauge\n" \
+        "          description: Heap blocks vacuumed\n" \
+        "        - name: index_vacuum_count\n" \
+        "          type: gauge\n" \
+        "          description: Number of index vacuum cycles completed\n" \
+        "        - name: max_dead_tuples\n" \
+        "          type: gauge\n" \
+        "          description: Maximum dead tuples\n" \
+        "        - name: num_dead_tuples\n" \
+        "          type: gauge\n" \
+        "          description: Current dead tuples\n" \
+        "        - name: pct_scan_completed\n" \
+        "          type: gauge\n" \
+        "          description: Vacuum scan progress percentage\n" \
+        "\n" \
+        "    - query: SELECT\n" \
+        "                p.pid,\n" \
+        "                a.datname,\n" \
+        "                a.usename,\n" \
+        "                a.query,\n" \
+        "                p.phase,\n" \
+        "                p.heap_blks_total,\n" \
+        "                p.heap_blks_scanned,\n" \
+        "                p.heap_blks_vacuumed,\n" \
+        "                p.index_vacuum_count,\n" \
+        "                p.max_dead_tuple_bytes,\n" \
+        "                p.dead_tuple_bytes,\n" \
+        "                p.num_dead_item_ids,\n" \
+        "                p.indexes_total,\n" \
+        "                p.indexes_processed,\n" \
+        "                CASE WHEN p.heap_blks_total > 0\n" \
+        "                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)\n" \
+        "                     ELSE 0\n" \
+        "                END AS pct_scan_completed,\n" \
+        "                CASE WHEN p.indexes_total > 0\n" \
+        "                     THEN round(100 * p.indexes_processed / p.indexes_total, 2)\n" \
+        "                     ELSE 0\n" \
+        "                END AS pct_index_completed\n" \
+        "              FROM pg_stat_progress_vacuum p\n" \
+        "              JOIN pg_stat_activity a USING (pid)\n" \
+        "              ORDER BY p.pid;\n" \
+        "      version: 17\n" \
+        "      columns:\n" \
+        "        - name: pid\n" \
+        "          type: label\n" \
+        "        - name: datname\n" \
+        "          type: label\n" \
+        "        - name: usename\n" \
+        "          type: label\n" \
+        "        - name: query\n" \
+        "          type: label\n" \
+        "        - name: phase\n" \
+        "          type: label\n" \
+        "        - name: heap_blks_total\n" \
+        "          type: gauge\n" \
+        "          description: Total heap blocks in table\n" \
+        "        - name: heap_blks_scanned\n" \
+        "          type: gauge\n" \
+        "          description: Heap blocks scanned\n" \
+        "        - name: heap_blks_vacuumed\n" \
+        "          type: gauge\n" \
+        "          description: Heap blocks vacuumed\n" \
+        "        - name: index_vacuum_count\n" \
+        "          type: gauge\n" \
+        "          description: Number of index vacuum cycles completed\n" \
+        "        - name: max_dead_tuple_bytes\n" \
+        "          type: gauge\n" \
+        "          description: Maximum dead tuple bytes\n" \
+        "        - name: dead_tuple_bytes\n" \
+        "          type: gauge\n" \
+        "          description: Current dead tuple bytes\n" \
+        "        - name: num_dead_item_ids\n" \
+        "          type: gauge\n" \
+        "          description: Number of dead item identifiers\n" \
+        "        - name: indexes_total\n" \
+        "          type: gauge\n" \
+        "          description: Total number of indexes\n" \
+        "        - name: indexes_processed\n" \
+        "          type: gauge\n" \
+        "          description: Number of indexes processed\n" \
+        "        - name: pct_scan_completed\n" \
+        "          type: gauge\n" \
+        "          description: Vacuum scan progress percentage\n" \
+        "        - name: pct_index_completed\n" \
+        "          type: gauge\n" \
+        "          description: Index processing progress percentage\n" \
+        "    tag: pg_stat_progress_vacuum\n" \
+        "    sort: data\n" \
+        "    collector: vacuum_progress\n" \
+        "\n" \
         "#\n" \
         "# PostgreSQL 14\n" \
         "#\n" \


### PR DESCRIPTION
Hi, @jesperpedersen @resyfer  i need some help...am i adding these metrics incorrectly? I am not sure why on curl-ing the metrics endpoint I am unable to see the metrics I just added (`curl | grep 'pg_stat_progress_vacuum'`).

Am I doing something wrong?