### PR TITLE
Add metrics for tracking vacuum

### DIFF
--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -1010,6 +1010,93 @@
       "tag": "pg_stat_progress_vacuum",
       "sort": "data",
       "collector": "vacuum_progress"
+    },
+    {
+      "queries": [
+        {
+          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "n_live_tup",
+              "type": "gauge",
+              "description": "Estimated number of live rows"
+            },
+            {
+              "name": "n_dead_tup",
+              "type": "gauge",
+              "description": "Estimated number of dead rows"
+            },
+            {
+              "name": "dead_rows_pct",
+              "type": "gauge",
+              "description": "Percentage of dead rows relative to live rows"
+            },
+            {
+              "name": "n_mod_since_analyze",
+              "type": "gauge",
+              "description": "Estimated number of rows modified since last analyze"
+            },
+            {
+              "name": "n_ins_since_vacuum",
+              "type": "gauge",
+              "description": "Estimated number of rows inserted since last vacuum"
+            },
+            {
+              "name": "last_vacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual vacuum (-1 if never)"
+            },
+            {
+              "name": "last_autovacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autovacuum (-1 if never)"
+            },
+            {
+              "name": "last_analyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual analyze (-1 if never)"
+            },
+            {
+              "name": "last_autoanalyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autoanalyze (-1 if never)"
+            },
+            {
+              "name": "vacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually vacuumed"
+            },
+            {
+              "name": "autovacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been vacuumed by autovacuum"
+            },
+            {
+              "name": "analyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually analyzed"
+            },
+            {
+              "name": "autoanalyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been analyzed by autoanalyze"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_stat_user_tables_vacuum",
+      "sort": "data",
+      "collector": "stat_user_tables",
+      "database": "all"
     }
   ]
 }

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -1225,6 +1225,93 @@
       ],
       "tag": "pg_stat_database",
       "collector": "stat_db"
+    },
+    {
+      "queries": [
+        {
+          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "n_live_tup",
+              "type": "gauge",
+              "description": "Estimated number of live rows"
+            },
+            {
+              "name": "n_dead_tup",
+              "type": "gauge",
+              "description": "Estimated number of dead rows"
+            },
+            {
+              "name": "dead_rows_pct",
+              "type": "gauge",
+              "description": "Percentage of dead rows relative to live rows"
+            },
+            {
+              "name": "n_mod_since_analyze",
+              "type": "gauge",
+              "description": "Estimated number of rows modified since last analyze"
+            },
+            {
+              "name": "n_ins_since_vacuum",
+              "type": "gauge",
+              "description": "Estimated number of rows inserted since last vacuum"
+            },
+            {
+              "name": "last_vacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual vacuum (-1 if never)"
+            },
+            {
+              "name": "last_autovacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autovacuum (-1 if never)"
+            },
+            {
+              "name": "last_analyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual analyze (-1 if never)"
+            },
+            {
+              "name": "last_autoanalyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autoanalyze (-1 if never)"
+            },
+            {
+              "name": "vacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually vacuumed"
+            },
+            {
+              "name": "autovacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been vacuumed by autovacuum"
+            },
+            {
+              "name": "analyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually analyzed"
+            },
+            {
+              "name": "autoanalyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been analyzed by autoanalyze"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_stat_user_tables_vacuum",
+      "sort": "data",
+      "collector": "stat_user_tables",
+      "database": "all"
     }
   ]
 }

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -1243,6 +1243,93 @@
       ],
       "tag": "pg_wal_prefetch_reset",
       "collector": "wal_prefetch_reset"
+    },
+    {
+      "queries": [
+        {
+          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "n_live_tup",
+              "type": "gauge",
+              "description": "Estimated number of live rows"
+            },
+            {
+              "name": "n_dead_tup",
+              "type": "gauge",
+              "description": "Estimated number of dead rows"
+            },
+            {
+              "name": "dead_rows_pct",
+              "type": "gauge",
+              "description": "Percentage of dead rows relative to live rows"
+            },
+            {
+              "name": "n_mod_since_analyze",
+              "type": "gauge",
+              "description": "Estimated number of rows modified since last analyze"
+            },
+            {
+              "name": "n_ins_since_vacuum",
+              "type": "gauge",
+              "description": "Estimated number of rows inserted since last vacuum"
+            },
+            {
+              "name": "last_vacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual vacuum (-1 if never)"
+            },
+            {
+              "name": "last_autovacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autovacuum (-1 if never)"
+            },
+            {
+              "name": "last_analyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual analyze (-1 if never)"
+            },
+            {
+              "name": "last_autoanalyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autoanalyze (-1 if never)"
+            },
+            {
+              "name": "vacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually vacuumed"
+            },
+            {
+              "name": "autovacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been vacuumed by autovacuum"
+            },
+            {
+              "name": "analyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually analyzed"
+            },
+            {
+              "name": "autoanalyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been analyzed by autoanalyze"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_stat_user_tables_vacuum",
+      "sort": "data",
+      "collector": "stat_user_tables",
+      "database": "all"
     }
   ]
 }

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -1412,6 +1412,227 @@
       "sort": "data",
       "collector": "stat_all_indexes",
       "database": "all"
+    },
+    {
+      "queries": [
+        {
+          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "n_live_tup",
+              "type": "gauge",
+              "description": "Estimated number of live rows"
+            },
+            {
+              "name": "n_dead_tup",
+              "type": "gauge",
+              "description": "Estimated number of dead rows"
+            },
+            {
+              "name": "dead_rows_pct",
+              "type": "gauge",
+              "description": "Percentage of dead rows relative to live rows"
+            },
+            {
+              "name": "n_mod_since_analyze",
+              "type": "gauge",
+              "description": "Estimated number of rows modified since last analyze"
+            },
+            {
+              "name": "n_ins_since_vacuum",
+              "type": "gauge",
+              "description": "Estimated number of rows inserted since last vacuum"
+            },
+            {
+              "name": "last_vacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual vacuum (-1 if never)"
+            },
+            {
+              "name": "last_autovacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autovacuum (-1 if never)"
+            },
+            {
+              "name": "last_analyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual analyze (-1 if never)"
+            },
+            {
+              "name": "last_autoanalyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autoanalyze (-1 if never)"
+            },
+            {
+              "name": "vacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually vacuumed"
+            },
+            {
+              "name": "autovacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been vacuumed by autovacuum"
+            },
+            {
+              "name": "analyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually analyzed"
+            },
+            {
+              "name": "autoanalyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been analyzed by autoanalyze"
+            }
+          ]
+        },
+        {
+          "query": "SELECT schemaname, relname, seq_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds, seq_tup_read, idx_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_tup_newpage_upd, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "version": 16,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "seq_scan",
+              "type": "counter",
+              "description": "Number of sequential scans initiated on this table"
+            },
+            {
+              "name": "last_seq_scan_seconds",
+              "type": "gauge",
+              "description": "Seconds since last sequential scan (-1 if never)"
+            },
+            {
+              "name": "seq_tup_read",
+              "type": "counter",
+              "description": "Number of live rows fetched by sequential scans"
+            },
+            {
+              "name": "idx_scan",
+              "type": "counter",
+              "description": "Number of index scans initiated on this table"
+            },
+            {
+              "name": "last_idx_scan_seconds",
+              "type": "gauge",
+              "description": "Seconds since last index scan (-1 if never)"
+            },
+            {
+              "name": "idx_tup_fetch",
+              "type": "counter",
+              "description": "Number of live rows fetched by index scans"
+            },
+            {
+              "name": "n_tup_ins",
+              "type": "counter",
+              "description": "Number of rows inserted"
+            },
+            {
+              "name": "n_tup_upd",
+              "type": "counter",
+              "description": "Number of rows updated"
+            },
+            {
+              "name": "n_tup_del",
+              "type": "counter",
+              "description": "Number of rows deleted"
+            },
+            {
+              "name": "n_tup_hot_upd",
+              "type": "counter",
+              "description": "Number of rows HOT updated"
+            },
+            {
+              "name": "n_tup_newpage_upd",
+              "type": "counter",
+              "description": "Number of rows updated where successor goes to new heap page"
+            },
+            {
+              "name": "n_live_tup",
+              "type": "gauge",
+              "description": "Estimated number of live rows"
+            },
+            {
+              "name": "n_dead_tup",
+              "type": "gauge",
+              "description": "Estimated number of dead rows"
+            },
+            {
+              "name": "dead_rows_pct",
+              "type": "gauge",
+              "description": "Percentage of dead rows relative to live rows"
+            },
+            {
+              "name": "n_mod_since_analyze",
+              "type": "gauge",
+              "description": "Estimated number of rows modified since last analyze"
+            },
+            {
+              "name": "n_ins_since_vacuum",
+              "type": "gauge",
+              "description": "Estimated number of rows inserted since last vacuum"
+            },
+            {
+              "name": "last_vacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual vacuum (-1 if never)"
+            },
+            {
+              "name": "last_autovacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autovacuum (-1 if never)"
+            },
+            {
+              "name": "last_analyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual analyze (-1 if never)"
+            },
+            {
+              "name": "last_autoanalyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autoanalyze (-1 if never)"
+            },
+            {
+              "name": "vacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually vacuumed"
+            },
+            {
+              "name": "autovacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been vacuumed by autovacuum"
+            },
+            {
+              "name": "analyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually analyzed"
+            },
+            {
+              "name": "autoanalyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been analyzed by autoanalyze"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_stat_user_tables_vacuum",
+      "sort": "data",
+      "collector": "stat_user_tables",
+      "database": "all"
     }
   ]
 }

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -1479,6 +1479,227 @@
       "tag": "pg_wait_events",
       "sort": "data",
       "collector": "wait_events"
+    },
+    {
+      "queries": [
+        {
+          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "n_live_tup",
+              "type": "gauge",
+              "description": "Estimated number of live rows"
+            },
+            {
+              "name": "n_dead_tup",
+              "type": "gauge",
+              "description": "Estimated number of dead rows"
+            },
+            {
+              "name": "dead_rows_pct",
+              "type": "gauge",
+              "description": "Percentage of dead rows relative to live rows"
+            },
+            {
+              "name": "n_mod_since_analyze",
+              "type": "gauge",
+              "description": "Estimated number of rows modified since last analyze"
+            },
+            {
+              "name": "n_ins_since_vacuum",
+              "type": "gauge",
+              "description": "Estimated number of rows inserted since last vacuum"
+            },
+            {
+              "name": "last_vacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual vacuum (-1 if never)"
+            },
+            {
+              "name": "last_autovacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autovacuum (-1 if never)"
+            },
+            {
+              "name": "last_analyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual analyze (-1 if never)"
+            },
+            {
+              "name": "last_autoanalyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autoanalyze (-1 if never)"
+            },
+            {
+              "name": "vacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually vacuumed"
+            },
+            {
+              "name": "autovacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been vacuumed by autovacuum"
+            },
+            {
+              "name": "analyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually analyzed"
+            },
+            {
+              "name": "autoanalyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been analyzed by autoanalyze"
+            }
+          ]
+        },
+        {
+          "query": "SELECT schemaname, relname, seq_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds, seq_tup_read, idx_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_tup_newpage_upd, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "version": 16,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "seq_scan",
+              "type": "counter",
+              "description": "Number of sequential scans initiated on this table"
+            },
+            {
+              "name": "last_seq_scan_seconds",
+              "type": "gauge",
+              "description": "Seconds since last sequential scan (-1 if never)"
+            },
+            {
+              "name": "seq_tup_read",
+              "type": "counter",
+              "description": "Number of live rows fetched by sequential scans"
+            },
+            {
+              "name": "idx_scan",
+              "type": "counter",
+              "description": "Number of index scans initiated on this table"
+            },
+            {
+              "name": "last_idx_scan_seconds",
+              "type": "gauge",
+              "description": "Seconds since last index scan (-1 if never)"
+            },
+            {
+              "name": "idx_tup_fetch",
+              "type": "counter",
+              "description": "Number of live rows fetched by index scans"
+            },
+            {
+              "name": "n_tup_ins",
+              "type": "counter",
+              "description": "Number of rows inserted"
+            },
+            {
+              "name": "n_tup_upd",
+              "type": "counter",
+              "description": "Number of rows updated"
+            },
+            {
+              "name": "n_tup_del",
+              "type": "counter",
+              "description": "Number of rows deleted"
+            },
+            {
+              "name": "n_tup_hot_upd",
+              "type": "counter",
+              "description": "Number of rows HOT updated"
+            },
+            {
+              "name": "n_tup_newpage_upd",
+              "type": "counter",
+              "description": "Number of rows updated where successor goes to new heap page"
+            },
+            {
+              "name": "n_live_tup",
+              "type": "gauge",
+              "description": "Estimated number of live rows"
+            },
+            {
+              "name": "n_dead_tup",
+              "type": "gauge",
+              "description": "Estimated number of dead rows"
+            },
+            {
+              "name": "dead_rows_pct",
+              "type": "gauge",
+              "description": "Percentage of dead rows relative to live rows"
+            },
+            {
+              "name": "n_mod_since_analyze",
+              "type": "gauge",
+              "description": "Estimated number of rows modified since last analyze"
+            },
+            {
+              "name": "n_ins_since_vacuum",
+              "type": "gauge",
+              "description": "Estimated number of rows inserted since last vacuum"
+            },
+            {
+              "name": "last_vacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual vacuum (-1 if never)"
+            },
+            {
+              "name": "last_autovacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autovacuum (-1 if never)"
+            },
+            {
+              "name": "last_analyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual analyze (-1 if never)"
+            },
+            {
+              "name": "last_autoanalyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autoanalyze (-1 if never)"
+            },
+            {
+              "name": "vacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually vacuumed"
+            },
+            {
+              "name": "autovacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been vacuumed by autovacuum"
+            },
+            {
+              "name": "analyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually analyzed"
+            },
+            {
+              "name": "autoanalyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been analyzed by autoanalyze"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_stat_user_tables_vacuum",
+      "sort": "data",
+      "collector": "stat_user_tables",
+      "database": "all"
     }
   ]
 }

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -895,3 +895,76 @@ metrics:
         - name: pct_scan_completed
           type: gauge
           description: Vacuum scan progress percentage
+# Table-level vacuum and analyze statistics
+  - queries:
+    - query: SELECT
+                schemaname,
+                relname,
+                n_live_tup,
+                n_dead_tup,
+                CASE 
+                  WHEN n_live_tup > 0 
+                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
+                  ELSE 0
+                END AS dead_rows_pct,
+                n_mod_since_analyze,
+                n_ins_since_vacuum,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
+                vacuum_count,
+                autovacuum_count,
+                analyze_count,
+                autoanalyze_count
+              FROM pg_stat_user_tables
+              ORDER BY n_dead_tup DESC;
+      version: 13
+      columns:
+        - name: schemaname
+          type: label
+        - name: relname
+          type: label
+        - name: n_live_tup
+          type: gauge
+          description: Estimated number of live rows
+        - name: n_dead_tup
+          type: gauge
+          description: Estimated number of dead rows
+        - name: dead_rows_pct
+          type: gauge
+          description: Percentage of dead rows relative to live rows
+        - name: n_mod_since_analyze
+          type: gauge
+          description: Estimated number of rows modified since last analyze
+        - name: n_ins_since_vacuum
+          type: gauge
+          description: Estimated number of rows inserted since last vacuum
+        - name: last_vacuum_seconds
+          type: gauge
+          description: Seconds since last manual vacuum (-1 if never)
+        - name: last_autovacuum_seconds
+          type: gauge
+          description: Seconds since last autovacuum (-1 if never)
+        - name: last_analyze_seconds
+          type: gauge
+          description: Seconds since last manual analyze (-1 if never)
+        - name: last_autoanalyze_seconds
+          type: gauge
+          description: Seconds since last autoanalyze (-1 if never)
+        - name: vacuum_count
+          type: counter
+          description: Number of times this table has been manually vacuumed
+        - name: autovacuum_count
+          type: counter
+          description: Number of times this table has been vacuumed by autovacuum
+        - name: analyze_count
+          type: counter
+          description: Number of times this table has been manually analyzed
+        - name: autoanalyze_count
+          type: counter
+          description: Number of times this table has been analyzed by autoanalyze
+    tag: pg_stat_user_tables_vacuum
+    sort: data
+    collector: stat_user_tables
+    database: all

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -741,6 +741,79 @@ metrics:
         - name: pct_scan_completed
           type: gauge
           description: Vacuum scan progress percentage
+# Table-level vacuum and analyze statistics
+  - queries:
+    - query: SELECT
+                schemaname,
+                relname,
+                n_live_tup,
+                n_dead_tup,
+                CASE 
+                  WHEN n_live_tup > 0 
+                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
+                  ELSE 0
+                END AS dead_rows_pct,
+                n_mod_since_analyze,
+                n_ins_since_vacuum,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
+                vacuum_count,
+                autovacuum_count,
+                analyze_count,
+                autoanalyze_count
+              FROM pg_stat_user_tables
+              ORDER BY n_dead_tup DESC;
+      version: 13
+      columns:
+        - name: schemaname
+          type: label
+        - name: relname
+          type: label
+        - name: n_live_tup
+          type: gauge
+          description: Estimated number of live rows
+        - name: n_dead_tup
+          type: gauge
+          description: Estimated number of dead rows
+        - name: dead_rows_pct
+          type: gauge
+          description: Percentage of dead rows relative to live rows
+        - name: n_mod_since_analyze
+          type: gauge
+          description: Estimated number of rows modified since last analyze
+        - name: n_ins_since_vacuum
+          type: gauge
+          description: Estimated number of rows inserted since last vacuum
+        - name: last_vacuum_seconds
+          type: gauge
+          description: Seconds since last manual vacuum (-1 if never)
+        - name: last_autovacuum_seconds
+          type: gauge
+          description: Seconds since last autovacuum (-1 if never)
+        - name: last_analyze_seconds
+          type: gauge
+          description: Seconds since last manual analyze (-1 if never)
+        - name: last_autoanalyze_seconds
+          type: gauge
+          description: Seconds since last autoanalyze (-1 if never)
+        - name: vacuum_count
+          type: counter
+          description: Number of times this table has been manually vacuumed
+        - name: autovacuum_count
+          type: counter
+          description: Number of times this table has been vacuumed by autovacuum
+        - name: analyze_count
+          type: counter
+          description: Number of times this table has been manually analyzed
+        - name: autoanalyze_count
+          type: counter
+          description: Number of times this table has been analyzed by autoanalyze
+    tag: pg_stat_user_tables_vacuum
+    sort: data
+    collector: stat_user_tables
+    database: all
 #
 # PostgreSQL 14
 #

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -741,6 +741,79 @@ metrics:
         - name: pct_scan_completed
           type: gauge
           description: Vacuum scan progress percentage
+# Table-level vacuum and analyze statistics
+  - queries:
+    - query: SELECT
+                schemaname,
+                relname,
+                n_live_tup,
+                n_dead_tup,
+                CASE 
+                  WHEN n_live_tup > 0 
+                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
+                  ELSE 0
+                END AS dead_rows_pct,
+                n_mod_since_analyze,
+                n_ins_since_vacuum,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
+                vacuum_count,
+                autovacuum_count,
+                analyze_count,
+                autoanalyze_count
+              FROM pg_stat_user_tables
+              ORDER BY n_dead_tup DESC;
+      version: 13
+      columns:
+        - name: schemaname
+          type: label
+        - name: relname
+          type: label
+        - name: n_live_tup
+          type: gauge
+          description: Estimated number of live rows
+        - name: n_dead_tup
+          type: gauge
+          description: Estimated number of dead rows
+        - name: dead_rows_pct
+          type: gauge
+          description: Percentage of dead rows relative to live rows
+        - name: n_mod_since_analyze
+          type: gauge
+          description: Estimated number of rows modified since last analyze
+        - name: n_ins_since_vacuum
+          type: gauge
+          description: Estimated number of rows inserted since last vacuum
+        - name: last_vacuum_seconds
+          type: gauge
+          description: Seconds since last manual vacuum (-1 if never)
+        - name: last_autovacuum_seconds
+          type: gauge
+          description: Seconds since last autovacuum (-1 if never)
+        - name: last_analyze_seconds
+          type: gauge
+          description: Seconds since last manual analyze (-1 if never)
+        - name: last_autoanalyze_seconds
+          type: gauge
+          description: Seconds since last autoanalyze (-1 if never)
+        - name: vacuum_count
+          type: counter
+          description: Number of times this table has been manually vacuumed
+        - name: autovacuum_count
+          type: counter
+          description: Number of times this table has been vacuumed by autovacuum
+        - name: analyze_count
+          type: counter
+          description: Number of times this table has been manually analyzed
+        - name: autoanalyze_count
+          type: counter
+          description: Number of times this table has been analyzed by autoanalyze
+    tag: pg_stat_user_tables_vacuum
+    sort: data
+    collector: stat_user_tables
+    database: all
 #
 # PostgreSQL 14
 #

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -680,6 +680,191 @@ metrics:
         - name: pct_scan_completed
           type: gauge
           description: Vacuum scan progress percentage
+# Table-level vacuum and analyze statistics
+  - queries:
+    - query: SELECT
+                schemaname,
+                relname,
+                n_live_tup,
+                n_dead_tup,
+                CASE 
+                  WHEN n_live_tup > 0 
+                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
+                  ELSE 0
+                END AS dead_rows_pct,
+                n_mod_since_analyze,
+                n_ins_since_vacuum,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
+                vacuum_count,
+                autovacuum_count,
+                analyze_count,
+                autoanalyze_count
+              FROM pg_stat_user_tables
+              ORDER BY n_dead_tup DESC;
+      version: 13
+      columns:
+        - name: schemaname
+          type: label
+        - name: relname
+          type: label
+        - name: n_live_tup
+          type: gauge
+          description: Estimated number of live rows
+        - name: n_dead_tup
+          type: gauge
+          description: Estimated number of dead rows
+        - name: dead_rows_pct
+          type: gauge
+          description: Percentage of dead rows relative to live rows
+        - name: n_mod_since_analyze
+          type: gauge
+          description: Estimated number of rows modified since last analyze
+        - name: n_ins_since_vacuum
+          type: gauge
+          description: Estimated number of rows inserted since last vacuum
+        - name: last_vacuum_seconds
+          type: gauge
+          description: Seconds since last manual vacuum (-1 if never)
+        - name: last_autovacuum_seconds
+          type: gauge
+          description: Seconds since last autovacuum (-1 if never)
+        - name: last_analyze_seconds
+          type: gauge
+          description: Seconds since last manual analyze (-1 if never)
+        - name: last_autoanalyze_seconds
+          type: gauge
+          description: Seconds since last autoanalyze (-1 if never)
+        - name: vacuum_count
+          type: counter
+          description: Number of times this table has been manually vacuumed
+        - name: autovacuum_count
+          type: counter
+          description: Number of times this table has been vacuumed by autovacuum
+        - name: analyze_count
+          type: counter
+          description: Number of times this table has been manually analyzed
+        - name: autoanalyze_count
+          type: counter
+          description: Number of times this table has been analyzed by autoanalyze
+
+    - query: SELECT
+                schemaname,
+                relname,
+                seq_scan,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds,
+                seq_tup_read,
+                idx_scan,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds,
+                idx_tup_fetch,
+                n_tup_ins,
+                n_tup_upd,
+                n_tup_del,
+                n_tup_hot_upd,
+                n_tup_newpage_upd,
+                n_live_tup,
+                n_dead_tup,
+                CASE 
+                  WHEN n_live_tup > 0 
+                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
+                  ELSE 0
+                END AS dead_rows_pct,
+                n_mod_since_analyze,
+                n_ins_since_vacuum,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
+                vacuum_count,
+                autovacuum_count,
+                analyze_count,
+                autoanalyze_count
+              FROM pg_stat_user_tables
+              ORDER BY n_dead_tup DESC;
+      version: 16
+      columns:
+        - name: schemaname
+          type: label
+        - name: relname
+          type: label
+        - name: seq_scan
+          type: counter
+          description: Number of sequential scans initiated on this table
+        - name: last_seq_scan_seconds
+          type: gauge
+          description: Seconds since last sequential scan (-1 if never)
+        - name: seq_tup_read
+          type: counter
+          description: Number of live rows fetched by sequential scans
+        - name: idx_scan
+          type: counter
+          description: Number of index scans initiated on this table
+        - name: last_idx_scan_seconds
+          type: gauge
+          description: Seconds since last index scan (-1 if never)
+        - name: idx_tup_fetch
+          type: counter
+          description: Number of live rows fetched by index scans
+        - name: n_tup_ins
+          type: counter
+          description: Number of rows inserted
+        - name: n_tup_upd
+          type: counter
+          description: Number of rows updated
+        - name: n_tup_del
+          type: counter
+          description: Number of rows deleted
+        - name: n_tup_hot_upd
+          type: counter
+          description: Number of rows HOT updated
+        - name: n_tup_newpage_upd
+          type: counter
+          description: Number of rows updated where successor goes to new heap page
+        - name: n_live_tup
+          type: gauge
+          description: Estimated number of live rows
+        - name: n_dead_tup
+          type: gauge
+          description: Estimated number of dead rows
+        - name: dead_rows_pct
+          type: gauge
+          description: Percentage of dead rows relative to live rows
+        - name: n_mod_since_analyze
+          type: gauge
+          description: Estimated number of rows modified since last analyze
+        - name: n_ins_since_vacuum
+          type: gauge
+          description: Estimated number of rows inserted since last vacuum
+        - name: last_vacuum_seconds
+          type: gauge
+          description: Seconds since last manual vacuum (-1 if never)
+        - name: last_autovacuum_seconds
+          type: gauge
+          description: Seconds since last autovacuum (-1 if never)
+        - name: last_analyze_seconds
+          type: gauge
+          description: Seconds since last manual analyze (-1 if never)
+        - name: last_autoanalyze_seconds
+          type: gauge
+          description: Seconds since last autoanalyze (-1 if never)
+        - name: vacuum_count
+          type: counter
+          description: Number of times this table has been manually vacuumed
+        - name: autovacuum_count
+          type: counter
+          description: Number of times this table has been vacuumed by autovacuum
+        - name: analyze_count
+          type: counter
+          description: Number of times this table has been manually analyzed
+        - name: autoanalyze_count
+          type: counter
+          description: Number of times this table has been analyzed by autoanalyze
+    tag: pg_stat_user_tables_vacuum
+    sort: data
+    collector: stat_user_tables
+    database: all
 #
 # PostgreSQL 14
 #

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -726,6 +726,191 @@ metrics:
     tag: pg_stat_progress_vacuum
     sort: data
     collector: vacuum_progress
+# Table-level vacuum and analyze statistics
+  - queries:
+    - query: SELECT
+                schemaname,
+                relname,
+                n_live_tup,
+                n_dead_tup,
+                CASE 
+                  WHEN n_live_tup > 0 
+                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
+                  ELSE 0
+                END AS dead_rows_pct,
+                n_mod_since_analyze,
+                n_ins_since_vacuum,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
+                vacuum_count,
+                autovacuum_count,
+                analyze_count,
+                autoanalyze_count
+              FROM pg_stat_user_tables
+              ORDER BY n_dead_tup DESC;
+      version: 13
+      columns:
+        - name: schemaname
+          type: label
+        - name: relname
+          type: label
+        - name: n_live_tup
+          type: gauge
+          description: Estimated number of live rows
+        - name: n_dead_tup
+          type: gauge
+          description: Estimated number of dead rows
+        - name: dead_rows_pct
+          type: gauge
+          description: Percentage of dead rows relative to live rows
+        - name: n_mod_since_analyze
+          type: gauge
+          description: Estimated number of rows modified since last analyze
+        - name: n_ins_since_vacuum
+          type: gauge
+          description: Estimated number of rows inserted since last vacuum
+        - name: last_vacuum_seconds
+          type: gauge
+          description: Seconds since last manual vacuum (-1 if never)
+        - name: last_autovacuum_seconds
+          type: gauge
+          description: Seconds since last autovacuum (-1 if never)
+        - name: last_analyze_seconds
+          type: gauge
+          description: Seconds since last manual analyze (-1 if never)
+        - name: last_autoanalyze_seconds
+          type: gauge
+          description: Seconds since last autoanalyze (-1 if never)
+        - name: vacuum_count
+          type: counter
+          description: Number of times this table has been manually vacuumed
+        - name: autovacuum_count
+          type: counter
+          description: Number of times this table has been vacuumed by autovacuum
+        - name: analyze_count
+          type: counter
+          description: Number of times this table has been manually analyzed
+        - name: autoanalyze_count
+          type: counter
+          description: Number of times this table has been analyzed by autoanalyze
+
+    - query: SELECT
+                schemaname,
+                relname,
+                seq_scan,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds,
+                seq_tup_read,
+                idx_scan,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds,
+                idx_tup_fetch,
+                n_tup_ins,
+                n_tup_upd,
+                n_tup_del,
+                n_tup_hot_upd,
+                n_tup_newpage_upd,
+                n_live_tup,
+                n_dead_tup,
+                CASE 
+                  WHEN n_live_tup > 0 
+                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
+                  ELSE 0
+                END AS dead_rows_pct,
+                n_mod_since_analyze,
+                n_ins_since_vacuum,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
+                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
+                vacuum_count,
+                autovacuum_count,
+                analyze_count,
+                autoanalyze_count
+              FROM pg_stat_user_tables
+              ORDER BY n_dead_tup DESC;
+      version: 16
+      columns:
+        - name: schemaname
+          type: label
+        - name: relname
+          type: label
+        - name: seq_scan
+          type: counter
+          description: Number of sequential scans initiated on this table
+        - name: last_seq_scan_seconds
+          type: gauge
+          description: Seconds since last sequential scan (-1 if never)
+        - name: seq_tup_read
+          type: counter
+          description: Number of live rows fetched by sequential scans
+        - name: idx_scan
+          type: counter
+          description: Number of index scans initiated on this table
+        - name: last_idx_scan_seconds
+          type: gauge
+          description: Seconds since last index scan (-1 if never)
+        - name: idx_tup_fetch
+          type: counter
+          description: Number of live rows fetched by index scans
+        - name: n_tup_ins
+          type: counter
+          description: Number of rows inserted
+        - name: n_tup_upd
+          type: counter
+          description: Number of rows updated
+        - name: n_tup_del
+          type: counter
+          description: Number of rows deleted
+        - name: n_tup_hot_upd
+          type: counter
+          description: Number of rows HOT updated
+        - name: n_tup_newpage_upd
+          type: counter
+          description: Number of rows updated where successor goes to new heap page
+        - name: n_live_tup
+          type: gauge
+          description: Estimated number of live rows
+        - name: n_dead_tup
+          type: gauge
+          description: Estimated number of dead rows
+        - name: dead_rows_pct
+          type: gauge
+          description: Percentage of dead rows relative to live rows
+        - name: n_mod_since_analyze
+          type: gauge
+          description: Estimated number of rows modified since last analyze
+        - name: n_ins_since_vacuum
+          type: gauge
+          description: Estimated number of rows inserted since last vacuum
+        - name: last_vacuum_seconds
+          type: gauge
+          description: Seconds since last manual vacuum (-1 if never)
+        - name: last_autovacuum_seconds
+          type: gauge
+          description: Seconds since last autovacuum (-1 if never)
+        - name: last_analyze_seconds
+          type: gauge
+          description: Seconds since last manual analyze (-1 if never)
+        - name: last_autoanalyze_seconds
+          type: gauge
+          description: Seconds since last autoanalyze (-1 if never)
+        - name: vacuum_count
+          type: counter
+          description: Number of times this table has been manually vacuumed
+        - name: autovacuum_count
+          type: counter
+          description: Number of times this table has been vacuumed by autovacuum
+        - name: analyze_count
+          type: counter
+          description: Number of times this table has been manually analyzed
+        - name: autoanalyze_count
+          type: counter
+          description: Number of times this table has been analyzed by autoanalyze
+    tag: pg_stat_user_tables_vacuum
+    sort: data
+    collector: stat_user_tables
+    database: all
 #
 # PostgreSQL 14
 #

--- a/doc/manual/en/06-prometheus.md
+++ b/doc/manual/en/06-prometheus.md
@@ -38,6 +38,7 @@
 * `pg_encrypted_conn`
 * `pg_shmem_allocations`
 * `pg_stat_progress_vacuum`
+* `pg_stat_user_tables_vacuum`
 * `pg_stat_statements_total_exec_time`
 * `pg_stat_statements_plans`
 * `pg_stat_statements_wal_bytes`

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -808,6 +808,192 @@ extern "C" {
         "    sort: data\n" \
         "    collector: vacuum_progress\n" \
         "\n" \
+        "# Table-level vacuum and analyze statistics\n" \
+        "  - queries:\n" \
+        "    - query: SELECT\n" \
+        "                schemaname,\n" \
+        "                relname,\n" \
+        "                n_live_tup,\n" \
+        "                n_dead_tup,\n" \
+        "                CASE \n" \
+        "                  WHEN n_live_tup > 0 \n" \
+        "                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)\n" \
+        "                  ELSE 0\n" \
+        "                END AS dead_rows_pct,\n" \
+        "                n_mod_since_analyze,\n" \
+        "                n_ins_since_vacuum,\n" \
+        "                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,\n" \
+        "                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,\n" \
+        "                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,\n" \
+        "                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,\n" \
+        "                vacuum_count,\n" \
+        "                autovacuum_count,\n" \
+        "                analyze_count,\n" \
+        "                autoanalyze_count\n" \
+        "              FROM pg_stat_user_tables\n" \
+        "              ORDER BY n_dead_tup DESC;\n" \
+        "      version: 13\n" \
+        "      columns:\n" \
+        "        - name: schemaname\n" \
+        "          type: label\n" \
+        "        - name: relname\n" \
+        "          type: label\n" \
+        "        - name: n_live_tup\n" \
+        "          type: gauge\n" \
+        "          description: Estimated number of live rows\n" \
+        "        - name: n_dead_tup\n" \
+        "          type: gauge\n" \
+        "          description: Estimated number of dead rows\n" \
+        "        - name: dead_rows_pct\n" \
+        "          type: gauge\n" \
+        "          description: Percentage of dead rows relative to live rows\n" \
+        "        - name: n_mod_since_analyze\n" \
+        "          type: gauge\n" \
+        "          description: Estimated number of rows modified since last analyze\n" \
+        "        - name: n_ins_since_vacuum\n" \
+        "          type: gauge\n" \
+        "          description: Estimated number of rows inserted since last vacuum\n" \
+        "        - name: last_vacuum_seconds\n" \
+        "          type: gauge\n" \
+        "          description: Seconds since last manual vacuum (-1 if never)\n" \
+        "        - name: last_autovacuum_seconds\n" \
+        "          type: gauge\n" \
+        "          description: Seconds since last autovacuum (-1 if never)\n" \
+        "        - name: last_analyze_seconds\n" \
+        "          type: gauge\n" \
+        "          description: Seconds since last manual analyze (-1 if never)\n" \
+        "        - name: last_autoanalyze_seconds\n" \
+        "          type: gauge\n" \
+        "          description: Seconds since last autoanalyze (-1 if never)\n" \
+        "        - name: vacuum_count\n" \
+        "          type: counter\n" \
+        "          description: Number of times this table has been manually vacuumed\n" \
+        "        - name: autovacuum_count\n" \
+        "          type: counter\n" \
+        "          description: Number of times this table has been vacuumed by autovacuum\n" \
+        "        - name: analyze_count\n" \
+        "          type: counter\n" \
+        "          description: Number of times this table has been manually analyzed\n" \
+        "        - name: autoanalyze_count\n" \
+        "          type: counter\n" \
+        "          description: Number of times this table has been analyzed by autoanalyze\n" \
+        "\n" \
+        "    - query: SELECT\n" \
+        "                schemaname,\n" \
+        "                relname,\n" \
+        "                seq_scan,\n" \
+        "                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds,\n" \
+        "                seq_tup_read,\n" \
+        "                idx_scan,\n" \
+        "                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds,\n" \
+        "                idx_tup_fetch,\n" \
+        "                n_tup_ins,\n" \
+        "                n_tup_upd,\n" \
+        "                n_tup_del,\n" \
+        "                n_tup_hot_upd,\n" \
+        "                n_tup_newpage_upd,\n" \
+        "                n_live_tup,\n" \
+        "                n_dead_tup,\n" \
+        "                CASE \n" \
+        "                  WHEN n_live_tup > 0 \n" \
+        "                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)\n" \
+        "                  ELSE 0\n" \
+        "                END AS dead_rows_pct,\n" \
+        "                n_mod_since_analyze,\n" \
+        "                n_ins_since_vacuum,\n" \
+        "                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,\n" \
+        "                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,\n" \
+        "                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,\n" \
+        "                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,\n" \
+        "                vacuum_count,\n" \
+        "                autovacuum_count,\n" \
+        "                analyze_count,\n" \
+        "                autoanalyze_count\n" \
+        "              FROM pg_stat_user_tables\n" \
+        "              ORDER BY n_dead_tup DESC;\n" \
+        "      version: 16\n" \
+        "      columns:\n" \
+        "        - name: schemaname\n" \
+        "          type: label\n" \
+        "        - name: relname\n" \
+        "          type: label\n" \
+        "        - name: seq_scan\n" \
+        "          type: counter\n" \
+        "          description: Number of sequential scans initiated on this table\n" \
+        "        - name: last_seq_scan_seconds\n" \
+        "          type: gauge\n" \
+        "          description: Seconds since last sequential scan (-1 if never)\n" \
+        "        - name: seq_tup_read\n" \
+        "          type: counter\n" \
+        "          description: Number of live rows fetched by sequential scans\n" \
+        "        - name: idx_scan\n" \
+        "          type: counter\n" \
+        "          description: Number of index scans initiated on this table\n" \
+        "        - name: last_idx_scan_seconds\n" \
+        "          type: gauge\n" \
+        "          description: Seconds since last index scan (-1 if never)\n" \
+        "        - name: idx_tup_fetch\n" \
+        "          type: counter\n" \
+        "          description: Number of live rows fetched by index scans\n" \
+        "        - name: n_tup_ins\n" \
+        "          type: counter\n" \
+        "          description: Number of rows inserted\n" \
+        "        - name: n_tup_upd\n" \
+        "          type: counter\n" \
+        "          description: Number of rows updated\n" \
+        "        - name: n_tup_del\n" \
+        "          type: counter\n" \
+        "          description: Number of rows deleted\n" \
+        "        - name: n_tup_hot_upd\n" \
+        "          type: counter\n" \
+        "          description: Number of rows HOT updated\n" \
+        "        - name: n_tup_newpage_upd\n" \
+        "          type: counter\n" \
+        "          description: Number of rows updated where successor goes to new heap page\n" \
+        "        - name: n_live_tup\n" \
+        "          type: gauge\n" \
+        "          description: Estimated number of live rows\n" \
+        "        - name: n_dead_tup\n" \
+        "          type: gauge\n" \
+        "          description: Estimated number of dead rows\n" \
+        "        - name: dead_rows_pct\n" \
+        "          type: gauge\n" \
+        "          description: Percentage of dead rows relative to live rows\n" \
+        "        - name: n_mod_since_analyze\n" \
+        "          type: gauge\n" \
+        "          description: Estimated number of rows modified since last analyze\n" \
+        "        - name: n_ins_since_vacuum\n" \
+        "          type: gauge\n" \
+        "          description: Estimated number of rows inserted since last vacuum\n" \
+        "        - name: last_vacuum_seconds\n" \
+        "          type: gauge\n" \
+        "          description: Seconds since last manual vacuum (-1 if never)\n" \
+        "        - name: last_autovacuum_seconds\n" \
+        "          type: gauge\n" \
+        "          description: Seconds since last autovacuum (-1 if never)\n" \
+        "        - name: last_analyze_seconds\n" \
+        "          type: gauge\n" \
+        "          description: Seconds since last manual analyze (-1 if never)\n" \
+        "        - name: last_autoanalyze_seconds\n" \
+        "          type: gauge\n" \
+        "          description: Seconds since last autoanalyze (-1 if never)\n" \
+        "        - name: vacuum_count\n" \
+        "          type: counter\n" \
+        "          description: Number of times this table has been manually vacuumed\n" \
+        "        - name: autovacuum_count\n" \
+        "          type: counter\n" \
+        "          description: Number of times this table has been vacuumed by autovacuum\n" \
+        "        - name: analyze_count\n" \
+        "          type: counter\n" \
+        "          description: Number of times this table has been manually analyzed\n" \
+        "        - name: autoanalyze_count\n" \
+        "          type: counter\n" \
+        "          description: Number of times this table has been analyzed by autoanalyze\n" \
+        "    tag: pg_stat_user_tables_vacuum\n" \
+        "    sort: data\n" \
+        "    collector: stat_user_tables\n" \
+        "    database: all\n" \
+        "\n" \
         "#\n" \
         "# PostgreSQL 14\n" \
         "#\n" \


### PR DESCRIPTION
Addressing #291. Did run into limits with MISC_LENGTH so kept the descriptions abit short. I think the defaults in this case are `-1` wherever applicable. Have taken a note of this since it could be helpful for later.

PTAL @jesperpedersen @resyfer 