### PR TITLE
[#359] Add pre-flight validation of the configuration file before attempting

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Arshdeep Singh <balarsh535@gmail.com>
 Botir Khaltaev <btrghstk@gmail.com>
 Ahmed Osama Fathy <ahmedosamaft@gmail.com>
 Vanes Angelo <k124k3n@gmail.com>
+Sara Nabih <nabihsara8@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -23,6 +23,7 @@ Tejas Tyagi<tejastyagi.tt@gmail.com>
 Arshdeep Singh <balarsh535@gmail.com>
 Ahmed Osama Fathy <ahmedosamaft@gmail.com>
 Vanes Angelo <k124k3n@gmail.com>
+Sara Nabih <nabihsara8@gmail.com>
 ```
 
 ## Contributing

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -104,6 +104,17 @@ int
 pgexporter_init_configuration(void* shmem);
 
 /**
+ * Validate a configuration file for existence, type, readability and binary content
+ * @param path The file path
+ * @return 0 if the file is valid, otherwise a positive error value:
+ *         ENOENT  = file does not exist or is not a regular file
+ *         EACCES  = file is not readable
+ *         EINVAL  = path is NULL or file contains binary data
+ */
+int
+pgexporter_validate_config_file(char* path);
+
+/**
  * Read the configuration from a file
  * @param shmem The shared memory segment
  * @param filename The file name

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -848,7 +848,7 @@ pgexporter_backtrace(void);
  * @return 0 if success, otherwise 1
  */
 int
-pgexporter_backtrace_string(char **s);
+pgexporter_backtrace_string(char** s);
 
 /**
  * Get the OS name and kernel version.


### PR DESCRIPTION
## Problem

The daemon may fail while parsing the main configuration file and emit ambiguous parsing errors when the root cause is a filesystem issue (missing file, a directory path, insufficient permissions, or a binary file).
These cases produce unclear operator feedback (including poor systemd STATUS messages) and make diagnosis harder.
Proposed Solution
## Solution

    checks the path exists,
    verifies it is a regular file,
    ensures it is readable,
    ensures the file is not binary (no NUL bytes).

Fixes [#359]