### PR TITLE
Add metric for blocked vacuum

### DIFF
--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -1149,6 +1149,61 @@
       "sort": "data",
       "collector": "table_bloat",
       "database": "all"
+    },
+    {
+      "queries": [
+        {
+          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "version": 10,
+          "columns": [
+            {
+              "name": "blocked_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocked_database",
+              "type": "label"
+            },
+            {
+              "name": "blocked_user",
+              "type": "label"
+            },
+            {
+              "name": "blocked_query",
+              "type": "label"
+            },
+            {
+              "name": "blocked_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the vacuum has been blocked"
+            },
+            {
+              "name": "blocking_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocking_database",
+              "type": "label"
+            },
+            {
+              "name": "blocking_user",
+              "type": "label"
+            },
+            {
+              "name": "blocking_query",
+              "type": "label"
+            },
+            {
+              "name": "blocking_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the blocking query has been running"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_blocked_vacuum",
+      "sort": "data",
+      "collector": "blocked_vacuum"
     }
   ]
 }

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -1364,6 +1364,61 @@
       "sort": "data",
       "collector": "table_bloat",
       "database": "all"
+    },
+    {
+      "queries": [
+        {
+          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "version": 10,
+          "columns": [
+            {
+              "name": "blocked_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocked_database",
+              "type": "label"
+            },
+            {
+              "name": "blocked_user",
+              "type": "label"
+            },
+            {
+              "name": "blocked_query",
+              "type": "label"
+            },
+            {
+              "name": "blocked_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the vacuum has been blocked"
+            },
+            {
+              "name": "blocking_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocking_database",
+              "type": "label"
+            },
+            {
+              "name": "blocking_user",
+              "type": "label"
+            },
+            {
+              "name": "blocking_query",
+              "type": "label"
+            },
+            {
+              "name": "blocking_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the blocking query has been running"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_blocked_vacuum",
+      "sort": "data",
+      "collector": "blocked_vacuum"
     }
   ]
 }

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -1382,6 +1382,61 @@
       "sort": "data",
       "collector": "table_bloat",
       "database": "all"
+    },
+    {
+      "queries": [
+        {
+          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "version": 10,
+          "columns": [
+            {
+              "name": "blocked_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocked_database",
+              "type": "label"
+            },
+            {
+              "name": "blocked_user",
+              "type": "label"
+            },
+            {
+              "name": "blocked_query",
+              "type": "label"
+            },
+            {
+              "name": "blocked_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the vacuum has been blocked"
+            },
+            {
+              "name": "blocking_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocking_database",
+              "type": "label"
+            },
+            {
+              "name": "blocking_user",
+              "type": "label"
+            },
+            {
+              "name": "blocking_query",
+              "type": "label"
+            },
+            {
+              "name": "blocking_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the blocking query has been running"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_blocked_vacuum",
+      "sort": "data",
+      "collector": "blocked_vacuum"
     }
   ]
 }

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -1685,6 +1685,61 @@
       "sort": "data",
       "collector": "table_bloat",
       "database": "all"
+    },
+    {
+      "queries": [
+        {
+          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "version": 10,
+          "columns": [
+            {
+              "name": "blocked_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocked_database",
+              "type": "label"
+            },
+            {
+              "name": "blocked_user",
+              "type": "label"
+            },
+            {
+              "name": "blocked_query",
+              "type": "label"
+            },
+            {
+              "name": "blocked_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the vacuum has been blocked"
+            },
+            {
+              "name": "blocking_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocking_database",
+              "type": "label"
+            },
+            {
+              "name": "blocking_user",
+              "type": "label"
+            },
+            {
+              "name": "blocking_query",
+              "type": "label"
+            },
+            {
+              "name": "blocking_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the blocking query has been running"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_blocked_vacuum",
+      "sort": "data",
+      "collector": "blocked_vacuum"
     }
   ]
 }

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -1752,6 +1752,61 @@
       "sort": "data",
       "collector": "table_bloat",
       "database": "all"
+    },
+    {
+      "queries": [
+        {
+          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "version": 10,
+          "columns": [
+            {
+              "name": "blocked_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocked_database",
+              "type": "label"
+            },
+            {
+              "name": "blocked_user",
+              "type": "label"
+            },
+            {
+              "name": "blocked_query",
+              "type": "label"
+            },
+            {
+              "name": "blocked_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the vacuum has been blocked"
+            },
+            {
+              "name": "blocking_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocking_database",
+              "type": "label"
+            },
+            {
+              "name": "blocking_user",
+              "type": "label"
+            },
+            {
+              "name": "blocking_query",
+              "type": "label"
+            },
+            {
+              "name": "blocking_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the blocking query has been running"
+            }
+          ]
+        }
+      ],
+      "tag": "pg_blocked_vacuum",
+      "sort": "data",
+      "collector": "blocked_vacuum"
     }
   ]
 }

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -606,7 +606,55 @@ metrics:
     tag: pg_view_vacuum
     sort: data
     collector: db_vacuum
-
+# Blocked vacuum operations
+  - queries:
+    - query: SELECT
+                blocked.pid AS blocked_pid,
+                blocked.datname AS blocked_database,
+                blocked.usename AS blocked_user,
+                blocked.query AS blocked_query,
+                EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds,
+                blocking.pid AS blocking_pid,
+                blocking.datname AS blocking_database,
+                blocking.usename AS blocking_user,
+                blocking.query AS blocking_query,
+                EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds
+              FROM pg_stat_activity blocked
+              JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
+              JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation
+                AND blocked_locks.pid != blocking_locks.pid
+              JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid
+              WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%')
+                AND NOT blocked_locks.granted
+                AND blocking_locks.granted
+              ORDER BY blocked_duration_seconds DESC;
+      version: 10
+      columns:
+        - name: blocked_pid
+          type: label
+        - name: blocked_database
+          type: label
+        - name: blocked_user
+          type: label
+        - name: blocked_query
+          type: label
+        - name: blocked_duration_seconds
+          type: gauge
+          description: Duration in seconds that the vacuum has been blocked
+        - name: blocking_pid
+          type: label
+        - name: blocking_database
+          type: label
+        - name: blocking_user
+          type: label
+        - name: blocking_query
+          type: label
+        - name: blocking_duration_seconds
+          type: gauge
+          description: Duration in seconds that the blocking query has been running
+    tag: pg_blocked_vacuum
+    sort: data
+    collector: blocked_vacuum
 #
 # PostgreSQL 11
 #

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -606,7 +606,55 @@ metrics:
     tag: pg_view_vacuum
     sort: data
     collector: db_vacuum
-
+# Blocked vacuum operations
+  - queries:
+    - query: SELECT
+                blocked.pid AS blocked_pid,
+                blocked.datname AS blocked_database,
+                blocked.usename AS blocked_user,
+                blocked.query AS blocked_query,
+                EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds,
+                blocking.pid AS blocking_pid,
+                blocking.datname AS blocking_database,
+                blocking.usename AS blocking_user,
+                blocking.query AS blocking_query,
+                EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds
+              FROM pg_stat_activity blocked
+              JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
+              JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation
+                AND blocked_locks.pid != blocking_locks.pid
+              JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid
+              WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%')
+                AND NOT blocked_locks.granted
+                AND blocking_locks.granted
+              ORDER BY blocked_duration_seconds DESC;
+      version: 10
+      columns:
+        - name: blocked_pid
+          type: label
+        - name: blocked_database
+          type: label
+        - name: blocked_user
+          type: label
+        - name: blocked_query
+          type: label
+        - name: blocked_duration_seconds
+          type: gauge
+          description: Duration in seconds that the vacuum has been blocked
+        - name: blocking_pid
+          type: label
+        - name: blocking_database
+          type: label
+        - name: blocking_user
+          type: label
+        - name: blocking_query
+          type: label
+        - name: blocking_duration_seconds
+          type: gauge
+          description: Duration in seconds that the blocking query has been running
+    tag: pg_blocked_vacuum
+    sort: data
+    collector: blocked_vacuum
 #
 # PostgreSQL 11
 #

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -606,7 +606,55 @@ metrics:
     tag: pg_view_vacuum
     sort: data
     collector: db_vacuum
-
+# Blocked vacuum operations
+  - queries:
+    - query: SELECT
+                blocked.pid AS blocked_pid,
+                blocked.datname AS blocked_database,
+                blocked.usename AS blocked_user,
+                blocked.query AS blocked_query,
+                EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds,
+                blocking.pid AS blocking_pid,
+                blocking.datname AS blocking_database,
+                blocking.usename AS blocking_user,
+                blocking.query AS blocking_query,
+                EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds
+              FROM pg_stat_activity blocked
+              JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
+              JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation
+                AND blocked_locks.pid != blocking_locks.pid
+              JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid
+              WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%')
+                AND NOT blocked_locks.granted
+                AND blocking_locks.granted
+              ORDER BY blocked_duration_seconds DESC;
+      version: 10
+      columns:
+        - name: blocked_pid
+          type: label
+        - name: blocked_database
+          type: label
+        - name: blocked_user
+          type: label
+        - name: blocked_query
+          type: label
+        - name: blocked_duration_seconds
+          type: gauge
+          description: Duration in seconds that the vacuum has been blocked
+        - name: blocking_pid
+          type: label
+        - name: blocking_database
+          type: label
+        - name: blocking_user
+          type: label
+        - name: blocking_query
+          type: label
+        - name: blocking_duration_seconds
+          type: gauge
+          description: Duration in seconds that the blocking query has been running
+    tag: pg_blocked_vacuum
+    sort: data
+    collector: blocked_vacuum
 #
 # PostgreSQL 11
 #

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -545,7 +545,55 @@ metrics:
     tag: pg_view_vacuum
     sort: data
     collector: db_vacuum
-
+# Blocked vacuum operations
+  - queries:
+    - query: SELECT
+                blocked.pid AS blocked_pid,
+                blocked.datname AS blocked_database,
+                blocked.usename AS blocked_user,
+                blocked.query AS blocked_query,
+                EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds,
+                blocking.pid AS blocking_pid,
+                blocking.datname AS blocking_database,
+                blocking.usename AS blocking_user,
+                blocking.query AS blocking_query,
+                EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds
+              FROM pg_stat_activity blocked
+              JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
+              JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation
+                AND blocked_locks.pid != blocking_locks.pid
+              JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid
+              WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%')
+                AND NOT blocked_locks.granted
+                AND blocking_locks.granted
+              ORDER BY blocked_duration_seconds DESC;
+      version: 10
+      columns:
+        - name: blocked_pid
+          type: label
+        - name: blocked_database
+          type: label
+        - name: blocked_user
+          type: label
+        - name: blocked_query
+          type: label
+        - name: blocked_duration_seconds
+          type: gauge
+          description: Duration in seconds that the vacuum has been blocked
+        - name: blocking_pid
+          type: label
+        - name: blocking_database
+          type: label
+        - name: blocking_user
+          type: label
+        - name: blocking_query
+          type: label
+        - name: blocking_duration_seconds
+          type: gauge
+          description: Duration in seconds that the blocking query has been running
+    tag: pg_blocked_vacuum
+    sort: data
+    collector: blocked_vacuum
 #
 # PostgreSQL 11
 #

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -517,7 +517,55 @@ metrics:
     tag: pg_view_vacuum
     sort: data
     collector: db_vacuum
-
+# Blocked vacuum operations
+  - queries:
+    - query: SELECT
+                blocked.pid AS blocked_pid,
+                blocked.datname AS blocked_database,
+                blocked.usename AS blocked_user,
+                blocked.query AS blocked_query,
+                EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds,
+                blocking.pid AS blocking_pid,
+                blocking.datname AS blocking_database,
+                blocking.usename AS blocking_user,
+                blocking.query AS blocking_query,
+                EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds
+              FROM pg_stat_activity blocked
+              JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
+              JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation
+                AND blocked_locks.pid != blocking_locks.pid
+              JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid
+              WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%')
+                AND NOT blocked_locks.granted
+                AND blocking_locks.granted
+              ORDER BY blocked_duration_seconds DESC;
+      version: 10
+      columns:
+        - name: blocked_pid
+          type: label
+        - name: blocked_database
+          type: label
+        - name: blocked_user
+          type: label
+        - name: blocked_query
+          type: label
+        - name: blocked_duration_seconds
+          type: gauge
+          description: Duration in seconds that the vacuum has been blocked
+        - name: blocking_pid
+          type: label
+        - name: blocking_database
+          type: label
+        - name: blocking_user
+          type: label
+        - name: blocking_query
+          type: label
+        - name: blocking_duration_seconds
+          type: gauge
+          description: Duration in seconds that the blocking query has been running
+    tag: pg_blocked_vacuum
+    sort: data
+    collector: blocked_vacuum
 #
 # PostgreSQL 11
 #

--- a/doc/manual/en/06-prometheus.md
+++ b/doc/manual/en/06-prometheus.md
@@ -33,6 +33,7 @@
 * `pg_stat_archiver`
 * `pg_db_vacuum`
 * `pg_view_vacuum`
+* `pg_blocked_vacuum`
 * `pg_wal_last_received`
 * `pg_gss_auth`
 * `pg_encrypted_conn`


### PR DESCRIPTION
Addressing #292 . Shows info (duration, pid, query) for blocker and blocked sessions. Output:
```
#HELP pgexporter_pg_blocked_vacuum_blocked_duration_seconds Duration in seconds that the vacuum has been blocked
#TYPE pgexporter_pg_blocked_vacuum_blocked_duration_seconds gauge
pgexporter_pg_blocked_vacuum_blocked_duration_seconds{server="primary", blocked_pid="118609", blocked_database="postgres", blocked_user="bassam", blocked_query="VACUUM big_table;", blocking_pid="26384", blocking_database="postgres", blocking_user="bassam", blocking_query="LOCK TABLE big_table IN ACCESS EXCLUSIVE MODE;", database="postgres"} 9

#HELP pgexporter_pg_blocked_vacuum_blocking_duration_seconds Duration in seconds that the blocking query has been running
#TYPE pgexporter_pg_blocked_vacuum_blocking_duration_seconds gauge
pgexporter_pg_blocked_vacuum_blocking_duration_seconds{server="primary", blocked_pid="118609", blocked_database="postgres", blocked_user="bassam", blocked_query="VACUUM big_table;", blocking_pid="26384", blocking_database="postgres", blocking_user="bassam", blocking_query="LOCK TABLE big_table IN ACCESS EXCLUSIVE MODE;", database="postgres"} 26
```

To reproduce here is what I did:
```sql
CREATE TABLE big_table AS
SELECT
    g AS id,
    repeat('ABCDEFGHIJKLMNOPQRSTUVWXYZ', 10) AS filler
FROM generate_series(1, 5000000) g; -- ~5 million rows

UPDATE big_table SET filler = filler || 'X';
```
Then do: 
```sql
BEGIN;
LOCK TABLE big_table IN ACCESS EXCLUSIVE MODE;
```

In  a new `psql` session run `VACUUM big_table;` before hitting curl on `pgexporter` endpoint.

TODO: Add default for this as part of #307.