### PR TITLE
[#331] Add type configuration

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -63,21 +63,29 @@ See a [sample](./etc/pgexporter.conf) configuration for running `pgexporter` on 
 
 ## Server section
 
-| Property | Default | Unit | Required | Description |
-|----------|---------|------|----------|-------------|
-| host | | String | Yes | The address of the PostgreSQL instance |
-| port | | Int | Yes | The port of the PostgreSQL instance |
-| user | | String | Yes | The user name |
-| data_dir | | String | No | The location of the data directory |
-| wal_dir | | String | No | The location of the WAL directory |
-| tls_cert_file | | String | No | Certificate file for TLS. This file must be owned by either the user running pgexporter or root. Can interpolate environment variables (e.g., `$HOME`) |
-| tls_key_file | | String | No | Private key file for TLS. This file must be owned by either the user running pgexporter or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. Can interpolate environment variables (e.g., `$HOME`) |
-| tls_ca_file | | String | No | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgexporter or root. Can interpolate environment variables (e.g., `$HOME`) |
-| extensions | | String | No | Comma-separated list of extensions to enable for this specific server. Overrides global extensions setting. If specified, only listed extensions will be enabled. If empty, all extensions are disabled for this server. |
+| Property | Default | Unit | Required | Applies To | Description |
+|----------|---------|------|----------|------------|-------------|
+| host | | String | Yes | All | The address of the PostgreSQL instance or Prometheus endpoint |
+| port | | Int | Yes | All | The port of the PostgreSQL instance or Prometheus endpoint |
+| type | postgresql | String | No | All | The server type: `postgresql` or `prometheus` |
+| user | | String | Conditional | PostgreSQL | The user name. Required for `postgresql` type |
+| data_dir | | String | No | PostgreSQL | The location of the data directory |
+| wal_dir | | String | No | PostgreSQL | The location of the WAL directory |
+| tls_cert_file | | String | No | All | Certificate file for TLS. This file must be owned by either the user running pgexporter or root. Can interpolate environment variables (e.g., `$HOME`) |
+| tls_key_file | | String | No | All | Private key file for TLS. This file must be owned by either the user running pgexporter or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. Can interpolate environment variables (e.g., `$HOME`) |
+| tls_ca_file | | String | No | All | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgexporter or root. Can interpolate environment variables (e.g., `$HOME`) |
+| extensions | | String | No | PostgreSQL | Comma-separated list of extensions to enable for this specific server. Overrides global extensions setting. If specified, only listed extensions will be enabled. If empty, all extensions are disabled for this server. |
 
-Note, that PostgreSQL 13+ is required.
+Note, that PostgreSQL 13+ is required for PostgreSQL servers.
 
 Note, that if `host` starts with a `/` it represents a path and `pgexporter` will connect using a Unix Domain Socket.
+
+## Server Types
+
+The `type` property defines how pgexporter interacts with the server:
+
+- **`postgresql`** (default): PostgreSQL database server for direct metrics collection. Requires `user` property and establishes database connections.
+- **`prometheus`**: Prometheus-compatible HTTP endpoint for metrics scraping. No `user` property required. Metrics pass through unchanged.
 
 ## Extension Configuration
 

--- a/doc/manual/en/04-configuration.md
+++ b/doc/manual/en/04-configuration.md
@@ -63,21 +63,29 @@ See a [sample][sample] configuration for running [**pgexporter**][pgexporter] on
 
 ## Server section
 
-| Property       | Default | Unit | Required | Description |
-|----------------|---------|------|----------|-------------|
-| host | | String | Yes | The address of the PostgreSQL instance |
-| port | | Int | Yes | The port of the PostgreSQL instance |
-| user | | String | Yes | The user name |
-| data_dir | | String | No | The location of the data directory |
-| wal_dir | | String | No | The location of the WAL directory |
-| tls_cert_file | | String | No | Certificate file for TLS. This file must be owned by either the user running pgexporter or root. |
-| tls_key_file | | String | No | Private key file for TLS. This file must be owned by either the user running pgexporter or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. |
-| tls_ca_file | | String | No | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgexporter or root.  |
-| extensions | | String | No | Comma-separated list of extensions to enable for this specific server. Overrides global extensions setting. If specified, only listed extensions will be enabled. If empty, all extensions are disabled for this server. |
+| Property       | Default | Unit | Required | Applies To | Description |
+|----------------|---------|------|----------|------------|-------------|
+| host | | String | Yes | All | The address of the PostgreSQL instance or Prometheus endpoint |
+| port | | Int | Yes | All | The port of the PostgreSQL instance or Prometheus endpoint |
+| type | postgresql | String | No | All | The server type: `postgresql` or `prometheus` |
+| user | | String | Conditional | PostgreSQL | The user name. Required for `postgresql` type |
+| data_dir | | String | No | PostgreSQL | The location of the data directory |
+| wal_dir | | String | No | PostgreSQL | The location of the WAL directory |
+| tls_cert_file | | String | No | All | Certificate file for TLS. This file must be owned by either the user running pgexporter or root. |
+| tls_key_file | | String | No | All | Private key file for TLS. This file must be owned by either the user running pgexporter or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. |
+| tls_ca_file | | String | No | All | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgexporter or root.  |
+| extensions | | String | No | PostgreSQL | Comma-separated list of extensions to enable for this specific server. Overrides global extensions setting. If specified, only listed extensions will be enabled. If empty, all extensions are disabled for this server. |
 
-Note, that PostgreSQL 13+ is required.
+Note, that PostgreSQL 13+ is required for PostgreSQL servers.
 
 Note, that if `host` starts with a `/` it represents a path and [**pgexporter**][pgexporter] will connect using a Unix Domain Socket.
+
+## Server Types
+
+The `type` property defines how [**pgexporter**][pgexporter] interacts with the server:
+
+- **`postgresql`** (default): PostgreSQL database server for direct metrics collection. Requires `user` property and establishes database connections.
+- **`prometheus`**: Prometheus-compatible HTTP endpoint for metrics scraping. No `user` property required. Metrics pass through unchanged.
 
 ## Extension Configuration
 

--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -83,6 +83,9 @@ extern "C" {
 #define SERVER_PRIMARY 1
 #define SERVER_REPLICA 2
 
+#define SERVER_TYPE_POSTGRESQL 0
+#define SERVER_TYPE_PROMETHEUS 1
+
 #define AUTH_SUCCESS      0
 #define AUTH_BAD_PASSWORD 1
 #define AUTH_ERROR        2
@@ -255,6 +258,7 @@ struct server
    char name[MISC_LENGTH];                                      /**< The name of the server */
    char host[MISC_LENGTH];                                      /**< The host name of the server */
    int port;                                                    /**< The port of the server */
+   int type;                                                    /**< The server type */
    char username[MAX_USERNAME_LENGTH];                          /**< The user name */
    char data[MISC_LENGTH];                                      /**< The data directory */
    char wal[MISC_LENGTH];                                       /**< The WAL directory */

--- a/src/include/queries.h
+++ b/src/include/queries.h
@@ -102,7 +102,6 @@ pgexporter_open_connections(void);
 void
 pgexporter_close_connections(void);
 
-
 /**
  * Execute query
  * @param server The server
@@ -113,7 +112,6 @@ pgexporter_close_connections(void);
  */
 int
 pgexporter_query_execute(int server, char* sql, char* tag, struct query** query);
-
 
 /**
  * Query PostgreSQL version

--- a/src/libpgexporter/queries.c
+++ b/src/libpgexporter/queries.c
@@ -64,14 +64,14 @@ pgexporter_check_pg_monitor_role(int server)
 
    if (config->servers[server].fd == -1)
    {
-      pgexporter_log_error("Cannot check pg_monitor role: no active connection to server '%s'", 
+      pgexporter_log_error("Cannot check pg_monitor role: no active connection to server '%s'",
                            &config->servers[server].name[0]);
       return 1;
    }
 
-   if (pgexporter_query_execute(server, 
-                               "SELECT pg_has_role(current_user, 'pg_monitor', 'USAGE') AS has_pg_monitor;",
-                               "pg_monitor_check", &q) == 0 && q != NULL)
+   if (pgexporter_query_execute(server,
+                                "SELECT pg_has_role(current_user, 'pg_monitor', 'USAGE') AS has_pg_monitor;",
+                                "pg_monitor_check", &q) == 0 && q != NULL)
    {
       if (q->tuples != NULL && q->tuples->data != NULL && q->tuples->data[0] != NULL)
       {
@@ -83,10 +83,10 @@ pgexporter_check_pg_monitor_role(int server)
          else
          {
             pgexporter_log_error("User '%s' lacks pg_monitor role on server '%s'. "
-                                "Grant pg_monitor role: GRANT pg_monitor TO %s;", 
-                                &config->servers[server].username[0],
-                                &config->servers[server].name[0],
-                                &config->servers[server].username[0]);
+                                 "Grant pg_monitor role: GRANT pg_monitor TO %s;",
+                                 &config->servers[server].username[0],
+                                 &config->servers[server].name[0],
+                                 &config->servers[server].username[0]);
             ret = 1;
          }
       }
@@ -96,7 +96,7 @@ pgexporter_check_pg_monitor_role(int server)
                               &config->servers[server].name[0]);
          ret = 1;
       }
-      
+
       pgexporter_free_query(q);
    }
    else
@@ -121,6 +121,11 @@ pgexporter_open_connections(void)
 
    for (int server = 0; server < config->number_of_servers; server++)
    {
+      if (config->servers[server].type == SERVER_TYPE_PROMETHEUS)
+      {
+         continue;
+      }
+
       if (config->servers[server].fd != -1)
       {
          if (!pgexporter_connection_isvalid(config->servers[server].ssl, config->servers[server].fd))
@@ -159,8 +164,8 @@ pgexporter_open_connections(void)
 
             if (pgexporter_check_pg_monitor_role(server) != 0)
             {
-               pgexporter_log_fatal("Server '%s': pg_monitor role check failed. pgexporter cannot function without proper permissions.", 
-                                   &config->servers[server].name[0]);
+               pgexporter_log_fatal("Server '%s': pg_monitor role check failed. pgexporter cannot function without proper permissions.",
+                                    &config->servers[server].name[0]);
                pgexporter_disconnect(config->servers[server].fd);
                config->servers[server].fd = -1;
                config->servers[server].new = false;
@@ -232,13 +237,11 @@ pgexporter_close_connections(void)
    }
 }
 
-
 int
 pgexporter_query_execute(int server, char* sql, char* tag, struct query** query)
 {
    return query_execute(server, sql, tag, -1, NULL, query);
 }
-
 
 int
 pgexporter_query_version(int server, struct query** query)


### PR DESCRIPTION
Example:
```
[pgexporter]
host = localhost
metrics = 5002
bridge = 5003
bridge_endpoints = localhost:5002,localhost:5000,localhost:5001
log_type = file
log_level = debug
log_path = /tmp/pgexporter.log
unix_socket_dir = /tmp/

[primary]
host = localhost
port = 5432
user = pgexporter

[pgagroal]
host = localhost
port = 5000
type = prometheus

[pgmoneta]
host = localhost
port = 5001
type = prometheus
```

PTAL - @jesperpedersen @resyfer 