### PR TITLE
[#298] Add metrics for pgcrypto

### DIFF
--- a/extensions/pgcrypto.yaml
+++ b/extensions/pgcrypto.yaml
@@ -1,0 +1,118 @@
+#
+# Copyright (C) 2025 The pgexporter community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+extension: pgcrypto
+metrics:
+
+#
+# Extension Version 1.3
+# Compatible: PostgreSQL 13-17
+# Provides cryptographic functions for data encryption, hashing, and security operations
+#
+
+# Function usage by category - shows what crypto capabilities are available
+  - metric: function_usage_by_category
+    queries:
+      - query: SELECT 
+                  current_database() as database,
+                  CASE 
+                    WHEN p.proname LIKE '%digest%' OR p.proname LIKE '%hash%' THEN 'digest'
+                    WHEN p.proname LIKE '%encrypt%' OR p.proname LIKE '%decrypt%' THEN 'encryption'
+                    WHEN p.proname LIKE '%hmac%' THEN 'hmac'
+                    WHEN p.proname LIKE '%pgp%' THEN 'pgp'
+                    WHEN p.proname LIKE '%gen_%' THEN 'generation'
+                    WHEN p.proname LIKE '%crypt%' THEN 'crypt'
+                    ELSE 'other'
+                  END as function_category,
+                  COUNT(*) as function_count
+                FROM pg_proc p
+                JOIN pg_depend d ON d.objid = p.oid
+                JOIN pg_extension e ON d.refobjid = e.oid
+                WHERE e.extname = 'pgcrypto' AND d.deptype = 'e'
+                GROUP BY 
+                  current_database(),
+                  CASE 
+                    WHEN p.proname LIKE '%digest%' OR p.proname LIKE '%hash%' THEN 'digest'
+                    WHEN p.proname LIKE '%encrypt%' OR p.proname LIKE '%decrypt%' THEN 'encryption'
+                    WHEN p.proname LIKE '%hmac%' THEN 'hmac'
+                    WHEN p.proname LIKE '%pgp%' THEN 'pgp'
+                    WHEN p.proname LIKE '%gen_%' THEN 'generation'
+                    WHEN p.proname LIKE '%crypt%' THEN 'crypt'
+                    ELSE 'other'
+                  END
+                ORDER BY function_count DESC;
+        version: "1.3"
+        columns:
+          - name: database
+            type: label
+          - name: function_category
+            type: label
+          - name: function_count
+            type: gauge
+            description: Number of pgcrypto functions by category
+
+# User crypto function usage - tracks custom crypto functions
+  - metric: user_crypto_function_usage
+    queries:
+      - query: SELECT 
+                  current_database() as database,
+                  schemaname,
+                  funcname,
+                  calls,
+                  total_time,
+                  self_time,
+                  CASE 
+                    WHEN calls > 0 THEN ROUND((total_time / calls)::numeric, 3)
+                    ELSE 0
+                  END as avg_time_per_call
+                FROM pg_stat_user_functions
+                WHERE funcname LIKE '%crypto%' 
+                   OR funcname LIKE '%encrypt%' 
+                   OR funcname LIKE '%hash%'
+                   OR funcname LIKE '%digest%'
+                ORDER BY calls DESC;
+        version: "1.3"
+        columns:
+          - name: database
+            type: label
+          - name: schemaname
+            type: label
+          - name: funcname
+            type: label
+          - name: calls
+            type: counter
+            description: Number of times function was called
+          - name: total_time
+            type: counter
+            description: Total execution time in milliseconds
+          - name: self_time
+            type: counter
+            description: Self execution time in milliseconds
+          - name: avg_time_per_call
+            type: gauge
+            description: Average execution time per call


### PR DESCRIPTION
Addressing #298. Unfortunately there are limited things you can do with the `pg_montior` role with pgcrypto. I wanted to add this query:
```yaml
# Tables with crypto usage - identifies tables with crypto-related columns
  - metric: tables_with_crypto_usage
    queries:
      - query: SELECT 
                  current_database() as database,
                  table_schema,
                  table_name,
                  COUNT(*) as crypto_like_columns
                FROM information_schema.columns
                WHERE (column_name LIKE '%hash%' 
                   OR column_name LIKE '%encrypt%' 
                   OR column_name LIKE '%crypto%'
                   OR (data_type = 'bytea' AND column_name NOT LIKE '%lob%'))
                  AND table_schema NOT IN ('information_schema', 'pg_catalog')
                GROUP BY current_database(), table_schema, table_name
                ORDER BY crypto_like_columns DESC;
        version: "1.3"
        columns:
          - name: database
            type: label
          - name: table_schema
            type: label
          - name: table_name
            type: label
          - name: crypto_like_columns
            type: gauge
            description: Number of columns that may contain crypto data
```

But it does not work with the monitor role. Further, to see metrics from `user_crypto_function_usage` we need to have `ALTER SYSTEM SET track_functions = 'all';`

This is the output:
```
#HELP pgexporter_pgcrypto_function_usage_by_category_function_count Number of pgcrypto functions by category
#TYPE pgexporter_pgcrypto_function_usage_by_category_function_count gauge
pgexporter_pgcrypto_function_usage_by_category_function_count{server="primary", database="postgres", function_category="encryption"} 22
pgexporter_pgcrypto_function_usage_by_category_function_count{server="primary", database="postgres", function_category="generation"} 4
pgexporter_pgcrypto_function_usage_by_category_function_count{server="primary", database="postgres", function_category="other"} 3
pgexporter_pgcrypto_function_usage_by_category_function_count{server="primary", database="postgres", function_category="digest"} 2
pgexporter_pgcrypto_function_usage_by_category_function_count{server="primary", database="postgres", function_category="hmac"} 2
pgexporter_pgcrypto_function_usage_by_category_function_count{server="primary", database="postgres", function_category="pgp"} 2
pgexporter_pgcrypto_function_usage_by_category_function_count{server="primary", database="postgres", function_category="crypt"} 1

#HELP pgexporter_pgcrypto_user_crypto_function_usage_calls Number of times function was called
#TYPE pgexporter_pgcrypto_user_crypto_function_usage_calls counter
pgexporter_pgcrypto_user_crypto_function_usage_calls{server="primary", database="postgres", schemaname="public", funcname="digest"} 30
pgexporter_pgcrypto_user_crypto_function_usage_calls{server="primary", database="postgres", schemaname="public", funcname="generate_api_key_hash"} 30
pgexporter_pgcrypto_user_crypto_function_usage_calls{server="primary", database="postgres", schemaname="public", funcname="hash_user_password"} 10
pgexporter_pgcrypto_user_crypto_function_usage_calls{server="primary", database="postgres", schemaname="public", funcname="encrypt"} 5
pgexporter_pgcrypto_user_crypto_function_usage_calls{server="primary", database="postgres", schemaname="public", funcname="encrypt_sensitive_data"} 5

#HELP pgexporter_pgcrypto_user_crypto_function_usage_total_time Total execution time in milliseconds
#TYPE pgexporter_pgcrypto_user_crypto_function_usage_total_time counter
pgexporter_pgcrypto_user_crypto_function_usage_total_time{server="primary", database="postgres", schemaname="public", funcname="digest"} 1
pgexporter_pgcrypto_user_crypto_function_usage_total_time{server="primary", database="postgres", schemaname="public", funcname="generate_api_key_hash"} 1
pgexporter_pgcrypto_user_crypto_function_usage_total_time{server="primary", database="postgres", schemaname="public", funcname="hash_user_password"} 1
pgexporter_pgcrypto_user_crypto_function_usage_total_time{server="primary", database="postgres", schemaname="public", funcname="encrypt"} 1
pgexporter_pgcrypto_user_crypto_function_usage_total_time{server="primary", database="postgres", schemaname="public", funcname="encrypt_sensitive_data"} 1

#HELP pgexporter_pgcrypto_user_crypto_function_usage_self_time Self execution time in milliseconds
#TYPE pgexporter_pgcrypto_user_crypto_function_usage_self_time counter
pgexporter_pgcrypto_user_crypto_function_usage_self_time{server="primary", database="postgres", schemaname="public", funcname="digest"} 1
pgexporter_pgcrypto_user_crypto_function_usage_self_time{server="primary", database="postgres", schemaname="public", funcname="generate_api_key_hash"} 1
pgexporter_pgcrypto_user_crypto_function_usage_self_time{server="primary", database="postgres", schemaname="public", funcname="hash_user_password"} 1
pgexporter_pgcrypto_user_crypto_function_usage_self_time{server="primary", database="postgres", schemaname="public", funcname="encrypt"} 1
pgexporter_pgcrypto_user_crypto_function_usage_self_time{server="primary", database="postgres", schemaname="public", funcname="encrypt_sensitive_data"} 1

#HELP pgexporter_pgcrypto_user_crypto_function_usage_avg_time_per_call Average execution time per call
#TYPE pgexporter_pgcrypto_user_crypto_function_usage_avg_time_per_call gauge
pgexporter_pgcrypto_user_crypto_function_usage_avg_time_per_call{server="primary", database="postgres", schemaname="public", funcname="digest"} 1
pgexporter_pgcrypto_user_crypto_function_usage_avg_time_per_call{server="primary", database="postgres", schemaname="public", funcname="generate_api_key_hash"} 1
pgexporter_pgcrypto_user_crypto_function_usage_avg_time_per_call{server="primary", database="postgres", schemaname="public", funcname="hash_user_password"} 1
pgexporter_pgcrypto_user_crypto_function_usage_avg_time_per_call{server="primary", database="postgres", schemaname="public", funcname="encrypt"} 1
pgexporter_pgcrypto_user_crypto_function_usage_avg_time_per_call{server="primary", database="postgres", schemaname="public", funcname="encrypt_sensitive_data"} 1
```
As always, test cases can be found [here](https://github.com/bassamadnan/pg_ext_tracker/tree/main/pgcrypto).