### PR TITLE
[#361] Added script to generate contrib files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,25 @@ jobs:
             exit 1
           fi
 
+  contrib-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y python3 python3-pip
+          pip3 install --break-system-packages pyyaml
+
+      - name: Check contrib file drift
+        run: |
+          python3 scripts/generate_contrib.py \
+            --internal-h src/include/internal.h \
+            --check
+        working-directory: /home/runner/work/pgexporter/pgexporter/
+
   build-ubuntu:
-    needs: [format-check]
+    needs: [format-check, contrib-check]
     runs-on: ubuntu-latest
 
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ vendor/
 .ccls
 compile_commands.json
 .DS_Store
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python

--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Ahmed Osama Fathy <ahmedosamaft@gmail.com>
 Vanes Angelo <k124k3n@gmail.com>
 Sara Nabih <nabihsara8@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
+Somye Mahajan <mahajan.somye@gmail.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,13 @@ else ()
   message(FATAL_ERROR "LibYAML needed")
 endif()
 
+find_package(Python3 COMPONENTS Interpreter)
+if (Python3_FOUND)
+  message(STATUS "Python3 found: ${Python3_EXECUTABLE}")
+else()
+  message(STATUS "Python3 not found; contrib file generation will be skipped")
+endif()
+
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/src/")
 
 add_subdirectory(doc)
@@ -211,3 +218,20 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test")
 else()
   message(STATUS "Test directory not found, skipping tests")
 endif()
+
+#
+# Custom target to regenerate contrib files
+#
+if(Python3_FOUND)
+  set(GENERATOR_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_contrib.py")
+  set(INTERNAL_H "${CMAKE_CURRENT_SOURCE_DIR}/src/include/internal.h")
+  
+  add_custom_target(
+    generate-contrib
+    COMMAND ${Python3_EXECUTABLE} ${GENERATOR_SCRIPT}
+            --internal-h ${INTERNAL_H}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Regenerating contrib YAML/JSON files from internal.h"
+  )
+endif()
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,23 @@ You can discuss bug reports, enhancements and features in our [forum](https://gi
 
 Once there is an agreement on the development plan you can open an issue that will used for reference in the pull request.
 
+## Editing Queries and Metrics
+
+When modifying queries or metrics in `src/include/internal.h`:
+
+1. Make your changes to `src/include/internal.h`
+2. Regenerate the contrib files:
+   ```bash
+   make generate-contrib
+   ```
+   Or directly:
+   ```bash
+   python3 scripts/generate_contrib.py --internal-h src/include/internal.h
+   ```
+3. Commit both `src/include/internal.h` and the regenerated `contrib/yaml/*.yaml` and `contrib/json/*.json` files together
+
+The generator uses `internal.h` as the single source of truth, automatically creating YAML and JSON outputs for PostgreSQL 13–18. Do not manually edit the generated contrib files.
+
 ## Development
 
 You can follow this workflow for your development.

--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -2,6 +2,10 @@
   "version": 13,
   "metrics": [
     {
+      "tag": "postgresql_primary",
+      "collector": "primary",
+      "sort": "name",
+      "server": "both",
       "queries": [
         {
           "query": "SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );",
@@ -13,13 +17,12 @@
             }
           ]
         }
-      ],
-      "tag": "postgresql_primary",
-      "sort": "name",
-      "collector": "primary",
-      "server": "both"
+      ]
     },
     {
+      "tag": "pg_database_size",
+      "collector": "db",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, pg_database_size(datname) FROM pg_database;",
@@ -35,12 +38,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_database_size",
-      "sort": "data",
-      "collector": "db"
+      ]
     },
     {
+      "tag": "pg_locks_count",
+      "collector": "locks",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;",
@@ -60,12 +63,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_locks_count",
-      "sort": "data",
-      "collector": "locks"
+      ]
     },
     {
+      "tag": "pg_replication_slots",
+      "collector": "replication",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;",
@@ -95,12 +98,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_replication_slots",
-      "sort": "data",
-      "collector": "replication"
+      ]
     },
     {
+      "tag": "pg_stat_bgwriter",
+      "collector": "stat_bgwriter",
       "queries": [
         {
           "query": "SELECT buffers_alloc, buffers_backend, buffers_backend_fsync, buffers_checkpoint, buffers_clean, checkpoint_sync_time, checkpoint_write_time, checkpoints_req, checkpoints_timed, maxwritten_clean FROM pg_stat_bgwriter;",
@@ -158,53 +160,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_bgwriter",
-      "collector": "stat_bgwriter"
+      ]
     },
     {
-      "queries": [
-        {
-          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
-          "version": 10,
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "confl_tablespace",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_tablespace"
-            },
-            {
-              "name": "confl_lock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_lock"
-            },
-            {
-              "name": "confl_snapshot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_snapshot"
-            },
-            {
-              "name": "confl_bufferpin",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_bufferpin"
-            },
-            {
-              "name": "confl_deadlock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_deadlock"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_database_conflicts",
-      "sort": "data",
-      "collector": "stat_conflicts"
-    },
-    {
+      "tag": "pg_process_idle_seconds",
+      "collector": "idle_procs",
       "queries": [
         {
           "query": "WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;",
@@ -221,11 +181,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_process_idle_seconds",
-      "collector": "idle_procs"
+      ]
     },
     {
+      "tag": "pg_available_extensions",
+      "collector": "available_extensions",
       "queries": [
         {
           "query": "SELECT COUNT(*) AS extensions FROM pg_available_extensions;",
@@ -237,11 +197,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_available_extensions",
-      "collector": "available_extensions"
+      ]
     },
     {
+      "tag": "pg_installed_extensions",
+      "collector": "installed_extensions",
       "queries": [
         {
           "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
@@ -257,11 +217,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_installed_extensions",
-      "collector": "installed_extensions"
+      ]
     },
     {
+      "tag": "pg_file_settings",
+      "collector": "file_settings",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -281,12 +242,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_file_settings",
-      "sort": "data",
-      "collector": "file_settings"
+      ]
     },
     {
+      "tag": "pg_indexes",
+      "collector": "indexes",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;",
@@ -306,12 +267,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_indexes",
-      "sort": "data",
-      "collector": "indexes"
+      ]
     },
     {
+      "tag": "pg_matviews",
+      "collector": "matviews",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;",
@@ -323,11 +283,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_matviews",
-      "collector": "matviews"
+      ]
     },
     {
+      "tag": "pg_role",
+      "collector": "roles",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_roles;",
@@ -339,11 +299,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_role",
-      "collector": "roles"
+      ]
     },
     {
+      "tag": "pg_rule",
+      "collector": "rules",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;",
@@ -359,12 +320,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_rule",
-      "sort": "data",
-      "collector": "rules"
+      ]
     },
     {
+      "tag": "pg_shadow",
+      "collector": "auth_type",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -380,12 +341,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_shadow",
-      "sort": "data",
-      "collector": "auth_type"
+      ]
     },
     {
+      "tag": "pg_usr_evt_trigger",
+      "collector": "usr_evt_trigger",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",
@@ -397,11 +357,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_usr_evt_trigger",
-      "collector": "usr_evt_trigger"
+      ]
     },
     {
+      "tag": "pg_db_conn",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;",
@@ -417,12 +378,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_db_conn_ssl",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;",
@@ -438,12 +399,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn_ssl",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_statio_all_tables",
+      "collector": "statio_all_tables",
       "queries": [
         {
           "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
@@ -491,11 +451,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_tables",
-      "collector": "statio_all_tables"
+      ]
     },
     {
+      "tag": "pg_statio_all_sequences",
+      "collector": "statio_all_sequences",
       "queries": [
         {
           "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
@@ -513,11 +473,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_sequences",
-      "collector": "statio_all_sequences"
+      ]
     },
     {
+      "tag": "pg_stat_user_functions",
+      "collector": "stat_user_functions",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;",
@@ -544,12 +505,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_user_functions",
-      "sort": "data",
-      "collector": "stat_user_functions"
+      ]
     },
     {
+      "tag": "pg_stat_replication",
+      "collector": "stat_replication",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;",
@@ -565,12 +526,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_replication",
-      "sort": "data",
-      "collector": "stat_replication"
+      ]
     },
     {
+      "tag": "pg_stat_archiver",
+      "collector": "stat_archiver",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;",
@@ -598,45 +559,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_archiver",
-      "sort": "data",
-      "collector": "stat_archiver"
+      ]
     },
     {
-      "queries": [
-        {
-          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "name": "idx_scans",
-              "description": "Number of index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_reads",
-              "description": "Number of index entries returned by scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_fetchs",
-              "description": "Number of rows fetched by simple index scans on the table's indexes."
-            },
-            {
-              "type": "label",
-              "name": "relname"
-            }
-          ]
-        }
-      ],
-      "tag": "stat_all_indexes",
+      "tag": "pg_db_vacuum",
+      "collector": "db_vacuum",
       "sort": "data",
-      "collector": "pg_stat_all_indexes",
-      "database": "all"
-    },
-    {
       "queries": [
         {
           "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
@@ -654,12 +582,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_view_vacuum",
+      "collector": "db_vacuum",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');",
@@ -677,12 +605,67 @@
             }
           ]
         }
-      ],
-      "tag": "pg_view_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_blocked_vacuum",
+      "collector": "blocked_vacuum",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "version": 10,
+          "columns": [
+            {
+              "name": "blocked_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocked_database",
+              "type": "label"
+            },
+            {
+              "name": "blocked_user",
+              "type": "label"
+            },
+            {
+              "name": "blocked_query",
+              "type": "label"
+            },
+            {
+              "name": "blocked_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the vacuum has been blocked"
+            },
+            {
+              "name": "blocking_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocking_database",
+              "type": "label"
+            },
+            {
+              "name": "blocking_user",
+              "type": "label"
+            },
+            {
+              "name": "blocking_query",
+              "type": "label"
+            },
+            {
+              "name": "blocking_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the blocking query has been running"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_wal_last_received",
+      "collector": "wal_last_received",
+      "server": "replica",
       "queries": [
         {
           "query": "SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;",
@@ -698,12 +681,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_wal_last_received",
-      "collector": "wal_last_received",
-      "server": "replica"
+      ]
     },
     {
+      "tag": "pg_gss_auth",
+      "collector": "gssapi",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;",
@@ -715,11 +697,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_gss_auth",
-      "collector": "gssapi"
+      ]
     },
     {
+      "tag": "pg_encrypted_conn",
+      "collector": "encryted_conns",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;",
@@ -731,102 +713,357 @@
             }
           ]
         }
-      ],
-      "tag": "pg_encrypted_conn",
-      "collector": "encryted_conns"
+      ]
     },
     {
+      "tag": "pg_shmem_allocations",
+      "collector": "shmem_size",
       "queries": [
         {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
+          "query": "SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;",
+          "version": 13,
           "columns": [
             {
-              "name": "database",
+              "name": "size",
+              "type": "histogram",
+              "description": "Histogram of shared memory sizes."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_progress_vacuum",
+      "collector": "vacuum_progress",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "pid",
               "type": "label"
             },
             {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
+              "name": "datname",
+              "type": "label"
             },
             {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
+              "name": "usename",
+              "type": "label"
             },
             {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
+              "name": "query",
+              "type": "label"
             },
             {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
+              "name": "phase",
+              "type": "label"
             },
             {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
+              "name": "heap_blks_total",
               "type": "gauge",
-              "description": "pg_stat_database_temp_files"
+              "description": "Total heap blocks in table"
             },
             {
-              "name": "temp_bytes",
+              "name": "heap_blks_scanned",
               "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
+              "description": "Heap blocks scanned"
             },
             {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
+              "name": "heap_blks_vacuumed",
               "type": "gauge",
-              "description": "pg_stat_database_numbackends"
+              "description": "Heap blocks vacuumed"
+            },
+            {
+              "name": "index_vacuum_count",
+              "type": "gauge",
+              "description": "Number of index vacuum cycles completed"
+            },
+            {
+              "name": "max_dead_tuples",
+              "type": "gauge",
+              "description": "Maximum dead tuples"
+            },
+            {
+              "name": "num_dead_tuples",
+              "type": "gauge",
+              "description": "Current dead tuples"
+            },
+            {
+              "name": "pct_scan_completed",
+              "type": "gauge",
+              "description": "Vacuum scan progress percentage"
             }
-          ],
-          "version": 10
-        },
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_progress_analyze",
+      "collector": "analyze_progress",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "pid",
+              "type": "label"
+            },
+            {
+              "name": "datname",
+              "type": "label"
+            },
+            {
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "phase",
+              "type": "label"
+            },
+            {
+              "name": "sample_blks_total",
+              "type": "gauge",
+              "description": "Total blocks to sample"
+            },
+            {
+              "name": "sample_blks_scanned",
+              "type": "gauge",
+              "description": "Blocks sampled so far"
+            },
+            {
+              "name": "ext_stats_total",
+              "type": "gauge",
+              "description": "Total extended statistics to compute"
+            },
+            {
+              "name": "ext_stats_computed",
+              "type": "gauge",
+              "description": "Extended statistics computed"
+            },
+            {
+              "name": "child_tables_total",
+              "type": "gauge",
+              "description": "Total child tables to analyze"
+            },
+            {
+              "name": "child_tables_done",
+              "type": "gauge",
+              "description": "Child tables analyzed"
+            },
+            {
+              "name": "pct_sample_completed",
+              "type": "gauge",
+              "description": "Percentage of sampling completed"
+            },
+            {
+              "name": "pct_child_tables_completed",
+              "type": "gauge",
+              "description": "Percentage of child tables completed"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_user_tables_vacuum",
+      "collector": "stat_user_tables",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "n_live_tup",
+              "type": "gauge",
+              "description": "Estimated number of live rows"
+            },
+            {
+              "name": "n_dead_tup",
+              "type": "gauge",
+              "description": "Estimated number of dead rows"
+            },
+            {
+              "name": "dead_rows_pct",
+              "type": "gauge",
+              "description": "Percentage of dead rows relative to live rows"
+            },
+            {
+              "name": "n_mod_since_analyze",
+              "type": "gauge",
+              "description": "Estimated number of rows modified since last analyze"
+            },
+            {
+              "name": "n_ins_since_vacuum",
+              "type": "gauge",
+              "description": "Estimated number of rows inserted since last vacuum"
+            },
+            {
+              "name": "last_vacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual vacuum (-1 if never)"
+            },
+            {
+              "name": "last_autovacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autovacuum (-1 if never)"
+            },
+            {
+              "name": "last_analyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual analyze (-1 if never)"
+            },
+            {
+              "name": "last_autoanalyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autoanalyze (-1 if never)"
+            },
+            {
+              "name": "vacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually vacuumed"
+            },
+            {
+              "name": "autovacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been vacuumed by autovacuum"
+            },
+            {
+              "name": "analyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually analyzed"
+            },
+            {
+              "name": "autoanalyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been analyzed by autoanalyze"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_table_ratio",
+      "collector": "table_activity_ratio",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "blocks_read",
+              "type": "counter",
+              "description": "Total blocks read from disk (heap + index)"
+            },
+            {
+              "name": "tuples_read",
+              "type": "counter",
+              "description": "Total number of tuples read (sequential + index scans)"
+            },
+            {
+              "name": "blocks_write",
+              "type": "gauge",
+              "description": "Estimated blocks affected by write operations"
+            },
+            {
+              "name": "tuples_write",
+              "type": "counter",
+              "description": "Total number of tuples inserted, updated, or deleted"
+            },
+            {
+              "name": "ratio_write",
+              "type": "gauge",
+              "description": "Percentage of I/O activity that is writes (0-100)"
+            },
+            {
+              "name": "ratio_read",
+              "type": "gauge",
+              "description": "Percentage of I/O activity that is reads (0-100)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_table_bloat",
+      "collector": "table_bloat",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "tblname",
+              "type": "label"
+            },
+            {
+              "name": "table_size",
+              "type": "gauge",
+              "description": "Actual table size in bytes"
+            },
+            {
+              "name": "bloat_size",
+              "type": "gauge",
+              "description": "Estimated bloat size in bytes"
+            },
+            {
+              "name": "bloat_ratio_pct",
+              "type": "gauge",
+              "description": "Bloat ratio as percentage"
+            },
+            {
+              "name": "tblpages",
+              "type": "gauge",
+              "description": "Actual number of pages used by table"
+            },
+            {
+              "name": "est_tblpages",
+              "type": "gauge",
+              "description": "Estimated number of pages needed"
+            },
+            {
+              "name": "block_size",
+              "type": "gauge",
+              "description": "Database block size in bytes"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_database",
+      "collector": "stat_db",
+      "queries": [
         {
           "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
           "version": 12,
@@ -922,340 +1159,82 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_database",
-      "collector": "stat_db",
-      "sort": "data"
+      ]
     },
     {
-      "queries": [
-        {
-          "query": "SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;",
-          "columns": [
-            {
-              "name": "size",
-              "type": "histogram",
-              "description": "Histogram of shared memory sizes."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_shmem_allocations",
-      "collector": "shmem_size"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "pid",
-              "type": "label"
-            },
-            {
-              "name": "datname",
-              "type": "label"
-            },
-            {
-              "name": "usename",
-              "type": "label"
-            },
-            {
-              "name": "query",
-              "type": "label"
-            },
-            {
-              "name": "phase",
-              "type": "label"
-            },
-            {
-              "name": "heap_blks_total",
-              "type": "gauge",
-              "description": "Total heap blocks in table"
-            },
-            {
-              "name": "heap_blks_scanned",
-              "type": "gauge",
-              "description": "Heap blocks scanned"
-            },
-            {
-              "name": "heap_blks_vacuumed",
-              "type": "gauge",
-              "description": "Heap blocks vacuumed"
-            },
-            {
-              "name": "index_vacuum_count",
-              "type": "gauge",
-              "description": "Number of index vacuum cycles completed"
-            },
-            {
-              "name": "max_dead_tuples",
-              "type": "gauge",
-              "description": "Maximum dead tuples"
-            },
-            {
-              "name": "num_dead_tuples",
-              "type": "gauge",
-              "description": "Current dead tuples"
-            },
-            {
-              "name": "pct_scan_completed",
-              "type": "gauge",
-              "description": "Vacuum scan progress percentage"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_progress_vacuum",
+      "tag": "pg_stat_database_conflicts",
+      "collector": "stat_conflicts",
       "sort": "data",
-      "collector": "vacuum_progress"
-    },
-    {
       "queries": [
         {
-          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "schemaname",
-              "type": "label"
-            },
-            {
-              "name": "relname",
-              "type": "label"
-            },
-            {
-              "name": "n_live_tup",
-              "type": "gauge",
-              "description": "Estimated number of live rows"
-            },
-            {
-              "name": "n_dead_tup",
-              "type": "gauge",
-              "description": "Estimated number of dead rows"
-            },
-            {
-              "name": "dead_rows_pct",
-              "type": "gauge",
-              "description": "Percentage of dead rows relative to live rows"
-            },
-            {
-              "name": "n_mod_since_analyze",
-              "type": "gauge",
-              "description": "Estimated number of rows modified since last analyze"
-            },
-            {
-              "name": "n_ins_since_vacuum",
-              "type": "gauge",
-              "description": "Estimated number of rows inserted since last vacuum"
-            },
-            {
-              "name": "last_vacuum_seconds",
-              "type": "gauge",
-              "description": "Seconds since last manual vacuum (-1 if never)"
-            },
-            {
-              "name": "last_autovacuum_seconds",
-              "type": "gauge",
-              "description": "Seconds since last autovacuum (-1 if never)"
-            },
-            {
-              "name": "last_analyze_seconds",
-              "type": "gauge",
-              "description": "Seconds since last manual analyze (-1 if never)"
-            },
-            {
-              "name": "last_autoanalyze_seconds",
-              "type": "gauge",
-              "description": "Seconds since last autoanalyze (-1 if never)"
-            },
-            {
-              "name": "vacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually vacuumed"
-            },
-            {
-              "name": "autovacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been vacuumed by autovacuum"
-            },
-            {
-              "name": "analyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually analyzed"
-            },
-            {
-              "name": "autoanalyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been analyzed by autoanalyze"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_user_tables_vacuum",
-      "sort": "data",
-      "collector": "stat_user_tables",
-      "database": "all"
-    },
-    {
-      "queries": [
-        {
-          "query": "WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "schemaname",
-              "type": "label"
-            },
-            {
-              "name": "relname",
-              "type": "label"
-            },
-            {
-              "name": "blocks_read",
-              "type": "counter",
-              "description": "Total blocks read from disk (heap + index)"
-            },
-            {
-              "name": "tuples_read",
-              "type": "counter",
-              "description": "Total number of tuples read (sequential + index scans)"
-            },
-            {
-              "name": "blocks_write",
-              "type": "gauge",
-              "description": "Estimated blocks affected by write operations"
-            },
-            {
-              "name": "tuples_write",
-              "type": "counter",
-              "description": "Total number of tuples inserted, updated, or deleted"
-            },
-            {
-              "name": "ratio_write",
-              "type": "gauge",
-              "description": "Percentage of I/O activity that is writes (0-100)"
-            },
-            {
-              "name": "ratio_read",
-              "type": "gauge",
-              "description": "Percentage of I/O activity that is reads (0-100)"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_table_ratio",
-      "sort": "data",
-      "collector": "table_activity_ratio",
-      "database": "all"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "schemaname",
-              "type": "label"
-            },
-            {
-              "name": "tblname",
-              "type": "label"
-            },
-            {
-              "name": "table_size",
-              "type": "gauge",
-              "description": "Actual table size in bytes"
-            },
-            {
-              "name": "bloat_size",
-              "type": "gauge",
-              "description": "Estimated bloat size in bytes"
-            },
-            {
-              "name": "bloat_ratio_pct",
-              "type": "gauge",
-              "description": "Bloat ratio as percentage"
-            },
-            {
-              "name": "tblpages",
-              "type": "gauge",
-              "description": "Actual number of pages used by table"
-            },
-            {
-              "name": "est_tblpages",
-              "type": "gauge",
-              "description": "Estimated number of pages needed"
-            },
-            {
-              "name": "block_size",
-              "type": "gauge",
-              "description": "Database block size in bytes"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_table_bloat",
-      "sort": "data",
-      "collector": "table_bloat",
-      "database": "all"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
           "version": 10,
           "columns": [
             {
-              "name": "blocked_pid",
+              "name": "database",
               "type": "label"
             },
             {
-              "name": "blocked_database",
-              "type": "label"
+              "name": "confl_tablespace",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_tablespace"
             },
             {
-              "name": "blocked_user",
-              "type": "label"
+              "name": "confl_lock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_lock"
             },
             {
-              "name": "blocked_query",
-              "type": "label"
+              "name": "confl_snapshot",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_snapshot"
             },
             {
-              "name": "blocked_duration_seconds",
-              "type": "gauge",
-              "description": "Duration in seconds that the vacuum has been blocked"
+              "name": "confl_bufferpin",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_bufferpin"
             },
             {
-              "name": "blocking_pid",
-              "type": "label"
-            },
-            {
-              "name": "blocking_database",
-              "type": "label"
-            },
-            {
-              "name": "blocking_user",
-              "type": "label"
-            },
-            {
-              "name": "blocking_query",
-              "type": "label"
-            },
-            {
-              "name": "blocking_duration_seconds",
-              "type": "gauge",
-              "description": "Duration in seconds that the blocking query has been running"
+              "name": "confl_deadlock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_deadlock"
             }
           ]
         }
-      ],
-      "tag": "pg_blocked_vacuum",
+      ]
+    },
+    {
+      "tag": "pg_stat_all_indexes",
+      "collector": "stat_all_indexes",
       "sort": "data",
-      "collector": "blocked_vacuum"
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes GROUP BY relname;",
+          "version": 10,
+          "columns": [
+            {
+              "type": "counter",
+              "name": "idx_scans",
+              "description": "Number of index scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_reads",
+              "description": "Number of index entries returned by scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_fetchs",
+              "description": "Number of rows fetched by simple index scans on the table's indexes."
+            },
+            {
+              "type": "label",
+              "name": "relname"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -2,6 +2,10 @@
   "version": 14,
   "metrics": [
     {
+      "tag": "postgresql_primary",
+      "collector": "primary",
+      "sort": "name",
+      "server": "both",
       "queries": [
         {
           "query": "SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );",
@@ -13,13 +17,12 @@
             }
           ]
         }
-      ],
-      "tag": "postgresql_primary",
-      "sort": "name",
-      "collector": "primary",
-      "server": "both"
+      ]
     },
     {
+      "tag": "pg_database_size",
+      "collector": "db",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, pg_database_size(datname) FROM pg_database;",
@@ -35,12 +38,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_database_size",
-      "sort": "data",
-      "collector": "db"
+      ]
     },
     {
+      "tag": "pg_locks_count",
+      "collector": "locks",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;",
@@ -60,12 +63,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_locks_count",
-      "sort": "data",
-      "collector": "locks"
+      ]
     },
     {
+      "tag": "pg_replication_slots",
+      "collector": "replication",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;",
@@ -95,12 +98,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_replication_slots",
-      "sort": "data",
-      "collector": "replication"
+      ]
     },
     {
+      "tag": "pg_stat_bgwriter",
+      "collector": "stat_bgwriter",
       "queries": [
         {
           "query": "SELECT buffers_alloc, buffers_backend, buffers_backend_fsync, buffers_checkpoint, buffers_clean, checkpoint_sync_time, checkpoint_write_time, checkpoints_req, checkpoints_timed, maxwritten_clean FROM pg_stat_bgwriter;",
@@ -158,53 +160,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_bgwriter",
-      "collector": "stat_bgwriter"
+      ]
     },
     {
-      "queries": [
-        {
-          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
-          "version": 10,
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "confl_tablespace",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_tablespace"
-            },
-            {
-              "name": "confl_lock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_lock"
-            },
-            {
-              "name": "confl_snapshot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_snapshot"
-            },
-            {
-              "name": "confl_bufferpin",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_bufferpin"
-            },
-            {
-              "name": "confl_deadlock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_deadlock"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_database_conflicts",
-      "sort": "data",
-      "collector": "stat_conflicts"
-    },
-    {
+      "tag": "pg_process_idle_seconds",
+      "collector": "idle_procs",
       "queries": [
         {
           "query": "WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;",
@@ -221,11 +181,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_process_idle_seconds",
-      "collector": "idle_procs"
+      ]
     },
     {
+      "tag": "pg_available_extensions",
+      "collector": "available_extensions",
       "queries": [
         {
           "query": "SELECT COUNT(*) AS extensions FROM pg_available_extensions;",
@@ -237,11 +197,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_available_extensions",
-      "collector": "available_extensions"
+      ]
     },
     {
+      "tag": "pg_installed_extensions",
+      "collector": "installed_extensions",
       "queries": [
         {
           "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
@@ -257,11 +217,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_installed_extensions",
-      "collector": "installed_extensions"
+      ]
     },
     {
+      "tag": "pg_file_settings",
+      "collector": "file_settings",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -281,12 +242,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_file_settings",
-      "sort": "data",
-      "collector": "file_settings"
+      ]
     },
     {
+      "tag": "pg_indexes",
+      "collector": "indexes",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;",
@@ -306,12 +267,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_indexes",
-      "sort": "data",
-      "collector": "indexes"
+      ]
     },
     {
+      "tag": "pg_matviews",
+      "collector": "matviews",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;",
@@ -323,11 +283,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_matviews",
-      "collector": "matviews"
+      ]
     },
     {
+      "tag": "pg_role",
+      "collector": "roles",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_roles;",
@@ -339,11 +299,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_role",
-      "collector": "roles"
+      ]
     },
     {
+      "tag": "pg_rule",
+      "collector": "rules",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;",
@@ -359,12 +320,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_rule",
-      "sort": "data",
-      "collector": "rules"
+      ]
     },
     {
+      "tag": "pg_shadow",
+      "collector": "auth_type",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -380,12 +341,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_shadow",
-      "sort": "data",
-      "collector": "auth_type"
+      ]
     },
     {
+      "tag": "pg_usr_evt_trigger",
+      "collector": "usr_evt_trigger",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",
@@ -397,11 +357,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_usr_evt_trigger",
-      "collector": "usr_evt_trigger"
+      ]
     },
     {
+      "tag": "pg_db_conn",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;",
@@ -417,12 +378,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_db_conn_ssl",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;",
@@ -438,12 +399,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn_ssl",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_statio_all_tables",
+      "collector": "statio_all_tables",
       "queries": [
         {
           "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
@@ -491,11 +451,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_tables",
-      "collector": "statio_all_tables"
+      ]
     },
     {
+      "tag": "pg_statio_all_sequences",
+      "collector": "statio_all_sequences",
       "queries": [
         {
           "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
@@ -513,11 +473,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_sequences",
-      "collector": "statio_all_sequences"
+      ]
     },
     {
+      "tag": "pg_stat_user_functions",
+      "collector": "stat_user_functions",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;",
@@ -544,12 +505,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_user_functions",
-      "sort": "data",
-      "collector": "stat_user_functions"
+      ]
     },
     {
+      "tag": "pg_stat_replication",
+      "collector": "stat_replication",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;",
@@ -565,12 +526,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_replication",
-      "sort": "data",
-      "collector": "stat_replication"
+      ]
     },
     {
+      "tag": "pg_stat_archiver",
+      "collector": "stat_archiver",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;",
@@ -598,45 +559,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_archiver",
-      "sort": "data",
-      "collector": "stat_archiver"
+      ]
     },
     {
-      "queries": [
-        {
-          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "name": "idx_scans",
-              "description": "Number of index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_reads",
-              "description": "Number of index entries returned by scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_fetchs",
-              "description": "Number of rows fetched by simple index scans on the table's indexes."
-            },
-            {
-              "type": "label",
-              "name": "relname"
-            }
-          ]
-        }
-      ],
-      "tag": "stat_all_indexes",
+      "tag": "pg_db_vacuum",
+      "collector": "db_vacuum",
       "sort": "data",
-      "collector": "pg_stat_all_indexes",
-      "database": "all"
-    },
-    {
       "queries": [
         {
           "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
@@ -654,12 +582,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_view_vacuum",
+      "collector": "db_vacuum",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');",
@@ -677,12 +605,67 @@
             }
           ]
         }
-      ],
-      "tag": "pg_view_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_blocked_vacuum",
+      "collector": "blocked_vacuum",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "version": 10,
+          "columns": [
+            {
+              "name": "blocked_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocked_database",
+              "type": "label"
+            },
+            {
+              "name": "blocked_user",
+              "type": "label"
+            },
+            {
+              "name": "blocked_query",
+              "type": "label"
+            },
+            {
+              "name": "blocked_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the vacuum has been blocked"
+            },
+            {
+              "name": "blocking_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocking_database",
+              "type": "label"
+            },
+            {
+              "name": "blocking_user",
+              "type": "label"
+            },
+            {
+              "name": "blocking_query",
+              "type": "label"
+            },
+            {
+              "name": "blocking_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the blocking query has been running"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_wal_last_received",
+      "collector": "wal_last_received",
+      "server": "replica",
       "queries": [
         {
           "query": "SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;",
@@ -698,12 +681,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_wal_last_received",
-      "collector": "wal_last_received",
-      "server": "replica"
+      ]
     },
     {
+      "tag": "pg_gss_auth",
+      "collector": "gssapi",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;",
@@ -715,11 +697,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_gss_auth",
-      "collector": "gssapi"
+      ]
     },
     {
+      "tag": "pg_encrypted_conn",
+      "collector": "encryted_conns",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;",
@@ -731,11 +713,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_encrypted_conn",
-      "collector": "encryted_conns"
+      ]
     },
     {
+      "tag": "pg_shmem_allocations",
+      "collector": "shmem_size",
       "queries": [
         {
           "query": "SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;",
@@ -748,11 +730,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_shmem_allocations",
-      "collector": "shmem_size"
+      ]
     },
     {
+      "tag": "pg_stat_progress_vacuum",
+      "collector": "vacuum_progress",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
@@ -815,15 +798,275 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_progress_vacuum",
-      "sort": "data",
-      "collector": "vacuum_progress"
+      ]
     },
     {
+      "tag": "pg_stat_progress_analyze",
+      "collector": "analyze_progress",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "pid",
+              "type": "label"
+            },
+            {
+              "name": "datname",
+              "type": "label"
+            },
+            {
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "phase",
+              "type": "label"
+            },
+            {
+              "name": "sample_blks_total",
+              "type": "gauge",
+              "description": "Total blocks to sample"
+            },
+            {
+              "name": "sample_blks_scanned",
+              "type": "gauge",
+              "description": "Blocks sampled so far"
+            },
+            {
+              "name": "ext_stats_total",
+              "type": "gauge",
+              "description": "Total extended statistics to compute"
+            },
+            {
+              "name": "ext_stats_computed",
+              "type": "gauge",
+              "description": "Extended statistics computed"
+            },
+            {
+              "name": "child_tables_total",
+              "type": "gauge",
+              "description": "Total child tables to analyze"
+            },
+            {
+              "name": "child_tables_done",
+              "type": "gauge",
+              "description": "Child tables analyzed"
+            },
+            {
+              "name": "pct_sample_completed",
+              "type": "gauge",
+              "description": "Percentage of sampling completed"
+            },
+            {
+              "name": "pct_child_tables_completed",
+              "type": "gauge",
+              "description": "Percentage of child tables completed"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_user_tables_vacuum",
+      "collector": "stat_user_tables",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "n_live_tup",
+              "type": "gauge",
+              "description": "Estimated number of live rows"
+            },
+            {
+              "name": "n_dead_tup",
+              "type": "gauge",
+              "description": "Estimated number of dead rows"
+            },
+            {
+              "name": "dead_rows_pct",
+              "type": "gauge",
+              "description": "Percentage of dead rows relative to live rows"
+            },
+            {
+              "name": "n_mod_since_analyze",
+              "type": "gauge",
+              "description": "Estimated number of rows modified since last analyze"
+            },
+            {
+              "name": "n_ins_since_vacuum",
+              "type": "gauge",
+              "description": "Estimated number of rows inserted since last vacuum"
+            },
+            {
+              "name": "last_vacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual vacuum (-1 if never)"
+            },
+            {
+              "name": "last_autovacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autovacuum (-1 if never)"
+            },
+            {
+              "name": "last_analyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual analyze (-1 if never)"
+            },
+            {
+              "name": "last_autoanalyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autoanalyze (-1 if never)"
+            },
+            {
+              "name": "vacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually vacuumed"
+            },
+            {
+              "name": "autovacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been vacuumed by autovacuum"
+            },
+            {
+              "name": "analyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually analyzed"
+            },
+            {
+              "name": "autoanalyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been analyzed by autoanalyze"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_table_ratio",
+      "collector": "table_activity_ratio",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "blocks_read",
+              "type": "counter",
+              "description": "Total blocks read from disk (heap + index)"
+            },
+            {
+              "name": "tuples_read",
+              "type": "counter",
+              "description": "Total number of tuples read (sequential + index scans)"
+            },
+            {
+              "name": "blocks_write",
+              "type": "gauge",
+              "description": "Estimated blocks affected by write operations"
+            },
+            {
+              "name": "tuples_write",
+              "type": "counter",
+              "description": "Total number of tuples inserted, updated, or deleted"
+            },
+            {
+              "name": "ratio_write",
+              "type": "gauge",
+              "description": "Percentage of I/O activity that is writes (0-100)"
+            },
+            {
+              "name": "ratio_read",
+              "type": "gauge",
+              "description": "Percentage of I/O activity that is reads (0-100)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_table_bloat",
+      "collector": "table_bloat",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "tblname",
+              "type": "label"
+            },
+            {
+              "name": "table_size",
+              "type": "gauge",
+              "description": "Actual table size in bytes"
+            },
+            {
+              "name": "bloat_size",
+              "type": "gauge",
+              "description": "Estimated bloat size in bytes"
+            },
+            {
+              "name": "bloat_ratio_pct",
+              "type": "gauge",
+              "description": "Bloat ratio as percentage"
+            },
+            {
+              "name": "tblpages",
+              "type": "gauge",
+              "description": "Actual number of pages used by table"
+            },
+            {
+              "name": "est_tblpages",
+              "type": "gauge",
+              "description": "Estimated number of pages needed"
+            },
+            {
+              "name": "block_size",
+              "type": "gauge",
+              "description": "Database block size in bytes"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_mem_ctx",
+      "collector": "mem_ctx",
       "queries": [
         {
           "query": "SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;",
+          "version": 14,
           "columns": [
             {
               "name": "contexts",
@@ -851,14 +1094,15 @@
             }
           ]
         }
-      ],
-      "tag": "pg_mem_ctx",
-      "collector": "mem_ctx"
+      ]
     },
     {
+      "tag": "pg_stat_wal",
+      "collector": "stat_wal",
       "queries": [
         {
           "query": "SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal;",
+          "version": 14,
           "columns": [
             {
               "name": "wal_records",
@@ -902,199 +1146,15 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_wal",
-      "collector": "stat_wal"
+      ]
     },
     {
+      "tag": "pg_stat_database",
+      "collector": "stat_db",
       "queries": [
         {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            }
-          ],
-          "version": 10
-        },
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            },
-            {
-              "name": "checksum_failures",
-              "type": "gauge",
-              "description": "pg_stat_database_checksum_failures"
-            }
-          ],
-          "version": 12
-        },
-        {
           "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
+          "version": 14,
           "columns": [
             {
               "name": "database",
@@ -1222,255 +1282,82 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_database",
-      "collector": "stat_db"
+      ]
     },
     {
-      "queries": [
-        {
-          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "schemaname",
-              "type": "label"
-            },
-            {
-              "name": "relname",
-              "type": "label"
-            },
-            {
-              "name": "n_live_tup",
-              "type": "gauge",
-              "description": "Estimated number of live rows"
-            },
-            {
-              "name": "n_dead_tup",
-              "type": "gauge",
-              "description": "Estimated number of dead rows"
-            },
-            {
-              "name": "dead_rows_pct",
-              "type": "gauge",
-              "description": "Percentage of dead rows relative to live rows"
-            },
-            {
-              "name": "n_mod_since_analyze",
-              "type": "gauge",
-              "description": "Estimated number of rows modified since last analyze"
-            },
-            {
-              "name": "n_ins_since_vacuum",
-              "type": "gauge",
-              "description": "Estimated number of rows inserted since last vacuum"
-            },
-            {
-              "name": "last_vacuum_seconds",
-              "type": "gauge",
-              "description": "Seconds since last manual vacuum (-1 if never)"
-            },
-            {
-              "name": "last_autovacuum_seconds",
-              "type": "gauge",
-              "description": "Seconds since last autovacuum (-1 if never)"
-            },
-            {
-              "name": "last_analyze_seconds",
-              "type": "gauge",
-              "description": "Seconds since last manual analyze (-1 if never)"
-            },
-            {
-              "name": "last_autoanalyze_seconds",
-              "type": "gauge",
-              "description": "Seconds since last autoanalyze (-1 if never)"
-            },
-            {
-              "name": "vacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually vacuumed"
-            },
-            {
-              "name": "autovacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been vacuumed by autovacuum"
-            },
-            {
-              "name": "analyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually analyzed"
-            },
-            {
-              "name": "autoanalyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been analyzed by autoanalyze"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_user_tables_vacuum",
+      "tag": "pg_stat_database_conflicts",
+      "collector": "stat_conflicts",
       "sort": "data",
-      "collector": "stat_user_tables",
-      "database": "all"
-    },
-    {
       "queries": [
         {
-          "query": "WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "schemaname",
-              "type": "label"
-            },
-            {
-              "name": "relname",
-              "type": "label"
-            },
-            {
-              "name": "blocks_read",
-              "type": "counter",
-              "description": "Total blocks read from disk (heap + index)"
-            },
-            {
-              "name": "tuples_read",
-              "type": "counter",
-              "description": "Total number of tuples read (sequential + index scans)"
-            },
-            {
-              "name": "blocks_write",
-              "type": "gauge",
-              "description": "Estimated blocks affected by write operations"
-            },
-            {
-              "name": "tuples_write",
-              "type": "counter",
-              "description": "Total number of tuples inserted, updated, or deleted"
-            },
-            {
-              "name": "ratio_write",
-              "type": "gauge",
-              "description": "Percentage of I/O activity that is writes (0-100)"
-            },
-            {
-              "name": "ratio_read",
-              "type": "gauge",
-              "description": "Percentage of I/O activity that is reads (0-100)"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_table_ratio",
-      "sort": "data",
-      "collector": "table_activity_ratio",
-      "database": "all"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "schemaname",
-              "type": "label"
-            },
-            {
-              "name": "tblname",
-              "type": "label"
-            },
-            {
-              "name": "table_size",
-              "type": "gauge",
-              "description": "Actual table size in bytes"
-            },
-            {
-              "name": "bloat_size",
-              "type": "gauge",
-              "description": "Estimated bloat size in bytes"
-            },
-            {
-              "name": "bloat_ratio_pct",
-              "type": "gauge",
-              "description": "Bloat ratio as percentage"
-            },
-            {
-              "name": "tblpages",
-              "type": "gauge",
-              "description": "Actual number of pages used by table"
-            },
-            {
-              "name": "est_tblpages",
-              "type": "gauge",
-              "description": "Estimated number of pages needed"
-            },
-            {
-              "name": "block_size",
-              "type": "gauge",
-              "description": "Database block size in bytes"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_table_bloat",
-      "sort": "data",
-      "collector": "table_bloat",
-      "database": "all"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
           "version": 10,
           "columns": [
             {
-              "name": "blocked_pid",
+              "name": "database",
               "type": "label"
             },
             {
-              "name": "blocked_database",
-              "type": "label"
+              "name": "confl_tablespace",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_tablespace"
             },
             {
-              "name": "blocked_user",
-              "type": "label"
+              "name": "confl_lock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_lock"
             },
             {
-              "name": "blocked_query",
-              "type": "label"
+              "name": "confl_snapshot",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_snapshot"
             },
             {
-              "name": "blocked_duration_seconds",
-              "type": "gauge",
-              "description": "Duration in seconds that the vacuum has been blocked"
+              "name": "confl_bufferpin",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_bufferpin"
             },
             {
-              "name": "blocking_pid",
-              "type": "label"
-            },
-            {
-              "name": "blocking_database",
-              "type": "label"
-            },
-            {
-              "name": "blocking_user",
-              "type": "label"
-            },
-            {
-              "name": "blocking_query",
-              "type": "label"
-            },
-            {
-              "name": "blocking_duration_seconds",
-              "type": "gauge",
-              "description": "Duration in seconds that the blocking query has been running"
+              "name": "confl_deadlock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_deadlock"
             }
           ]
         }
-      ],
-      "tag": "pg_blocked_vacuum",
+      ]
+    },
+    {
+      "tag": "pg_stat_all_indexes",
+      "collector": "stat_all_indexes",
       "sort": "data",
-      "collector": "blocked_vacuum"
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes GROUP BY relname;",
+          "version": 10,
+          "columns": [
+            {
+              "type": "counter",
+              "name": "idx_scans",
+              "description": "Number of index scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_reads",
+              "description": "Number of index entries returned by scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_fetchs",
+              "description": "Number of rows fetched by simple index scans on the table's indexes."
+            },
+            {
+              "type": "label",
+              "name": "relname"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -2,6 +2,10 @@
   "version": 15,
   "metrics": [
     {
+      "tag": "postgresql_primary",
+      "collector": "primary",
+      "sort": "name",
+      "server": "both",
       "queries": [
         {
           "query": "SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );",
@@ -13,13 +17,12 @@
             }
           ]
         }
-      ],
-      "tag": "postgresql_primary",
-      "sort": "name",
-      "collector": "primary",
-      "server": "both"
+      ]
     },
     {
+      "tag": "pg_database_size",
+      "collector": "db",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, pg_database_size(datname) FROM pg_database;",
@@ -35,12 +38,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_database_size",
-      "sort": "data",
-      "collector": "db"
+      ]
     },
     {
+      "tag": "pg_locks_count",
+      "collector": "locks",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;",
@@ -60,12 +63,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_locks_count",
-      "sort": "data",
-      "collector": "locks"
+      ]
     },
     {
+      "tag": "pg_replication_slots",
+      "collector": "replication",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;",
@@ -95,12 +98,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_replication_slots",
-      "sort": "data",
-      "collector": "replication"
+      ]
     },
     {
+      "tag": "pg_stat_bgwriter",
+      "collector": "stat_bgwriter",
       "queries": [
         {
           "query": "SELECT buffers_alloc, buffers_backend, buffers_backend_fsync, buffers_checkpoint, buffers_clean, checkpoint_sync_time, checkpoint_write_time, checkpoints_req, checkpoints_timed, maxwritten_clean FROM pg_stat_bgwriter;",
@@ -158,53 +160,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_bgwriter",
-      "collector": "stat_bgwriter"
+      ]
     },
     {
-      "queries": [
-        {
-          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
-          "version": 10,
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "confl_tablespace",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_tablespace"
-            },
-            {
-              "name": "confl_lock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_lock"
-            },
-            {
-              "name": "confl_snapshot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_snapshot"
-            },
-            {
-              "name": "confl_bufferpin",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_bufferpin"
-            },
-            {
-              "name": "confl_deadlock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_deadlock"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_database_conflicts",
-      "sort": "data",
-      "collector": "stat_conflicts"
-    },
-    {
+      "tag": "pg_process_idle_seconds",
+      "collector": "idle_procs",
       "queries": [
         {
           "query": "WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;",
@@ -221,11 +181,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_process_idle_seconds",
-      "collector": "idle_procs"
+      ]
     },
     {
+      "tag": "pg_available_extensions",
+      "collector": "available_extensions",
       "queries": [
         {
           "query": "SELECT COUNT(*) AS extensions FROM pg_available_extensions;",
@@ -237,11 +197,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_available_extensions",
-      "collector": "available_extensions"
+      ]
     },
     {
+      "tag": "pg_installed_extensions",
+      "collector": "installed_extensions",
       "queries": [
         {
           "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
@@ -257,11 +217,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_installed_extensions",
-      "collector": "installed_extensions"
+      ]
     },
     {
+      "tag": "pg_file_settings",
+      "collector": "file_settings",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -281,12 +242,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_file_settings",
-      "sort": "data",
-      "collector": "file_settings"
+      ]
     },
     {
+      "tag": "pg_indexes",
+      "collector": "indexes",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;",
@@ -306,12 +267,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_indexes",
-      "sort": "data",
-      "collector": "indexes"
+      ]
     },
     {
+      "tag": "pg_matviews",
+      "collector": "matviews",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;",
@@ -323,11 +283,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_matviews",
-      "collector": "matviews"
+      ]
     },
     {
+      "tag": "pg_role",
+      "collector": "roles",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_roles;",
@@ -339,11 +299,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_role",
-      "collector": "roles"
+      ]
     },
     {
+      "tag": "pg_rule",
+      "collector": "rules",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;",
@@ -359,12 +320,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_rule",
-      "sort": "data",
-      "collector": "rules"
+      ]
     },
     {
+      "tag": "pg_shadow",
+      "collector": "auth_type",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -380,12 +341,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_shadow",
-      "sort": "data",
-      "collector": "auth_type"
+      ]
     },
     {
+      "tag": "pg_usr_evt_trigger",
+      "collector": "usr_evt_trigger",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",
@@ -397,11 +357,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_usr_evt_trigger",
-      "collector": "usr_evt_trigger"
+      ]
     },
     {
+      "tag": "pg_db_conn",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;",
@@ -417,12 +378,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_db_conn_ssl",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;",
@@ -438,12 +399,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn_ssl",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_statio_all_tables",
+      "collector": "statio_all_tables",
       "queries": [
         {
           "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
@@ -491,11 +451,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_tables",
-      "collector": "statio_all_tables"
+      ]
     },
     {
+      "tag": "pg_statio_all_sequences",
+      "collector": "statio_all_sequences",
       "queries": [
         {
           "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
@@ -513,11 +473,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_sequences",
-      "collector": "statio_all_sequences"
+      ]
     },
     {
+      "tag": "pg_stat_user_functions",
+      "collector": "stat_user_functions",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;",
@@ -544,12 +505,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_user_functions",
-      "sort": "data",
-      "collector": "stat_user_functions"
+      ]
     },
     {
+      "tag": "pg_stat_replication",
+      "collector": "stat_replication",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;",
@@ -565,12 +526,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_replication",
-      "sort": "data",
-      "collector": "stat_replication"
+      ]
     },
     {
+      "tag": "pg_stat_archiver",
+      "collector": "stat_archiver",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;",
@@ -598,45 +559,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_archiver",
-      "sort": "data",
-      "collector": "stat_archiver"
+      ]
     },
     {
-      "queries": [
-        {
-          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;",
-          "version": 10,
-          "columns": [
-            {
-              "type": "counter",
-              "name": "idx_scans",
-              "description": "Number of index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_reads",
-              "description": "Number of index entries returned by scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_fetchs",
-              "description": "Number of rows fetched by simple index scans on the table's indexes."
-            },
-            {
-              "type": "label",
-              "name": "relname"
-            }
-          ]
-        }
-      ],
-      "tag": "stat_all_indexes",
+      "tag": "pg_db_vacuum",
+      "collector": "db_vacuum",
       "sort": "data",
-      "collector": "pg_stat_all_indexes",
-      "database": "all"
-    },
-    {
       "queries": [
         {
           "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
@@ -654,12 +582,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_view_vacuum",
+      "collector": "db_vacuum",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');",
@@ -677,12 +605,67 @@
             }
           ]
         }
-      ],
-      "tag": "pg_view_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_blocked_vacuum",
+      "collector": "blocked_vacuum",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "version": 10,
+          "columns": [
+            {
+              "name": "blocked_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocked_database",
+              "type": "label"
+            },
+            {
+              "name": "blocked_user",
+              "type": "label"
+            },
+            {
+              "name": "blocked_query",
+              "type": "label"
+            },
+            {
+              "name": "blocked_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the vacuum has been blocked"
+            },
+            {
+              "name": "blocking_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocking_database",
+              "type": "label"
+            },
+            {
+              "name": "blocking_user",
+              "type": "label"
+            },
+            {
+              "name": "blocking_query",
+              "type": "label"
+            },
+            {
+              "name": "blocking_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the blocking query has been running"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_wal_last_received",
+      "collector": "wal_last_received",
+      "server": "replica",
       "queries": [
         {
           "query": "SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;",
@@ -698,12 +681,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_wal_last_received",
-      "collector": "wal_last_received",
-      "server": "replica"
+      ]
     },
     {
+      "tag": "pg_gss_auth",
+      "collector": "gssapi",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;",
@@ -715,11 +697,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_gss_auth",
-      "collector": "gssapi"
+      ]
     },
     {
+      "tag": "pg_encrypted_conn",
+      "collector": "encryted_conns",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;",
@@ -731,11 +713,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_encrypted_conn",
-      "collector": "encryted_conns"
+      ]
     },
     {
+      "tag": "pg_shmem_allocations",
+      "collector": "shmem_size",
       "queries": [
         {
           "query": "SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;",
@@ -748,11 +730,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_shmem_allocations",
-      "collector": "shmem_size"
+      ]
     },
     {
+      "tag": "pg_stat_progress_vacuum",
+      "collector": "vacuum_progress",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
@@ -815,12 +798,271 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_progress_vacuum",
-      "sort": "data",
-      "collector": "vacuum_progress"
+      ]
     },
     {
+      "tag": "pg_stat_progress_analyze",
+      "collector": "analyze_progress",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "pid",
+              "type": "label"
+            },
+            {
+              "name": "datname",
+              "type": "label"
+            },
+            {
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "phase",
+              "type": "label"
+            },
+            {
+              "name": "sample_blks_total",
+              "type": "gauge",
+              "description": "Total blocks to sample"
+            },
+            {
+              "name": "sample_blks_scanned",
+              "type": "gauge",
+              "description": "Blocks sampled so far"
+            },
+            {
+              "name": "ext_stats_total",
+              "type": "gauge",
+              "description": "Total extended statistics to compute"
+            },
+            {
+              "name": "ext_stats_computed",
+              "type": "gauge",
+              "description": "Extended statistics computed"
+            },
+            {
+              "name": "child_tables_total",
+              "type": "gauge",
+              "description": "Total child tables to analyze"
+            },
+            {
+              "name": "child_tables_done",
+              "type": "gauge",
+              "description": "Child tables analyzed"
+            },
+            {
+              "name": "pct_sample_completed",
+              "type": "gauge",
+              "description": "Percentage of sampling completed"
+            },
+            {
+              "name": "pct_child_tables_completed",
+              "type": "gauge",
+              "description": "Percentage of child tables completed"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_user_tables_vacuum",
+      "collector": "stat_user_tables",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "n_live_tup",
+              "type": "gauge",
+              "description": "Estimated number of live rows"
+            },
+            {
+              "name": "n_dead_tup",
+              "type": "gauge",
+              "description": "Estimated number of dead rows"
+            },
+            {
+              "name": "dead_rows_pct",
+              "type": "gauge",
+              "description": "Percentage of dead rows relative to live rows"
+            },
+            {
+              "name": "n_mod_since_analyze",
+              "type": "gauge",
+              "description": "Estimated number of rows modified since last analyze"
+            },
+            {
+              "name": "n_ins_since_vacuum",
+              "type": "gauge",
+              "description": "Estimated number of rows inserted since last vacuum"
+            },
+            {
+              "name": "last_vacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual vacuum (-1 if never)"
+            },
+            {
+              "name": "last_autovacuum_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autovacuum (-1 if never)"
+            },
+            {
+              "name": "last_analyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last manual analyze (-1 if never)"
+            },
+            {
+              "name": "last_autoanalyze_seconds",
+              "type": "gauge",
+              "description": "Seconds since last autoanalyze (-1 if never)"
+            },
+            {
+              "name": "vacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually vacuumed"
+            },
+            {
+              "name": "autovacuum_count",
+              "type": "counter",
+              "description": "Number of times this table has been vacuumed by autovacuum"
+            },
+            {
+              "name": "analyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been manually analyzed"
+            },
+            {
+              "name": "autoanalyze_count",
+              "type": "counter",
+              "description": "Number of times this table has been analyzed by autoanalyze"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_table_ratio",
+      "collector": "table_activity_ratio",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
+            {
+              "name": "blocks_read",
+              "type": "counter",
+              "description": "Total blocks read from disk (heap + index)"
+            },
+            {
+              "name": "tuples_read",
+              "type": "counter",
+              "description": "Total number of tuples read (sequential + index scans)"
+            },
+            {
+              "name": "blocks_write",
+              "type": "gauge",
+              "description": "Estimated blocks affected by write operations"
+            },
+            {
+              "name": "tuples_write",
+              "type": "counter",
+              "description": "Total number of tuples inserted, updated, or deleted"
+            },
+            {
+              "name": "ratio_write",
+              "type": "gauge",
+              "description": "Percentage of I/O activity that is writes (0-100)"
+            },
+            {
+              "name": "ratio_read",
+              "type": "gauge",
+              "description": "Percentage of I/O activity that is reads (0-100)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_table_bloat",
+      "collector": "table_bloat",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "tblname",
+              "type": "label"
+            },
+            {
+              "name": "table_size",
+              "type": "gauge",
+              "description": "Actual table size in bytes"
+            },
+            {
+              "name": "bloat_size",
+              "type": "gauge",
+              "description": "Estimated bloat size in bytes"
+            },
+            {
+              "name": "bloat_ratio_pct",
+              "type": "gauge",
+              "description": "Bloat ratio as percentage"
+            },
+            {
+              "name": "tblpages",
+              "type": "gauge",
+              "description": "Actual number of pages used by table"
+            },
+            {
+              "name": "est_tblpages",
+              "type": "gauge",
+              "description": "Estimated number of pages needed"
+            },
+            {
+              "name": "block_size",
+              "type": "gauge",
+              "description": "Database block size in bytes"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_mem_ctx",
+      "collector": "mem_ctx",
       "queries": [
         {
           "query": "SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;",
@@ -852,11 +1094,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_mem_ctx",
-      "collector": "mem_ctx"
+      ]
     },
     {
+      "tag": "pg_stat_wal",
+      "collector": "stat_wal",
       "queries": [
         {
           "query": "SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal;",
@@ -904,197 +1146,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_wal",
-      "collector": "stat_wal"
+      ]
     },
     {
+      "tag": "pg_stat_database",
+      "collector": "stat_db",
       "queries": [
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            }
-          ],
-          "version": 10
-        },
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            },
-            {
-              "name": "checksum_failures",
-              "type": "gauge",
-              "description": "pg_stat_database_checksum_failures"
-            }
-          ],
-          "version": 12
-        },
         {
           "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
           "version": 14,
@@ -1225,14 +1282,15 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_database",
-      "collector": "stat_db"
+      ]
     },
     {
+      "tag": "pg_wal_prefetch_reset",
+      "collector": "wal_prefetch_reset",
       "queries": [
         {
           "query": "SELECT FLOOR( EXTRACT( EPOCH FROM (now() - stats_reset) ) ) FROM pg_stat_recovery_prefetch;",
+          "version": 15,
           "columns": [
             {
               "type": "counter",
@@ -1240,255 +1298,82 @@
             }
           ]
         }
-      ],
-      "tag": "pg_wal_prefetch_reset",
-      "collector": "wal_prefetch_reset"
+      ]
     },
     {
-      "queries": [
-        {
-          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "schemaname",
-              "type": "label"
-            },
-            {
-              "name": "relname",
-              "type": "label"
-            },
-            {
-              "name": "n_live_tup",
-              "type": "gauge",
-              "description": "Estimated number of live rows"
-            },
-            {
-              "name": "n_dead_tup",
-              "type": "gauge",
-              "description": "Estimated number of dead rows"
-            },
-            {
-              "name": "dead_rows_pct",
-              "type": "gauge",
-              "description": "Percentage of dead rows relative to live rows"
-            },
-            {
-              "name": "n_mod_since_analyze",
-              "type": "gauge",
-              "description": "Estimated number of rows modified since last analyze"
-            },
-            {
-              "name": "n_ins_since_vacuum",
-              "type": "gauge",
-              "description": "Estimated number of rows inserted since last vacuum"
-            },
-            {
-              "name": "last_vacuum_seconds",
-              "type": "gauge",
-              "description": "Seconds since last manual vacuum (-1 if never)"
-            },
-            {
-              "name": "last_autovacuum_seconds",
-              "type": "gauge",
-              "description": "Seconds since last autovacuum (-1 if never)"
-            },
-            {
-              "name": "last_analyze_seconds",
-              "type": "gauge",
-              "description": "Seconds since last manual analyze (-1 if never)"
-            },
-            {
-              "name": "last_autoanalyze_seconds",
-              "type": "gauge",
-              "description": "Seconds since last autoanalyze (-1 if never)"
-            },
-            {
-              "name": "vacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually vacuumed"
-            },
-            {
-              "name": "autovacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been vacuumed by autovacuum"
-            },
-            {
-              "name": "analyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually analyzed"
-            },
-            {
-              "name": "autoanalyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been analyzed by autoanalyze"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_user_tables_vacuum",
+      "tag": "pg_stat_database_conflicts",
+      "collector": "stat_conflicts",
       "sort": "data",
-      "collector": "stat_user_tables",
-      "database": "all"
-    },
-    {
       "queries": [
         {
-          "query": "WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "schemaname",
-              "type": "label"
-            },
-            {
-              "name": "relname",
-              "type": "label"
-            },
-            {
-              "name": "blocks_read",
-              "type": "counter",
-              "description": "Total blocks read from disk (heap + index)"
-            },
-            {
-              "name": "tuples_read",
-              "type": "counter",
-              "description": "Total number of tuples read (sequential + index scans)"
-            },
-            {
-              "name": "blocks_write",
-              "type": "gauge",
-              "description": "Estimated blocks affected by write operations"
-            },
-            {
-              "name": "tuples_write",
-              "type": "counter",
-              "description": "Total number of tuples inserted, updated, or deleted"
-            },
-            {
-              "name": "ratio_write",
-              "type": "gauge",
-              "description": "Percentage of I/O activity that is writes (0-100)"
-            },
-            {
-              "name": "ratio_read",
-              "type": "gauge",
-              "description": "Percentage of I/O activity that is reads (0-100)"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_table_ratio",
-      "sort": "data",
-      "collector": "table_activity_ratio",
-      "database": "all"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "schemaname",
-              "type": "label"
-            },
-            {
-              "name": "tblname",
-              "type": "label"
-            },
-            {
-              "name": "table_size",
-              "type": "gauge",
-              "description": "Actual table size in bytes"
-            },
-            {
-              "name": "bloat_size",
-              "type": "gauge",
-              "description": "Estimated bloat size in bytes"
-            },
-            {
-              "name": "bloat_ratio_pct",
-              "type": "gauge",
-              "description": "Bloat ratio as percentage"
-            },
-            {
-              "name": "tblpages",
-              "type": "gauge",
-              "description": "Actual number of pages used by table"
-            },
-            {
-              "name": "est_tblpages",
-              "type": "gauge",
-              "description": "Estimated number of pages needed"
-            },
-            {
-              "name": "block_size",
-              "type": "gauge",
-              "description": "Database block size in bytes"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_table_bloat",
-      "sort": "data",
-      "collector": "table_bloat",
-      "database": "all"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
           "version": 10,
           "columns": [
             {
-              "name": "blocked_pid",
+              "name": "database",
               "type": "label"
             },
             {
-              "name": "blocked_database",
-              "type": "label"
+              "name": "confl_tablespace",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_tablespace"
             },
             {
-              "name": "blocked_user",
-              "type": "label"
+              "name": "confl_lock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_lock"
             },
             {
-              "name": "blocked_query",
-              "type": "label"
+              "name": "confl_snapshot",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_snapshot"
             },
             {
-              "name": "blocked_duration_seconds",
-              "type": "gauge",
-              "description": "Duration in seconds that the vacuum has been blocked"
+              "name": "confl_bufferpin",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_bufferpin"
             },
             {
-              "name": "blocking_pid",
-              "type": "label"
-            },
-            {
-              "name": "blocking_database",
-              "type": "label"
-            },
-            {
-              "name": "blocking_user",
-              "type": "label"
-            },
-            {
-              "name": "blocking_query",
-              "type": "label"
-            },
-            {
-              "name": "blocking_duration_seconds",
-              "type": "gauge",
-              "description": "Duration in seconds that the blocking query has been running"
+              "name": "confl_deadlock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_deadlock"
             }
           ]
         }
-      ],
-      "tag": "pg_blocked_vacuum",
+      ]
+    },
+    {
+      "tag": "pg_stat_all_indexes",
+      "collector": "stat_all_indexes",
       "sort": "data",
-      "collector": "blocked_vacuum"
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes GROUP BY relname;",
+          "version": 10,
+          "columns": [
+            {
+              "type": "counter",
+              "name": "idx_scans",
+              "description": "Number of index scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_reads",
+              "description": "Number of index entries returned by scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_fetchs",
+              "description": "Number of rows fetched by simple index scans on the table's indexes."
+            },
+            {
+              "type": "label",
+              "name": "relname"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -2,6 +2,10 @@
   "version": 16,
   "metrics": [
     {
+      "tag": "postgresql_primary",
+      "collector": "primary",
+      "sort": "name",
+      "server": "both",
       "queries": [
         {
           "query": "SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );",
@@ -13,13 +17,12 @@
             }
           ]
         }
-      ],
-      "tag": "postgresql_primary",
-      "sort": "name",
-      "collector": "primary",
-      "server": "both"
+      ]
     },
     {
+      "tag": "pg_database_size",
+      "collector": "db",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, pg_database_size(datname) FROM pg_database;",
@@ -35,12 +38,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_database_size",
-      "sort": "data",
-      "collector": "db"
+      ]
     },
     {
+      "tag": "pg_locks_count",
+      "collector": "locks",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;",
@@ -60,12 +63,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_locks_count",
-      "sort": "data",
-      "collector": "locks"
+      ]
     },
     {
+      "tag": "pg_replication_slots",
+      "collector": "replication",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;",
@@ -95,12 +98,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_replication_slots",
-      "sort": "data",
-      "collector": "replication"
+      ]
     },
     {
+      "tag": "pg_stat_bgwriter",
+      "collector": "stat_bgwriter",
       "queries": [
         {
           "query": "SELECT buffers_alloc, buffers_backend, buffers_backend_fsync, buffers_checkpoint, buffers_clean, checkpoint_sync_time, checkpoint_write_time, checkpoints_req, checkpoints_timed, maxwritten_clean FROM pg_stat_bgwriter;",
@@ -158,11 +160,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_bgwriter",
-      "collector": "stat_bgwriter"
+      ]
     },
     {
+      "tag": "pg_process_idle_seconds",
+      "collector": "idle_procs",
       "queries": [
         {
           "query": "WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;",
@@ -179,11 +181,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_process_idle_seconds",
-      "collector": "idle_procs"
+      ]
     },
     {
+      "tag": "pg_available_extensions",
+      "collector": "available_extensions",
       "queries": [
         {
           "query": "SELECT COUNT(*) AS extensions FROM pg_available_extensions;",
@@ -195,11 +197,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_available_extensions",
-      "collector": "available_extensions"
+      ]
     },
     {
+      "tag": "pg_installed_extensions",
+      "collector": "installed_extensions",
       "queries": [
         {
           "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
@@ -215,11 +217,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_installed_extensions",
-      "collector": "installed_extensions"
+      ]
     },
     {
+      "tag": "pg_file_settings",
+      "collector": "file_settings",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -239,12 +242,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_file_settings",
-      "sort": "data",
-      "collector": "file_settings"
+      ]
     },
     {
+      "tag": "pg_indexes",
+      "collector": "indexes",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;",
@@ -264,12 +267,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_indexes",
-      "sort": "data",
-      "collector": "indexes"
+      ]
     },
     {
+      "tag": "pg_matviews",
+      "collector": "matviews",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;",
@@ -281,11 +283,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_matviews",
-      "collector": "matviews"
+      ]
     },
     {
+      "tag": "pg_role",
+      "collector": "roles",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_roles;",
@@ -297,11 +299,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_role",
-      "collector": "roles"
+      ]
     },
     {
+      "tag": "pg_rule",
+      "collector": "rules",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;",
@@ -317,12 +320,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_rule",
-      "sort": "data",
-      "collector": "rules"
+      ]
     },
     {
+      "tag": "pg_shadow",
+      "collector": "auth_type",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -338,12 +341,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_shadow",
-      "sort": "data",
-      "collector": "auth_type"
+      ]
     },
     {
+      "tag": "pg_usr_evt_trigger",
+      "collector": "usr_evt_trigger",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",
@@ -355,11 +357,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_usr_evt_trigger",
-      "collector": "usr_evt_trigger"
+      ]
     },
     {
+      "tag": "pg_db_conn",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;",
@@ -375,12 +378,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_db_conn_ssl",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;",
@@ -396,12 +399,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn_ssl",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_statio_all_tables",
+      "collector": "statio_all_tables",
       "queries": [
         {
           "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
@@ -449,11 +451,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_tables",
-      "collector": "statio_all_tables"
+      ]
     },
     {
+      "tag": "pg_statio_all_sequences",
+      "collector": "statio_all_sequences",
       "queries": [
         {
           "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
@@ -471,11 +473,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_sequences",
-      "collector": "statio_all_sequences"
+      ]
     },
     {
+      "tag": "pg_stat_user_functions",
+      "collector": "stat_user_functions",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;",
@@ -502,12 +505,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_user_functions",
-      "sort": "data",
-      "collector": "stat_user_functions"
+      ]
     },
     {
+      "tag": "pg_stat_replication",
+      "collector": "stat_replication",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;",
@@ -523,12 +526,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_replication",
-      "sort": "data",
-      "collector": "stat_replication"
+      ]
     },
     {
+      "tag": "pg_stat_archiver",
+      "collector": "stat_archiver",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;",
@@ -556,12 +559,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_archiver",
-      "sort": "data",
-      "collector": "stat_archiver"
+      ]
     },
     {
+      "tag": "pg_db_vacuum",
+      "collector": "db_vacuum",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
@@ -579,12 +582,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_view_vacuum",
+      "collector": "db_vacuum",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');",
@@ -602,12 +605,67 @@
             }
           ]
         }
-      ],
-      "tag": "pg_view_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_blocked_vacuum",
+      "collector": "blocked_vacuum",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "version": 10,
+          "columns": [
+            {
+              "name": "blocked_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocked_database",
+              "type": "label"
+            },
+            {
+              "name": "blocked_user",
+              "type": "label"
+            },
+            {
+              "name": "blocked_query",
+              "type": "label"
+            },
+            {
+              "name": "blocked_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the vacuum has been blocked"
+            },
+            {
+              "name": "blocking_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocking_database",
+              "type": "label"
+            },
+            {
+              "name": "blocking_user",
+              "type": "label"
+            },
+            {
+              "name": "blocking_query",
+              "type": "label"
+            },
+            {
+              "name": "blocking_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the blocking query has been running"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_wal_last_received",
+      "collector": "wal_last_received",
+      "server": "replica",
       "queries": [
         {
           "query": "SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;",
@@ -623,12 +681,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_wal_last_received",
-      "collector": "wal_last_received",
-      "server": "replica"
+      ]
     },
     {
+      "tag": "pg_gss_auth",
+      "collector": "gssapi",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;",
@@ -640,11 +697,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_gss_auth",
-      "collector": "gssapi"
+      ]
     },
     {
+      "tag": "pg_encrypted_conn",
+      "collector": "encryted_conns",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;",
@@ -656,11 +713,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_encrypted_conn",
-      "collector": "encryted_conns"
+      ]
     },
     {
+      "tag": "pg_shmem_allocations",
+      "collector": "shmem_size",
       "queries": [
         {
           "query": "SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;",
@@ -673,11 +730,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_shmem_allocations",
-      "collector": "shmem_size"
+      ]
     },
     {
+      "tag": "pg_stat_progress_vacuum",
+      "collector": "vacuum_progress",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
@@ -740,760 +798,83 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_progress_vacuum",
+      ]
+    },
+    {
+      "tag": "pg_stat_progress_analyze",
+      "collector": "analyze_progress",
       "sort": "data",
-      "collector": "vacuum_progress"
-    },
-    {
       "queries": [
         {
-          "query": "SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;",
-          "version": 14,
-          "columns": [
-            {
-              "name": "contexts",
-              "type": "gauge",
-              "description": "Number of memory contexts per parent."
-            },
-            {
-              "name": "parent",
-              "type": "label"
-            },
-            {
-              "name": "free_bytes",
-              "type": "gauge",
-              "description": "Free bytes per memory context."
-            },
-            {
-              "name": "used_bytes",
-              "type": "gauge",
-              "description": "Used bytes per memory context."
-            },
-            {
-              "name": "total_bytes",
-              "type": "gauge",
-              "description": "Total bytes per memory context."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_mem_ctx",
-      "collector": "mem_ctx"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal;",
-          "version": 14,
-          "columns": [
-            {
-              "name": "wal_records",
-              "type": "counter",
-              "description": "Number of WAL records generated."
-            },
-            {
-              "name": "wal_fpi",
-              "type": "counter",
-              "description": "Number of WAL full page images generated."
-            },
-            {
-              "name": "wal_bytes",
-              "type": "counter",
-              "description": "Total bytes of generated WAL."
-            },
-            {
-              "name": "wal_buffers_full",
-              "type": "counter",
-              "description": "Number of disk writes due to WAL buffers being full."
-            },
-            {
-              "name": "wal_write",
-              "type": "counter",
-              "description": "Number of times WAL files were written to disk."
-            },
-            {
-              "name": "wal_sync",
-              "type": "counter",
-              "description": "Number of times WAL files were synced to disk."
-            },
-            {
-              "name": "wal_write_time",
-              "type": "counter",
-              "description": "Time taken for WAL files to be written to disk."
-            },
-            {
-              "name": "wal_sync_time",
-              "type": "counter",
-              "description": "Time taken for WAL files to be synced to disk."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_wal",
-      "collector": "stat_wal"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            }
-          ],
-          "version": 10
-        },
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            },
-            {
-              "name": "checksum_failures",
-              "type": "gauge",
-              "description": "pg_stat_database_checksum_failures"
-            }
-          ],
-          "version": 12
-        },
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "version": 14,
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            },
-            {
-              "name": "checksum_failures",
-              "type": "gauge",
-              "description": "pg_stat_database_checksum_failures"
-            },
-            {
-              "name": "session_time",
-              "type": "gauge",
-              "description": "pg_stat_database_session_time"
-            },
-            {
-              "name": "active_time",
-              "type": "gauge",
-              "description": "pg_stat_database_active_time"
-            },
-            {
-              "name": "idle_in_transaction_time",
-              "type": "gauge",
-              "description": "pg_stat_database_idle_in_transaction_time"
-            },
-            {
-              "name": "sessions",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions"
-            },
-            {
-              "name": "sessions_abandoned",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions_abandoned"
-            },
-            {
-              "name": "sessions_fatal",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions_fatal"
-            },
-            {
-              "name": "sessions_killed",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions_killed"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_database",
-      "collector": "stat_db"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT FLOOR( EXTRACT( EPOCH FROM (now() - stats_reset) ) ) FROM pg_stat_recovery_prefetch;",
-          "version": 15,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Seconds from last WAL prefetch stats reset."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_wal_prefetch_reset",
-      "collector": "wal_prefetch_reset"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE credentials_delegated = 't' AND datname IS NOT NULL;",
-          "columns": [
-            {
-              "type": "gauge",
-              "description": "Number of DB connections with delegated GSSAPI credentials."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_gssapi_credentials_delegated",
-      "collector": "gssapi_creds_delegated"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT backend_type, SUM(COALESCE(reads, 0)) AS reads, SUM(COALESCE(read_time, 0)) AS read_time, SUM(COALESCE(writes, 0)) AS writes, SUM(COALESCE(write_time, 0)) AS write_time, SUM(COALESCE(writebacks, 0)) AS writebacks, SUM(COALESCE(writeback_time, 0)) AS writeback_time, SUM(COALESCE(extends, 0)) AS extends, SUM(COALESCE(extend_time, 0)) AS extend_time, AVG(COALESCE(op_bytes, 0)) AS op_bytes, SUM(COALESCE(hits, 0)) AS hits, SUM(COALESCE(evictions, 0)) AS evictions, SUM(COALESCE(reuses, 0)) AS reuses, SUM(COALESCE(fsyncs, 0)) AS fsyncs, SUM(COALESCE(fsync_time, 0)) AS fsync_time FROM pg_stat_io GROUP BY backend_type;",
-          "columns": [
-            {
-              "name": "backend_type",
-              "type": "label"
-            },
-            {
-              "name": "reads",
-              "type": "counter",
-              "description": "Number of read operations."
-            },
-            {
-              "name": "read_time",
-              "type": "counter",
-              "description": "Total time spent on read operations in milliseconds."
-            },
-            {
-              "name": "writes",
-              "type": "counter",
-              "description": "Number of write operations."
-            },
-            {
-              "name": "write_time",
-              "type": "counter",
-              "description": "Total time spent on write operations in milliseconds."
-            },
-            {
-              "name": "writebacks",
-              "type": "counter",
-              "description": "Number of writeback to permanent storage requests sent to kernel."
-            },
-            {
-              "name": "writeback_time",
-              "type": "counter",
-              "description": "Total time spent on writeback operations in milliseconds."
-            },
-            {
-              "name": "extends",
-              "type": "counter",
-              "description": "Number of relation extend operations."
-            },
-            {
-              "name": "extend_time",
-              "type": "counter",
-              "description": "Total time spent on relation extend operations in milliseconds."
-            },
-            {
-              "name": "op_bytes",
-              "type": "gauge",
-              "description": "Bytes per unit of I/O read, written or extended."
-            },
-            {
-              "name": "hits",
-              "type": "counter",
-              "description": "The number of times a desired block was found in shared buffer."
-            },
-            {
-              "name": "evictions",
-              "type": "counter",
-              "description": "The number of times a block has been written out from shared or local buffer in order to make it available for another use."
-            },
-            {
-              "name": "reuses",
-              "type": "counter",
-              "description": "The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation."
-            },
-            {
-              "name": "fsyncs",
-              "type": "counter",
-              "description": "Number of fsync calls."
-            },
-            {
-              "name": "fsync_time",
-              "type": "counter",
-              "description": "Total time spent on fsync operations in milliseconds."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_io",
-      "collector": "stat_io"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "confl_tablespace",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_tablespace"
-            },
-            {
-              "name": "confl_lock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_lock"
-            },
-            {
-              "name": "confl_snapshot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_snapshot"
-            },
-            {
-              "name": "confl_bufferpin",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_bufferpin"
-            },
-            {
-              "name": "confl_deadlock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_deadlock"
-            }
-          ],
-          "version": 10
-        },
-        {
-          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock, confl_active_logicalslot FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "confl_tablespace",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_tablespace"
-            },
-            {
-              "name": "confl_lock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_lock"
-            },
-            {
-              "name": "confl_snapshot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_snapshot"
-            },
-            {
-              "name": "confl_bufferpin",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_bufferpin"
-            },
-            {
-              "name": "confl_deadlock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_dead"
-            },
-            {
-              "name": "confl_active_logicalslot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_active_logicalslot"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_database_conflicts",
-      "sort": "data",
-      "collector": "stat_conflicts"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes GROUP BY relname;",
-          "columns": [
-            {
-              "type": "counter",
-              "name": "idx_scans",
-              "description": "Number of index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_reads",
-              "description": "Number of index entries returned by scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_fetchs",
-              "description": "Number of rows fetched by simple index scans on the table's indexes."
-            },
-            {
-              "type": "label",
-              "name": "relname"
-            }
-          ],
-          "version": 10
-        },
-        {
-          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, COALESCE(MIN((EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;",
-          "columns": [
-            {
-              "type": "counter",
-              "name": "idx_scans",
-              "description": "Number of index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_reads",
-              "description": "Number of index entries returned by scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_fetchs",
-              "description": "Number of rows fetched by simple index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "time_elapsed_ms",
-              "description": "Milliseconds since last scan of an index in the table."
-            },
-            {
-              "type": "label",
-              "name": "relname"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_all_indexes",
-      "sort": "data",
-      "collector": "stat_all_indexes",
-      "database": "all"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "query": "SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
           "version": 13,
           "columns": [
             {
-              "name": "schemaname",
+              "name": "pid",
               "type": "label"
             },
             {
-              "name": "relname",
+              "name": "datname",
               "type": "label"
             },
             {
-              "name": "n_live_tup",
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "phase",
+              "type": "label"
+            },
+            {
+              "name": "sample_blks_total",
               "type": "gauge",
-              "description": "Estimated number of live rows"
+              "description": "Total blocks to sample"
             },
             {
-              "name": "n_dead_tup",
+              "name": "sample_blks_scanned",
               "type": "gauge",
-              "description": "Estimated number of dead rows"
+              "description": "Blocks sampled so far"
             },
             {
-              "name": "dead_rows_pct",
+              "name": "ext_stats_total",
               "type": "gauge",
-              "description": "Percentage of dead rows relative to live rows"
+              "description": "Total extended statistics to compute"
             },
             {
-              "name": "n_mod_since_analyze",
+              "name": "ext_stats_computed",
               "type": "gauge",
-              "description": "Estimated number of rows modified since last analyze"
+              "description": "Extended statistics computed"
             },
             {
-              "name": "n_ins_since_vacuum",
+              "name": "child_tables_total",
               "type": "gauge",
-              "description": "Estimated number of rows inserted since last vacuum"
+              "description": "Total child tables to analyze"
             },
             {
-              "name": "last_vacuum_seconds",
+              "name": "child_tables_done",
               "type": "gauge",
-              "description": "Seconds since last manual vacuum (-1 if never)"
+              "description": "Child tables analyzed"
             },
             {
-              "name": "last_autovacuum_seconds",
+              "name": "pct_sample_completed",
               "type": "gauge",
-              "description": "Seconds since last autovacuum (-1 if never)"
+              "description": "Percentage of sampling completed"
             },
             {
-              "name": "last_analyze_seconds",
+              "name": "pct_child_tables_completed",
               "type": "gauge",
-              "description": "Seconds since last manual analyze (-1 if never)"
-            },
-            {
-              "name": "last_autoanalyze_seconds",
-              "type": "gauge",
-              "description": "Seconds since last autoanalyze (-1 if never)"
-            },
-            {
-              "name": "vacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually vacuumed"
-            },
-            {
-              "name": "autovacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been vacuumed by autovacuum"
-            },
-            {
-              "name": "analyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually analyzed"
-            },
-            {
-              "name": "autoanalyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been analyzed by autoanalyze"
+              "description": "Percentage of child tables completed"
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_user_tables_vacuum",
+      "collector": "stat_user_tables",
+      "sort": "data",
+      "database": "all",
+      "queries": [
         {
           "query": "SELECT schemaname, relname, seq_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds, seq_tup_read, idx_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_tup_newpage_upd, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
           "version": 16,
@@ -1628,13 +1009,13 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_user_tables_vacuum",
-      "sort": "data",
-      "collector": "stat_user_tables",
-      "database": "all"
+      ]
     },
     {
+      "tag": "pg_table_ratio",
+      "collector": "table_activity_ratio",
+      "sort": "data",
+      "database": "all",
       "queries": [
         {
           "query": "WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;",
@@ -1680,13 +1061,13 @@
             }
           ]
         }
-      ],
-      "tag": "pg_table_ratio",
-      "sort": "data",
-      "collector": "table_activity_ratio",
-      "database": "all"
+      ]
     },
     {
+      "tag": "pg_table_bloat",
+      "collector": "table_bloat",
+      "sort": "data",
+      "database": "all",
       "queries": [
         {
           "query": "SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;",
@@ -1732,66 +1113,472 @@
             }
           ]
         }
-      ],
-      "tag": "pg_table_bloat",
-      "sort": "data",
-      "collector": "table_bloat",
-      "database": "all"
+      ]
     },
     {
+      "tag": "pg_mem_ctx",
+      "collector": "mem_ctx",
       "queries": [
         {
-          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
-          "version": 10,
+          "query": "SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;",
+          "version": 14,
           "columns": [
             {
-              "name": "blocked_pid",
-              "type": "label"
-            },
-            {
-              "name": "blocked_database",
-              "type": "label"
-            },
-            {
-              "name": "blocked_user",
-              "type": "label"
-            },
-            {
-              "name": "blocked_query",
-              "type": "label"
-            },
-            {
-              "name": "blocked_duration_seconds",
+              "name": "contexts",
               "type": "gauge",
-              "description": "Duration in seconds that the vacuum has been blocked"
+              "description": "Number of memory contexts per parent."
             },
             {
-              "name": "blocking_pid",
+              "name": "parent",
               "type": "label"
             },
             {
-              "name": "blocking_database",
-              "type": "label"
-            },
-            {
-              "name": "blocking_user",
-              "type": "label"
-            },
-            {
-              "name": "blocking_query",
-              "type": "label"
-            },
-            {
-              "name": "blocking_duration_seconds",
+              "name": "free_bytes",
               "type": "gauge",
-              "description": "Duration in seconds that the blocking query has been running"
+              "description": "Free bytes per memory context."
+            },
+            {
+              "name": "used_bytes",
+              "type": "gauge",
+              "description": "Used bytes per memory context."
+            },
+            {
+              "name": "total_bytes",
+              "type": "gauge",
+              "description": "Total bytes per memory context."
             }
           ]
         }
-      ],
-      "tag": "pg_blocked_vacuum",
+      ]
+    },
+    {
+      "tag": "pg_stat_wal",
+      "collector": "stat_wal",
+      "queries": [
+        {
+          "query": "SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal;",
+          "version": 14,
+          "columns": [
+            {
+              "name": "wal_records",
+              "type": "counter",
+              "description": "Number of WAL records generated."
+            },
+            {
+              "name": "wal_fpi",
+              "type": "counter",
+              "description": "Number of WAL full page images generated."
+            },
+            {
+              "name": "wal_bytes",
+              "type": "counter",
+              "description": "Total bytes of generated WAL."
+            },
+            {
+              "name": "wal_buffers_full",
+              "type": "counter",
+              "description": "Number of disk writes due to WAL buffers being full."
+            },
+            {
+              "name": "wal_write",
+              "type": "counter",
+              "description": "Number of times WAL files were written to disk."
+            },
+            {
+              "name": "wal_sync",
+              "type": "counter",
+              "description": "Number of times WAL files were synced to disk."
+            },
+            {
+              "name": "wal_write_time",
+              "type": "counter",
+              "description": "Time taken for WAL files to be written to disk."
+            },
+            {
+              "name": "wal_sync_time",
+              "type": "counter",
+              "description": "Time taken for WAL files to be synced to disk."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_database",
+      "collector": "stat_db",
+      "queries": [
+        {
+          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
+          "version": 14,
+          "columns": [
+            {
+              "name": "database",
+              "type": "label"
+            },
+            {
+              "name": "blk_read_time",
+              "type": "counter",
+              "description": "pg_stat_database_blk_read_time"
+            },
+            {
+              "name": "blk_write_time",
+              "type": "counter",
+              "description": "pg_stat_database_blk_write_time"
+            },
+            {
+              "name": "blks_hit",
+              "type": "counter",
+              "description": "pg_stat_database_blks_hit"
+            },
+            {
+              "name": "blks_read",
+              "type": "counter",
+              "description": "pg_stat_database_blks_read"
+            },
+            {
+              "name": "deadlocks",
+              "type": "counter",
+              "description": "pg_stat_database_deadlocks"
+            },
+            {
+              "name": "temp_files",
+              "type": "gauge",
+              "description": "pg_stat_database_temp_files"
+            },
+            {
+              "name": "temp_bytes",
+              "type": "gauge",
+              "description": "pg_stat_database_temp_bytes"
+            },
+            {
+              "name": "tup_returned",
+              "type": "counter",
+              "description": "pg_stat_database_tup_returned"
+            },
+            {
+              "name": "tup_fetched",
+              "type": "counter",
+              "description": "pg_stat_database_tup_fetched"
+            },
+            {
+              "name": "tup_inserted",
+              "type": "counter",
+              "description": "pg_stat_database_tup_inserted"
+            },
+            {
+              "name": "tup_updated",
+              "type": "counter",
+              "description": "pg_stat_database_tup_updated"
+            },
+            {
+              "name": "tup_deleted",
+              "type": "counter",
+              "description": "pg_stat_database_tup_deleted"
+            },
+            {
+              "name": "xact_commit",
+              "type": "counter",
+              "description": "pg_stat_database_xact_commit"
+            },
+            {
+              "name": "xact_rollback",
+              "type": "counter",
+              "description": "pg_stat_database_xact_rollback"
+            },
+            {
+              "name": "conflicts",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts"
+            },
+            {
+              "name": "numbackends",
+              "type": "gauge",
+              "description": "pg_stat_database_numbackends"
+            },
+            {
+              "name": "checksum_failures",
+              "type": "gauge",
+              "description": "pg_stat_database_checksum_failures"
+            },
+            {
+              "name": "session_time",
+              "type": "gauge",
+              "description": "pg_stat_database_session_time"
+            },
+            {
+              "name": "active_time",
+              "type": "gauge",
+              "description": "pg_stat_database_active_time"
+            },
+            {
+              "name": "idle_in_transaction_time",
+              "type": "gauge",
+              "description": "pg_stat_database_idle_in_transaction_time"
+            },
+            {
+              "name": "sessions",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions"
+            },
+            {
+              "name": "sessions_abandoned",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions_abandoned"
+            },
+            {
+              "name": "sessions_fatal",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions_fatal"
+            },
+            {
+              "name": "sessions_killed",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions_killed"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_subscription_stats",
+      "collector": "subscription_stats",
       "sort": "data",
-      "collector": "blocked_vacuum"
+      "queries": [
+        {
+          "query": "SELECT subid, subname, apply_error_count, sync_error_count, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint AS stats_reset_seconds FROM pg_stat_subscription_stats;",
+          "version": 16,
+          "columns": [
+            {
+              "name": "subid",
+              "type": "label",
+              "description": "Subscription OID"
+            },
+            {
+              "name": "subname",
+              "type": "label",
+              "description": "Subscription name"
+            },
+            {
+              "name": "apply_error_count",
+              "type": "counter",
+              "description": "Number of errors during apply"
+            },
+            {
+              "name": "sync_error_count",
+              "type": "counter",
+              "description": "Number of errors during initial sync"
+            },
+            {
+              "name": "stats_reset_seconds",
+              "type": "counter",
+              "description": "Seconds since statistics were last reset"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_wal_prefetch_reset",
+      "collector": "wal_prefetch_reset",
+      "queries": [
+        {
+          "query": "SELECT FLOOR( EXTRACT( EPOCH FROM (now() - stats_reset) ) ) FROM pg_stat_recovery_prefetch;",
+          "version": 15,
+          "columns": [
+            {
+              "type": "counter",
+              "description": "Seconds from last WAL prefetch stats reset."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_gssapi_credentials_delegated",
+      "collector": "gssapi_creds_delegated",
+      "queries": [
+        {
+          "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE credentials_delegated = 't' AND datname IS NOT NULL;",
+          "version": 16,
+          "columns": [
+            {
+              "type": "gauge",
+              "description": "Number of DB connections with delegated GSSAPI credentials."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_io",
+      "collector": "stat_io",
+      "queries": [
+        {
+          "query": "SELECT backend_type, SUM(COALESCE(reads, 0)) AS reads, SUM(COALESCE(read_time, 0)) AS read_time, SUM(COALESCE(writes, 0)) AS writes, SUM(COALESCE(write_time, 0)) AS write_time, SUM(COALESCE(writebacks, 0)) AS writebacks, SUM(COALESCE(writeback_time, 0)) AS writeback_time, SUM(COALESCE(extends, 0)) AS extends, SUM(COALESCE(extend_time, 0)) AS extend_time, AVG(COALESCE(op_bytes, 0)) AS op_bytes, SUM(COALESCE(hits, 0)) AS hits, SUM(COALESCE(evictions, 0)) AS evictions, SUM(COALESCE(reuses, 0)) AS reuses, SUM(COALESCE(fsyncs, 0)) AS fsyncs, SUM(COALESCE(fsync_time, 0)) AS fsync_time FROM pg_stat_io GROUP BY backend_type;",
+          "version": 16,
+          "columns": [
+            {
+              "name": "backend_type",
+              "type": "label"
+            },
+            {
+              "name": "reads",
+              "type": "counter",
+              "description": "Number of read operations."
+            },
+            {
+              "name": "read_time",
+              "type": "counter",
+              "description": "Total time spent on read operations in milliseconds."
+            },
+            {
+              "name": "writes",
+              "type": "counter",
+              "description": "Number of write operations."
+            },
+            {
+              "name": "write_time",
+              "type": "counter",
+              "description": "Total time spent on write operations in milliseconds."
+            },
+            {
+              "name": "writebacks",
+              "type": "counter",
+              "description": "Number of writeback to permanent storage requests sent to kernel."
+            },
+            {
+              "name": "writeback_time",
+              "type": "counter",
+              "description": "Total time spent on writeback operations in milliseconds."
+            },
+            {
+              "name": "extends",
+              "type": "counter",
+              "description": "Number of relation extend operations."
+            },
+            {
+              "name": "extend_time",
+              "type": "counter",
+              "description": "Total time spent on relation extend operations in milliseconds."
+            },
+            {
+              "name": "op_bytes",
+              "type": "gauge",
+              "description": "Bytes per unit of I/O read, written or extended."
+            },
+            {
+              "name": "hits",
+              "type": "counter",
+              "description": "The number of times a desired block was found in shared buffer."
+            },
+            {
+              "name": "evictions",
+              "type": "counter",
+              "description": "The number of times a block has been written out from shared or local buffer in order to make it available for another use."
+            },
+            {
+              "name": "reuses",
+              "type": "counter",
+              "description": "The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation."
+            },
+            {
+              "name": "fsyncs",
+              "type": "counter",
+              "description": "Number of fsync calls."
+            },
+            {
+              "name": "fsync_time",
+              "type": "counter",
+              "description": "Total time spent on fsync operations in milliseconds."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_database_conflicts",
+      "collector": "stat_conflicts",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock, confl_active_logicalslot FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
+          "version": 16,
+          "columns": [
+            {
+              "name": "database",
+              "type": "label"
+            },
+            {
+              "name": "confl_tablespace",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_tablespace"
+            },
+            {
+              "name": "confl_lock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_lock"
+            },
+            {
+              "name": "confl_snapshot",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_snapshot"
+            },
+            {
+              "name": "confl_bufferpin",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_bufferpin"
+            },
+            {
+              "name": "confl_deadlock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_dead"
+            },
+            {
+              "name": "confl_active_logicalslot",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_active_logicalslot"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_all_indexes",
+      "collector": "stat_all_indexes",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, COALESCE(MIN((EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;",
+          "version": 16,
+          "columns": [
+            {
+              "type": "counter",
+              "name": "idx_scans",
+              "description": "Number of index scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_reads",
+              "description": "Number of index entries returned by scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_fetchs",
+              "description": "Number of rows fetched by simple index scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "time_elapsed_ms",
+              "description": "Milliseconds since last scan of an index in the table."
+            },
+            {
+              "type": "label",
+              "name": "relname"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -2,6 +2,10 @@
   "version": 17,
   "metrics": [
     {
+      "tag": "postgresql_primary",
+      "collector": "primary",
+      "sort": "name",
+      "server": "both",
       "queries": [
         {
           "query": "SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );",
@@ -13,13 +17,12 @@
             }
           ]
         }
-      ],
-      "tag": "postgresql_primary",
-      "sort": "name",
-      "collector": "primary",
-      "server": "both"
+      ]
     },
     {
+      "tag": "pg_database_size",
+      "collector": "db",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, pg_database_size(datname) FROM pg_database;",
@@ -35,12 +38,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_database_size",
-      "sort": "data",
-      "collector": "db"
+      ]
     },
     {
+      "tag": "pg_locks_count",
+      "collector": "locks",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;",
@@ -60,12 +63,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_locks_count",
-      "sort": "data",
-      "collector": "locks"
+      ]
     },
     {
+      "tag": "pg_replication_slots",
+      "collector": "replication",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;",
@@ -95,16 +98,15 @@
             }
           ]
         }
-      ],
-      "tag": "pg_replication_slots",
-      "sort": "data",
-      "collector": "replication"
+      ]
     },
     {
+      "tag": "pg_stat_bgwriter",
+      "collector": "stat_bgwriter",
       "queries": [
         {
           "query": "SELECT buffers_alloc, buffers_clean, maxwritten_clean FROM pg_stat_bgwriter;",
-          "version": 10,
+          "version": 17,
           "columns": [
             {
               "description": "pg_stat_bgwriter_buffers_alloc",
@@ -123,11 +125,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_bgwriter",
-      "collector": "stat_bgwriter"
+      ]
     },
     {
+      "tag": "pg_process_idle_seconds",
+      "collector": "idle_procs",
       "queries": [
         {
           "query": "WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;",
@@ -144,11 +146,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_process_idle_seconds",
-      "collector": "idle_procs"
+      ]
     },
     {
+      "tag": "pg_available_extensions",
+      "collector": "available_extensions",
       "queries": [
         {
           "query": "SELECT COUNT(*) AS extensions FROM pg_available_extensions;",
@@ -160,11 +162,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_available_extensions",
-      "collector": "available_extensions"
+      ]
     },
     {
+      "tag": "pg_installed_extensions",
+      "collector": "installed_extensions",
       "queries": [
         {
           "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
@@ -180,11 +182,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_installed_extensions",
-      "collector": "installed_extensions"
+      ]
     },
     {
+      "tag": "pg_file_settings",
+      "collector": "file_settings",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -204,12 +207,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_file_settings",
-      "sort": "data",
-      "collector": "file_settings"
+      ]
     },
     {
+      "tag": "pg_indexes",
+      "collector": "indexes",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;",
@@ -229,12 +232,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_indexes",
-      "sort": "data",
-      "collector": "indexes"
+      ]
     },
     {
+      "tag": "pg_matviews",
+      "collector": "matviews",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;",
@@ -246,11 +248,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_matviews",
-      "collector": "matviews"
+      ]
     },
     {
+      "tag": "pg_role",
+      "collector": "roles",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_roles;",
@@ -262,11 +264,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_role",
-      "collector": "roles"
+      ]
     },
     {
+      "tag": "pg_rule",
+      "collector": "rules",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;",
@@ -282,12 +285,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_rule",
-      "sort": "data",
-      "collector": "rules"
+      ]
     },
     {
+      "tag": "pg_shadow",
+      "collector": "auth_type",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -303,12 +306,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_shadow",
-      "sort": "data",
-      "collector": "auth_type"
+      ]
     },
     {
+      "tag": "pg_usr_evt_trigger",
+      "collector": "usr_evt_trigger",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",
@@ -320,11 +322,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_usr_evt_trigger",
-      "collector": "usr_evt_trigger"
+      ]
     },
     {
+      "tag": "pg_db_conn",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;",
@@ -340,12 +343,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_db_conn_ssl",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;",
@@ -361,12 +364,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn_ssl",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_statio_all_tables",
+      "collector": "statio_all_tables",
       "queries": [
         {
           "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
@@ -414,11 +416,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_tables",
-      "collector": "statio_all_tables"
+      ]
     },
     {
+      "tag": "pg_statio_all_sequences",
+      "collector": "statio_all_sequences",
       "queries": [
         {
           "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
@@ -436,11 +438,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_sequences",
-      "collector": "statio_all_sequences"
+      ]
     },
     {
+      "tag": "pg_stat_user_functions",
+      "collector": "stat_user_functions",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;",
@@ -467,12 +470,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_user_functions",
-      "sort": "data",
-      "collector": "stat_user_functions"
+      ]
     },
     {
+      "tag": "pg_stat_replication",
+      "collector": "stat_replication",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;",
@@ -488,12 +491,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_replication",
-      "sort": "data",
-      "collector": "stat_replication"
+      ]
     },
     {
+      "tag": "pg_stat_archiver",
+      "collector": "stat_archiver",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;",
@@ -521,12 +524,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_archiver",
-      "sort": "data",
-      "collector": "stat_archiver"
+      ]
     },
     {
+      "tag": "pg_db_vacuum",
+      "collector": "db_vacuum",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
@@ -544,12 +547,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_view_vacuum",
+      "collector": "db_vacuum",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');",
@@ -567,12 +570,67 @@
             }
           ]
         }
-      ],
-      "tag": "pg_view_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_blocked_vacuum",
+      "collector": "blocked_vacuum",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "version": 10,
+          "columns": [
+            {
+              "name": "blocked_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocked_database",
+              "type": "label"
+            },
+            {
+              "name": "blocked_user",
+              "type": "label"
+            },
+            {
+              "name": "blocked_query",
+              "type": "label"
+            },
+            {
+              "name": "blocked_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the vacuum has been blocked"
+            },
+            {
+              "name": "blocking_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocking_database",
+              "type": "label"
+            },
+            {
+              "name": "blocking_user",
+              "type": "label"
+            },
+            {
+              "name": "blocking_query",
+              "type": "label"
+            },
+            {
+              "name": "blocking_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the blocking query has been running"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_wal_last_received",
+      "collector": "wal_last_received",
+      "server": "replica",
       "queries": [
         {
           "query": "SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;",
@@ -588,12 +646,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_wal_last_received",
-      "collector": "wal_last_received",
-      "server": "replica"
+      ]
     },
     {
+      "tag": "pg_gss_auth",
+      "collector": "gssapi",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;",
@@ -605,11 +662,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_gss_auth",
-      "collector": "gssapi"
+      ]
     },
     {
+      "tag": "pg_encrypted_conn",
+      "collector": "encryted_conns",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;",
@@ -621,11 +678,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_encrypted_conn",
-      "collector": "encryted_conns"
+      ]
     },
     {
+      "tag": "pg_shmem_allocations",
+      "collector": "shmem_size",
       "queries": [
         {
           "query": "SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;",
@@ -638,73 +695,13 @@
             }
           ]
         }
-      ],
-      "tag": "pg_shmem_allocations",
-      "collector": "shmem_size"
+      ]
     },
     {
+      "tag": "pg_stat_progress_vacuum",
+      "collector": "vacuum_progress",
+      "sort": "data",
       "queries": [
-        {
-          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "pid",
-              "type": "label"
-            },
-            {
-              "name": "datname",
-              "type": "label"
-            },
-            {
-              "name": "usename",
-              "type": "label"
-            },
-            {
-              "name": "query",
-              "type": "label"
-            },
-            {
-              "name": "phase",
-              "type": "label"
-            },
-            {
-              "name": "heap_blks_total",
-              "type": "gauge",
-              "description": "Total heap blocks in table"
-            },
-            {
-              "name": "heap_blks_scanned",
-              "type": "gauge",
-              "description": "Heap blocks scanned"
-            },
-            {
-              "name": "heap_blks_vacuumed",
-              "type": "gauge",
-              "description": "Heap blocks vacuumed"
-            },
-            {
-              "name": "index_vacuum_count",
-              "type": "gauge",
-              "description": "Number of index vacuum cycles completed"
-            },
-            {
-              "name": "max_dead_tuples",
-              "type": "gauge",
-              "description": "Maximum dead tuples"
-            },
-            {
-              "name": "num_dead_tuples",
-              "type": "gauge",
-              "description": "Current dead tuples"
-            },
-            {
-              "name": "pct_scan_completed",
-              "type": "gauge",
-              "description": "Vacuum scan progress percentage"
-            }
-          ]
-        },
         {
           "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuple_bytes, p.dead_tuple_bytes, p.num_dead_item_ids, p.indexes_total, p.indexes_processed, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed, CASE WHEN p.indexes_total > 0 THEN round(100 * p.indexes_processed / p.indexes_total, 2) ELSE 0 END AS pct_index_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
           "version": 17,
@@ -786,781 +783,83 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_progress_vacuum",
+      ]
+    },
+    {
+      "tag": "pg_stat_progress_analyze",
+      "collector": "analyze_progress",
       "sort": "data",
-      "collector": "vacuum_progress"
-    },
-    {
       "queries": [
         {
-          "query": "SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;",
-          "version": 14,
-          "columns": [
-            {
-              "name": "contexts",
-              "type": "gauge",
-              "description": "Number of memory contexts per parent."
-            },
-            {
-              "name": "parent",
-              "type": "label"
-            },
-            {
-              "name": "free_bytes",
-              "type": "gauge",
-              "description": "Free bytes per memory context."
-            },
-            {
-              "name": "used_bytes",
-              "type": "gauge",
-              "description": "Used bytes per memory context."
-            },
-            {
-              "name": "total_bytes",
-              "type": "gauge",
-              "description": "Total bytes per memory context."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_mem_ctx",
-      "collector": "mem_ctx"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal;",
-          "version": 14,
-          "columns": [
-            {
-              "name": "wal_records",
-              "type": "counter",
-              "description": "Number of WAL records generated."
-            },
-            {
-              "name": "wal_fpi",
-              "type": "counter",
-              "description": "Number of WAL full page images generated."
-            },
-            {
-              "name": "wal_bytes",
-              "type": "counter",
-              "description": "Total bytes of generated WAL."
-            },
-            {
-              "name": "wal_buffers_full",
-              "type": "counter",
-              "description": "Number of disk writes due to WAL buffers being full."
-            },
-            {
-              "name": "wal_write",
-              "type": "counter",
-              "description": "Number of times WAL files were written to disk."
-            },
-            {
-              "name": "wal_sync",
-              "type": "counter",
-              "description": "Number of times WAL files were synced to disk."
-            },
-            {
-              "name": "wal_write_time",
-              "type": "counter",
-              "description": "Time taken for WAL files to be written to disk."
-            },
-            {
-              "name": "wal_sync_time",
-              "type": "counter",
-              "description": "Time taken for WAL files to be synced to disk."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_wal",
-      "collector": "stat_wal"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            }
-          ],
-          "version": 10
-        },
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            },
-            {
-              "name": "checksum_failures",
-              "type": "gauge",
-              "description": "pg_stat_database_checksum_failures"
-            }
-          ],
-          "version": 12
-        },
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "version": 14,
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            },
-            {
-              "name": "checksum_failures",
-              "type": "gauge",
-              "description": "pg_stat_database_checksum_failures"
-            },
-            {
-              "name": "session_time",
-              "type": "gauge",
-              "description": "pg_stat_database_session_time"
-            },
-            {
-              "name": "active_time",
-              "type": "gauge",
-              "description": "pg_stat_database_active_time"
-            },
-            {
-              "name": "idle_in_transaction_time",
-              "type": "gauge",
-              "description": "pg_stat_database_idle_in_transaction_time"
-            },
-            {
-              "name": "sessions",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions"
-            },
-            {
-              "name": "sessions_abandoned",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions_abandoned"
-            },
-            {
-              "name": "sessions_fatal",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions_fatal"
-            },
-            {
-              "name": "sessions_killed",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions_killed"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_database",
-      "collector": "stat_db"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT FLOOR( EXTRACT( EPOCH FROM (now() - stats_reset) ) ) FROM pg_stat_recovery_prefetch;",
-          "version": 15,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Seconds from last WAL prefetch stats reset."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_wal_prefetch_reset",
-      "collector": "wal_prefetch_reset"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE credentials_delegated = 't' AND datname IS NOT NULL;",
-          "columns": [
-            {
-              "type": "gauge",
-              "description": "Number of DB connections with delegated GSSAPI credentials."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_gssapi_credentials_delegated",
-      "collector": "gssapi_creds_delegated"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT backend_type, SUM(COALESCE(reads, 0)) AS reads, SUM(COALESCE(read_time, 0)) AS read_time, SUM(COALESCE(writes, 0)) AS writes, SUM(COALESCE(write_time, 0)) AS write_time, SUM(COALESCE(writebacks, 0)) AS writebacks, SUM(COALESCE(writeback_time, 0)) AS writeback_time, SUM(COALESCE(extends, 0)) AS extends, SUM(COALESCE(extend_time, 0)) AS extend_time, AVG(COALESCE(op_bytes, 0)) AS op_bytes, SUM(COALESCE(hits, 0)) AS hits, SUM(COALESCE(evictions, 0)) AS evictions, SUM(COALESCE(reuses, 0)) AS reuses, SUM(COALESCE(fsyncs, 0)) AS fsyncs, SUM(COALESCE(fsync_time, 0)) AS fsync_time FROM pg_stat_io GROUP BY backend_type;",
-          "columns": [
-            {
-              "name": "backend_type",
-              "type": "label"
-            },
-            {
-              "name": "reads",
-              "type": "counter",
-              "description": "Number of read operations."
-            },
-            {
-              "name": "read_time",
-              "type": "counter",
-              "description": "Total time spent on read operations in milliseconds."
-            },
-            {
-              "name": "writes",
-              "type": "counter",
-              "description": "Number of write operations."
-            },
-            {
-              "name": "write_time",
-              "type": "counter",
-              "description": "Total time spent on write operations in milliseconds."
-            },
-            {
-              "name": "writebacks",
-              "type": "counter",
-              "description": "Number of writeback to permanent storage requests sent to kernel."
-            },
-            {
-              "name": "writeback_time",
-              "type": "counter",
-              "description": "Total time spent on writeback operations in milliseconds."
-            },
-            {
-              "name": "extends",
-              "type": "counter",
-              "description": "Number of relation extend operations."
-            },
-            {
-              "name": "extend_time",
-              "type": "counter",
-              "description": "Total time spent on relation extend operations in milliseconds."
-            },
-            {
-              "name": "op_bytes",
-              "type": "gauge",
-              "description": "Bytes per unit of I/O read, written or extended."
-            },
-            {
-              "name": "hits",
-              "type": "counter",
-              "description": "The number of times a desired block was found in shared buffer."
-            },
-            {
-              "name": "evictions",
-              "type": "counter",
-              "description": "The number of times a block has been written out from shared or local buffer in order to make it available for another use."
-            },
-            {
-              "name": "reuses",
-              "type": "counter",
-              "description": "The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation."
-            },
-            {
-              "name": "fsyncs",
-              "type": "counter",
-              "description": "Number of fsync calls."
-            },
-            {
-              "name": "fsync_time",
-              "type": "counter",
-              "description": "Total time spent on fsync operations in milliseconds."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_io",
-      "collector": "stat_io"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "confl_tablespace",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_tablespace"
-            },
-            {
-              "name": "confl_lock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_lock"
-            },
-            {
-              "name": "confl_snapshot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_snapshot"
-            },
-            {
-              "name": "confl_bufferpin",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_bufferpin"
-            },
-            {
-              "name": "confl_deadlock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_deadlock"
-            }
-          ],
-          "version": 10
-        },
-        {
-          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock, confl_active_logicalslot FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "confl_tablespace",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_tablespace"
-            },
-            {
-              "name": "confl_lock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_lock"
-            },
-            {
-              "name": "confl_snapshot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_snapshot"
-            },
-            {
-              "name": "confl_bufferpin",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_bufferpin"
-            },
-            {
-              "name": "confl_deadlock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_dead"
-            },
-            {
-              "name": "confl_active_logicalslot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_active_logicalslot"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_database_conflicts",
-      "sort": "data",
-      "collector": "stat_conflicts"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes GROUP BY relname;",
-          "columns": [
-            {
-              "type": "counter",
-              "name": "idx_scans",
-              "description": "Number of index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_reads",
-              "description": "Number of index entries returned by scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_fetchs",
-              "description": "Number of rows fetched by simple index scans on the table's indexes."
-            },
-            {
-              "type": "label",
-              "name": "relname"
-            }
-          ],
-          "version": 10
-        },
-        {
-          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, COALESCE(MIN((EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;",
-          "columns": [
-            {
-              "type": "counter",
-              "name": "idx_scans",
-              "description": "Number of index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_reads",
-              "description": "Number of index entries returned by scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_fetchs",
-              "description": "Number of rows fetched by simple index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "time_elapsed_ms",
-              "description": "Milliseconds since last scan of an index in the table."
-            },
-            {
-              "type": "label",
-              "name": "relname"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_all_indexes",
-      "sort": "data",
-      "collector": "stat_all_indexes",
-      "database": "all"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT type, count(*) as count FROM pg_wait_events GROUP BY type ORDER BY count DESC;",
-          "columns": [
-            {
-              "name": "type",
-              "type": "label"
-            },
-            {
-              "name": "count",
-              "type": "gauge",
-              "description": "pg_wait_events_count"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_wait_events",
-      "sort": "data",
-      "collector": "wait_events"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
+          "query": "SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
           "version": 13,
           "columns": [
             {
-              "name": "schemaname",
+              "name": "pid",
               "type": "label"
             },
             {
-              "name": "relname",
+              "name": "datname",
               "type": "label"
             },
             {
-              "name": "n_live_tup",
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "phase",
+              "type": "label"
+            },
+            {
+              "name": "sample_blks_total",
               "type": "gauge",
-              "description": "Estimated number of live rows"
+              "description": "Total blocks to sample"
             },
             {
-              "name": "n_dead_tup",
+              "name": "sample_blks_scanned",
               "type": "gauge",
-              "description": "Estimated number of dead rows"
+              "description": "Blocks sampled so far"
             },
             {
-              "name": "dead_rows_pct",
+              "name": "ext_stats_total",
               "type": "gauge",
-              "description": "Percentage of dead rows relative to live rows"
+              "description": "Total extended statistics to compute"
             },
             {
-              "name": "n_mod_since_analyze",
+              "name": "ext_stats_computed",
               "type": "gauge",
-              "description": "Estimated number of rows modified since last analyze"
+              "description": "Extended statistics computed"
             },
             {
-              "name": "n_ins_since_vacuum",
+              "name": "child_tables_total",
               "type": "gauge",
-              "description": "Estimated number of rows inserted since last vacuum"
+              "description": "Total child tables to analyze"
             },
             {
-              "name": "last_vacuum_seconds",
+              "name": "child_tables_done",
               "type": "gauge",
-              "description": "Seconds since last manual vacuum (-1 if never)"
+              "description": "Child tables analyzed"
             },
             {
-              "name": "last_autovacuum_seconds",
+              "name": "pct_sample_completed",
               "type": "gauge",
-              "description": "Seconds since last autovacuum (-1 if never)"
+              "description": "Percentage of sampling completed"
             },
             {
-              "name": "last_analyze_seconds",
+              "name": "pct_child_tables_completed",
               "type": "gauge",
-              "description": "Seconds since last manual analyze (-1 if never)"
-            },
-            {
-              "name": "last_autoanalyze_seconds",
-              "type": "gauge",
-              "description": "Seconds since last autoanalyze (-1 if never)"
-            },
-            {
-              "name": "vacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually vacuumed"
-            },
-            {
-              "name": "autovacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been vacuumed by autovacuum"
-            },
-            {
-              "name": "analyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually analyzed"
-            },
-            {
-              "name": "autoanalyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been analyzed by autoanalyze"
+              "description": "Percentage of child tables completed"
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_user_tables_vacuum",
+      "collector": "stat_user_tables",
+      "sort": "data",
+      "database": "all",
+      "queries": [
         {
           "query": "SELECT schemaname, relname, seq_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds, seq_tup_read, idx_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_tup_newpage_upd, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
           "version": 16,
@@ -1695,13 +994,13 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_user_tables_vacuum",
-      "sort": "data",
-      "collector": "stat_user_tables",
-      "database": "all"
+      ]
     },
     {
+      "tag": "pg_table_ratio",
+      "collector": "table_activity_ratio",
+      "sort": "data",
+      "database": "all",
       "queries": [
         {
           "query": "WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;",
@@ -1747,13 +1046,13 @@
             }
           ]
         }
-      ],
-      "tag": "pg_table_ratio",
-      "sort": "data",
-      "collector": "table_activity_ratio",
-      "database": "all"
+      ]
     },
     {
+      "tag": "pg_table_bloat",
+      "collector": "table_bloat",
+      "sort": "data",
+      "database": "all",
       "queries": [
         {
           "query": "SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;",
@@ -1799,66 +1098,551 @@
             }
           ]
         }
-      ],
-      "tag": "pg_table_bloat",
-      "sort": "data",
-      "collector": "table_bloat",
-      "database": "all"
+      ]
     },
     {
+      "tag": "pg_mem_ctx",
+      "collector": "mem_ctx",
       "queries": [
         {
-          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
-          "version": 10,
+          "query": "SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;",
+          "version": 14,
           "columns": [
             {
-              "name": "blocked_pid",
-              "type": "label"
-            },
-            {
-              "name": "blocked_database",
-              "type": "label"
-            },
-            {
-              "name": "blocked_user",
-              "type": "label"
-            },
-            {
-              "name": "blocked_query",
-              "type": "label"
-            },
-            {
-              "name": "blocked_duration_seconds",
+              "name": "contexts",
               "type": "gauge",
-              "description": "Duration in seconds that the vacuum has been blocked"
+              "description": "Number of memory contexts per parent."
             },
             {
-              "name": "blocking_pid",
+              "name": "parent",
               "type": "label"
             },
             {
-              "name": "blocking_database",
-              "type": "label"
-            },
-            {
-              "name": "blocking_user",
-              "type": "label"
-            },
-            {
-              "name": "blocking_query",
-              "type": "label"
-            },
-            {
-              "name": "blocking_duration_seconds",
+              "name": "free_bytes",
               "type": "gauge",
-              "description": "Duration in seconds that the blocking query has been running"
+              "description": "Free bytes per memory context."
+            },
+            {
+              "name": "used_bytes",
+              "type": "gauge",
+              "description": "Used bytes per memory context."
+            },
+            {
+              "name": "total_bytes",
+              "type": "gauge",
+              "description": "Total bytes per memory context."
             }
           ]
         }
-      ],
-      "tag": "pg_blocked_vacuum",
+      ]
+    },
+    {
+      "tag": "pg_stat_wal",
+      "collector": "stat_wal",
+      "queries": [
+        {
+          "query": "SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal;",
+          "version": 14,
+          "columns": [
+            {
+              "name": "wal_records",
+              "type": "counter",
+              "description": "Number of WAL records generated."
+            },
+            {
+              "name": "wal_fpi",
+              "type": "counter",
+              "description": "Number of WAL full page images generated."
+            },
+            {
+              "name": "wal_bytes",
+              "type": "counter",
+              "description": "Total bytes of generated WAL."
+            },
+            {
+              "name": "wal_buffers_full",
+              "type": "counter",
+              "description": "Number of disk writes due to WAL buffers being full."
+            },
+            {
+              "name": "wal_write",
+              "type": "counter",
+              "description": "Number of times WAL files were written to disk."
+            },
+            {
+              "name": "wal_sync",
+              "type": "counter",
+              "description": "Number of times WAL files were synced to disk."
+            },
+            {
+              "name": "wal_write_time",
+              "type": "counter",
+              "description": "Time taken for WAL files to be written to disk."
+            },
+            {
+              "name": "wal_sync_time",
+              "type": "counter",
+              "description": "Time taken for WAL files to be synced to disk."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_database",
+      "collector": "stat_db",
+      "queries": [
+        {
+          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
+          "version": 14,
+          "columns": [
+            {
+              "name": "database",
+              "type": "label"
+            },
+            {
+              "name": "blk_read_time",
+              "type": "counter",
+              "description": "pg_stat_database_blk_read_time"
+            },
+            {
+              "name": "blk_write_time",
+              "type": "counter",
+              "description": "pg_stat_database_blk_write_time"
+            },
+            {
+              "name": "blks_hit",
+              "type": "counter",
+              "description": "pg_stat_database_blks_hit"
+            },
+            {
+              "name": "blks_read",
+              "type": "counter",
+              "description": "pg_stat_database_blks_read"
+            },
+            {
+              "name": "deadlocks",
+              "type": "counter",
+              "description": "pg_stat_database_deadlocks"
+            },
+            {
+              "name": "temp_files",
+              "type": "gauge",
+              "description": "pg_stat_database_temp_files"
+            },
+            {
+              "name": "temp_bytes",
+              "type": "gauge",
+              "description": "pg_stat_database_temp_bytes"
+            },
+            {
+              "name": "tup_returned",
+              "type": "counter",
+              "description": "pg_stat_database_tup_returned"
+            },
+            {
+              "name": "tup_fetched",
+              "type": "counter",
+              "description": "pg_stat_database_tup_fetched"
+            },
+            {
+              "name": "tup_inserted",
+              "type": "counter",
+              "description": "pg_stat_database_tup_inserted"
+            },
+            {
+              "name": "tup_updated",
+              "type": "counter",
+              "description": "pg_stat_database_tup_updated"
+            },
+            {
+              "name": "tup_deleted",
+              "type": "counter",
+              "description": "pg_stat_database_tup_deleted"
+            },
+            {
+              "name": "xact_commit",
+              "type": "counter",
+              "description": "pg_stat_database_xact_commit"
+            },
+            {
+              "name": "xact_rollback",
+              "type": "counter",
+              "description": "pg_stat_database_xact_rollback"
+            },
+            {
+              "name": "conflicts",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts"
+            },
+            {
+              "name": "numbackends",
+              "type": "gauge",
+              "description": "pg_stat_database_numbackends"
+            },
+            {
+              "name": "checksum_failures",
+              "type": "gauge",
+              "description": "pg_stat_database_checksum_failures"
+            },
+            {
+              "name": "session_time",
+              "type": "gauge",
+              "description": "pg_stat_database_session_time"
+            },
+            {
+              "name": "active_time",
+              "type": "gauge",
+              "description": "pg_stat_database_active_time"
+            },
+            {
+              "name": "idle_in_transaction_time",
+              "type": "gauge",
+              "description": "pg_stat_database_idle_in_transaction_time"
+            },
+            {
+              "name": "sessions",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions"
+            },
+            {
+              "name": "sessions_abandoned",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions_abandoned"
+            },
+            {
+              "name": "sessions_fatal",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions_fatal"
+            },
+            {
+              "name": "sessions_killed",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions_killed"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_subscription_stats",
+      "collector": "subscription_stats",
       "sort": "data",
-      "collector": "blocked_vacuum"
+      "queries": [
+        {
+          "query": "SELECT subid, subname, apply_error_count, sync_error_count, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint AS stats_reset_seconds FROM pg_stat_subscription_stats;",
+          "version": 16,
+          "columns": [
+            {
+              "name": "subid",
+              "type": "label",
+              "description": "Subscription OID"
+            },
+            {
+              "name": "subname",
+              "type": "label",
+              "description": "Subscription name"
+            },
+            {
+              "name": "apply_error_count",
+              "type": "counter",
+              "description": "Number of errors during apply"
+            },
+            {
+              "name": "sync_error_count",
+              "type": "counter",
+              "description": "Number of errors during initial sync"
+            },
+            {
+              "name": "stats_reset_seconds",
+              "type": "counter",
+              "description": "Seconds since statistics were last reset"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_wal_prefetch_reset",
+      "collector": "wal_prefetch_reset",
+      "queries": [
+        {
+          "query": "SELECT FLOOR( EXTRACT( EPOCH FROM (now() - stats_reset) ) ) FROM pg_stat_recovery_prefetch;",
+          "version": 15,
+          "columns": [
+            {
+              "type": "counter",
+              "description": "Seconds from last WAL prefetch stats reset."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_gssapi_credentials_delegated",
+      "collector": "gssapi_creds_delegated",
+      "queries": [
+        {
+          "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE credentials_delegated = 't' AND datname IS NOT NULL;",
+          "version": 16,
+          "columns": [
+            {
+              "type": "gauge",
+              "description": "Number of DB connections with delegated GSSAPI credentials."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_io",
+      "collector": "stat_io",
+      "queries": [
+        {
+          "query": "SELECT backend_type, SUM(COALESCE(reads, 0)) AS reads, SUM(COALESCE(read_time, 0)) AS read_time, SUM(COALESCE(writes, 0)) AS writes, SUM(COALESCE(write_time, 0)) AS write_time, SUM(COALESCE(writebacks, 0)) AS writebacks, SUM(COALESCE(writeback_time, 0)) AS writeback_time, SUM(COALESCE(extends, 0)) AS extends, SUM(COALESCE(extend_time, 0)) AS extend_time, AVG(COALESCE(op_bytes, 0)) AS op_bytes, SUM(COALESCE(hits, 0)) AS hits, SUM(COALESCE(evictions, 0)) AS evictions, SUM(COALESCE(reuses, 0)) AS reuses, SUM(COALESCE(fsyncs, 0)) AS fsyncs, SUM(COALESCE(fsync_time, 0)) AS fsync_time FROM pg_stat_io GROUP BY backend_type;",
+          "version": 16,
+          "columns": [
+            {
+              "name": "backend_type",
+              "type": "label"
+            },
+            {
+              "name": "reads",
+              "type": "counter",
+              "description": "Number of read operations."
+            },
+            {
+              "name": "read_time",
+              "type": "counter",
+              "description": "Total time spent on read operations in milliseconds."
+            },
+            {
+              "name": "writes",
+              "type": "counter",
+              "description": "Number of write operations."
+            },
+            {
+              "name": "write_time",
+              "type": "counter",
+              "description": "Total time spent on write operations in milliseconds."
+            },
+            {
+              "name": "writebacks",
+              "type": "counter",
+              "description": "Number of writeback to permanent storage requests sent to kernel."
+            },
+            {
+              "name": "writeback_time",
+              "type": "counter",
+              "description": "Total time spent on writeback operations in milliseconds."
+            },
+            {
+              "name": "extends",
+              "type": "counter",
+              "description": "Number of relation extend operations."
+            },
+            {
+              "name": "extend_time",
+              "type": "counter",
+              "description": "Total time spent on relation extend operations in milliseconds."
+            },
+            {
+              "name": "op_bytes",
+              "type": "gauge",
+              "description": "Bytes per unit of I/O read, written or extended."
+            },
+            {
+              "name": "hits",
+              "type": "counter",
+              "description": "The number of times a desired block was found in shared buffer."
+            },
+            {
+              "name": "evictions",
+              "type": "counter",
+              "description": "The number of times a block has been written out from shared or local buffer in order to make it available for another use."
+            },
+            {
+              "name": "reuses",
+              "type": "counter",
+              "description": "The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation."
+            },
+            {
+              "name": "fsyncs",
+              "type": "counter",
+              "description": "Number of fsync calls."
+            },
+            {
+              "name": "fsync_time",
+              "type": "counter",
+              "description": "Total time spent on fsync operations in milliseconds."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_database_conflicts",
+      "collector": "stat_conflicts",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock, confl_active_logicalslot FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
+          "version": 16,
+          "columns": [
+            {
+              "name": "database",
+              "type": "label"
+            },
+            {
+              "name": "confl_tablespace",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_tablespace"
+            },
+            {
+              "name": "confl_lock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_lock"
+            },
+            {
+              "name": "confl_snapshot",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_snapshot"
+            },
+            {
+              "name": "confl_bufferpin",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_bufferpin"
+            },
+            {
+              "name": "confl_deadlock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_dead"
+            },
+            {
+              "name": "confl_active_logicalslot",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_active_logicalslot"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_all_indexes",
+      "collector": "stat_all_indexes",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, COALESCE(MIN((EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;",
+          "version": 16,
+          "columns": [
+            {
+              "type": "counter",
+              "name": "idx_scans",
+              "description": "Number of index scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_reads",
+              "description": "Number of index entries returned by scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_fetchs",
+              "description": "Number of rows fetched by simple index scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "time_elapsed_ms",
+              "description": "Milliseconds since last scan of an index in the table."
+            },
+            {
+              "type": "label",
+              "name": "relname"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_checkpointer",
+      "collector": "stat_checkpointer",
+      "queries": [
+        {
+          "query": "SELECT num_timed, num_requested, restartpoints_timed, restartpoints_req, restartpoints_done, write_time, sync_time, buffers_written, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint AS stats_reset_seconds FROM pg_stat_checkpointer;",
+          "version": 17,
+          "columns": [
+            {
+              "name": "num_timed",
+              "type": "counter",
+              "description": "Number of scheduled checkpoints performed"
+            },
+            {
+              "name": "num_requested",
+              "type": "counter",
+              "description": "Number of requested checkpoints performed"
+            },
+            {
+              "name": "restartpoints_timed",
+              "type": "counter",
+              "description": "Number of scheduled restartpoints on replica"
+            },
+            {
+              "name": "restartpoints_req",
+              "type": "counter",
+              "description": "Number of requested restartpoints on replica"
+            },
+            {
+              "name": "restartpoints_done",
+              "type": "counter",
+              "description": "Number of restartpoints completed on replica"
+            },
+            {
+              "name": "write_time",
+              "type": "counter",
+              "description": "Total time spent writing buffers during checkpoints (ms)"
+            },
+            {
+              "name": "sync_time",
+              "type": "counter",
+              "description": "Total time spent syncing buffers during checkpoints (ms)"
+            },
+            {
+              "name": "buffers_written",
+              "type": "counter",
+              "description": "Number of buffers written during checkpoints"
+            },
+            {
+              "name": "stats_reset_seconds",
+              "type": "counter",
+              "description": "Seconds since statistics were last reset"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_wait_events",
+      "collector": "wait_events",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT type, count(*) as count FROM pg_wait_events GROUP BY type ORDER BY count DESC;",
+          "version": 17,
+          "columns": [
+            {
+              "name": "type",
+              "type": "label"
+            },
+            {
+              "name": "count",
+              "type": "gauge",
+              "description": "pg_wait_events_count"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/contrib/json/postgresql-18.json
+++ b/contrib/json/postgresql-18.json
@@ -2,6 +2,10 @@
   "version": 18,
   "metrics": [
     {
+      "tag": "postgresql_primary",
+      "collector": "primary",
+      "sort": "name",
+      "server": "both",
       "queries": [
         {
           "query": "SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );",
@@ -13,13 +17,12 @@
             }
           ]
         }
-      ],
-      "tag": "postgresql_primary",
-      "sort": "name",
-      "collector": "primary",
-      "server": "both"
+      ]
     },
     {
+      "tag": "pg_database_size",
+      "collector": "db",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, pg_database_size(datname) FROM pg_database;",
@@ -35,12 +38,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_database_size",
-      "sort": "data",
-      "collector": "db"
+      ]
     },
     {
+      "tag": "pg_locks_count",
+      "collector": "locks",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;",
@@ -60,16 +63,16 @@
             }
           ]
         }
-      ],
-      "tag": "pg_locks_count",
-      "sort": "data",
-      "collector": "locks"
+      ]
     },
     {
+      "tag": "pg_replication_slots",
+      "collector": "replication",
+      "sort": "data",
       "queries": [
         {
-          "query": "SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;",
-          "version": 10,
+          "query": "SELECT slot_name, slot_type, database, active, temporary, two_phase, two_phase_at, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - inactive_since))::bigint AS inactive_since_seconds, conflicting, invalidation_reason, failover, synced FROM pg_replication_slots;",
+          "version": 18,
           "columns": [
             {
               "name": "slot_name",
@@ -84,27 +87,61 @@
               "type": "label"
             },
             {
-              "description": "Is the replication active",
               "name": "active",
-              "type": "gauge"
+              "type": "gauge",
+              "description": "Is the replication active"
             },
             {
-              "description": "Is the replication temporary",
               "name": "temporary",
-              "type": "gauge"
+              "type": "gauge",
+              "description": "Is the replication temporary"
+            },
+            {
+              "name": "two_phase",
+              "type": "gauge",
+              "description": "Is two-phase commit enabled for this slot"
+            },
+            {
+              "name": "two_phase_at",
+              "type": "label",
+              "description": "LSN at which two-phase state was enabled"
+            },
+            {
+              "name": "inactive_since_seconds",
+              "type": "gauge",
+              "description": "Seconds since slot became inactive (-1 if active or NULL)"
+            },
+            {
+              "name": "conflicting",
+              "type": "gauge",
+              "description": "Is this slot conflicting with other slots"
+            },
+            {
+              "name": "invalidation_reason",
+              "type": "label",
+              "description": "Reason slot was invalidated"
+            },
+            {
+              "name": "failover",
+              "type": "gauge",
+              "description": "Is failover enabled for this slot"
+            },
+            {
+              "name": "synced",
+              "type": "gauge",
+              "description": "Is this slot synced from primary"
             }
           ]
         }
-      ],
-      "tag": "pg_replication_slots",
-      "sort": "data",
-      "collector": "replication"
+      ]
     },
     {
+      "tag": "pg_stat_bgwriter",
+      "collector": "stat_bgwriter",
       "queries": [
         {
           "query": "SELECT buffers_alloc, buffers_clean, maxwritten_clean FROM pg_stat_bgwriter;",
-          "version": 10,
+          "version": 17,
           "columns": [
             {
               "description": "pg_stat_bgwriter_buffers_alloc",
@@ -123,11 +160,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_bgwriter",
-      "collector": "stat_bgwriter"
+      ]
     },
     {
+      "tag": "pg_process_idle_seconds",
+      "collector": "idle_procs",
       "queries": [
         {
           "query": "WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;",
@@ -144,11 +181,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_process_idle_seconds",
-      "collector": "idle_procs"
+      ]
     },
     {
+      "tag": "pg_available_extensions",
+      "collector": "available_extensions",
       "queries": [
         {
           "query": "SELECT COUNT(*) AS extensions FROM pg_available_extensions;",
@@ -160,11 +197,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_available_extensions",
-      "collector": "available_extensions"
+      ]
     },
     {
+      "tag": "pg_installed_extensions",
+      "collector": "installed_extensions",
       "queries": [
         {
           "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
@@ -180,11 +217,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_installed_extensions",
-      "collector": "installed_extensions"
+      ]
     },
     {
+      "tag": "pg_file_settings",
+      "collector": "file_settings",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -204,12 +242,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_file_settings",
-      "sort": "data",
-      "collector": "file_settings"
+      ]
     },
     {
+      "tag": "pg_indexes",
+      "collector": "indexes",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;",
@@ -229,12 +267,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_indexes",
-      "sort": "data",
-      "collector": "indexes"
+      ]
     },
     {
+      "tag": "pg_matviews",
+      "collector": "matviews",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;",
@@ -246,11 +283,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_matviews",
-      "collector": "matviews"
+      ]
     },
     {
+      "tag": "pg_role",
+      "collector": "roles",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_roles;",
@@ -262,11 +299,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_role",
-      "collector": "roles"
+      ]
     },
     {
+      "tag": "pg_rule",
+      "collector": "rules",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;",
@@ -282,12 +320,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_rule",
-      "sort": "data",
-      "collector": "rules"
+      ]
     },
     {
+      "tag": "pg_shadow",
+      "collector": "auth_type",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -303,12 +341,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_shadow",
-      "sort": "data",
-      "collector": "auth_type"
+      ]
     },
     {
+      "tag": "pg_usr_evt_trigger",
+      "collector": "usr_evt_trigger",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",
@@ -320,11 +357,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_usr_evt_trigger",
-      "collector": "usr_evt_trigger"
+      ]
     },
     {
+      "tag": "pg_db_conn",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;",
@@ -340,12 +378,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_db_conn_ssl",
+      "collector": "connections",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;",
@@ -361,12 +399,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_conn_ssl",
-      "sort": "data",
-      "collector": "connections"
+      ]
     },
     {
+      "tag": "pg_statio_all_tables",
+      "collector": "statio_all_tables",
       "queries": [
         {
           "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
@@ -414,11 +451,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_tables",
-      "collector": "statio_all_tables"
+      ]
     },
     {
+      "tag": "pg_statio_all_sequences",
+      "collector": "statio_all_sequences",
       "queries": [
         {
           "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
@@ -436,11 +473,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_statio_all_sequences",
-      "collector": "statio_all_sequences"
+      ]
     },
     {
+      "tag": "pg_stat_user_functions",
+      "collector": "stat_user_functions",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;",
@@ -467,12 +505,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_user_functions",
-      "sort": "data",
-      "collector": "stat_user_functions"
+      ]
     },
     {
+      "tag": "pg_stat_replication",
+      "collector": "stat_replication",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;",
@@ -488,12 +526,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_replication",
-      "sort": "data",
-      "collector": "stat_replication"
+      ]
     },
     {
+      "tag": "pg_stat_archiver",
+      "collector": "stat_archiver",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;",
@@ -521,12 +559,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_archiver",
-      "sort": "data",
-      "collector": "stat_archiver"
+      ]
     },
     {
+      "tag": "pg_db_vacuum",
+      "collector": "db_vacuum",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
@@ -544,12 +582,12 @@
             }
           ]
         }
-      ],
-      "tag": "pg_db_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_view_vacuum",
+      "collector": "db_vacuum",
+      "sort": "data",
       "queries": [
         {
           "query": "SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');",
@@ -567,12 +605,67 @@
             }
           ]
         }
-      ],
-      "tag": "pg_view_vacuum",
-      "sort": "data",
-      "collector": "db_vacuum"
+      ]
     },
     {
+      "tag": "pg_blocked_vacuum",
+      "collector": "blocked_vacuum",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
+          "version": 10,
+          "columns": [
+            {
+              "name": "blocked_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocked_database",
+              "type": "label"
+            },
+            {
+              "name": "blocked_user",
+              "type": "label"
+            },
+            {
+              "name": "blocked_query",
+              "type": "label"
+            },
+            {
+              "name": "blocked_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the vacuum has been blocked"
+            },
+            {
+              "name": "blocking_pid",
+              "type": "label"
+            },
+            {
+              "name": "blocking_database",
+              "type": "label"
+            },
+            {
+              "name": "blocking_user",
+              "type": "label"
+            },
+            {
+              "name": "blocking_query",
+              "type": "label"
+            },
+            {
+              "name": "blocking_duration_seconds",
+              "type": "gauge",
+              "description": "Duration in seconds that the blocking query has been running"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_wal_last_received",
+      "collector": "wal_last_received",
+      "server": "replica",
       "queries": [
         {
           "query": "SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;",
@@ -588,12 +681,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_wal_last_received",
-      "collector": "wal_last_received",
-      "server": "replica"
+      ]
     },
     {
+      "tag": "pg_gss_auth",
+      "collector": "gssapi",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;",
@@ -605,11 +697,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_gss_auth",
-      "collector": "gssapi"
+      ]
     },
     {
+      "tag": "pg_encrypted_conn",
+      "collector": "encryted_conns",
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;",
@@ -621,11 +713,11 @@
             }
           ]
         }
-      ],
-      "tag": "pg_encrypted_conn",
-      "collector": "encryted_conns"
+      ]
     },
     {
+      "tag": "pg_shmem_allocations",
+      "collector": "shmem_size",
       "queries": [
         {
           "query": "SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;",
@@ -638,76 +730,59 @@
             }
           ]
         }
-      ],
-      "tag": "pg_shmem_allocations",
-      "collector": "shmem_size"
+      ]
     },
     {
+      "tag": "pg_shmem_allocations_numa",
+      "collector": "shmem_numa",
+      "sort": "data",
       "queries": [
         {
-          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
-          "version": 13,
+          "query": "SELECT numa_node, COUNT(*) AS allocations, SUM(size) AS total_bytes, AVG(size) AS avg_bytes, MAX(size) AS max_bytes, MIN(size) AS min_bytes FROM pg_shmem_allocations_numa GROUP BY numa_node ORDER BY numa_node;",
+          "version": 18,
           "columns": [
             {
-              "name": "pid",
-              "type": "label"
+              "name": "numa_node",
+              "type": "label",
+              "description": "NUMA node number"
             },
             {
-              "name": "datname",
-              "type": "label"
-            },
-            {
-              "name": "usename",
-              "type": "label"
-            },
-            {
-              "name": "query",
-              "type": "label"
-            },
-            {
-              "name": "phase",
-              "type": "label"
-            },
-            {
-              "name": "heap_blks_total",
+              "name": "allocations",
               "type": "gauge",
-              "description": "Total heap blocks in table"
+              "description": "Number of shared memory allocations on this NUMA node"
             },
             {
-              "name": "heap_blks_scanned",
+              "name": "total_bytes",
               "type": "gauge",
-              "description": "Heap blocks scanned"
+              "description": "Total bytes allocated on this NUMA node"
             },
             {
-              "name": "heap_blks_vacuumed",
+              "name": "avg_bytes",
               "type": "gauge",
-              "description": "Heap blocks vacuumed"
+              "description": "Average allocation size on this NUMA node"
             },
             {
-              "name": "index_vacuum_count",
+              "name": "max_bytes",
               "type": "gauge",
-              "description": "Number of index vacuum cycles completed"
+              "description": "Maximum allocation size on this NUMA node"
             },
             {
-              "name": "max_dead_tuples",
+              "name": "min_bytes",
               "type": "gauge",
-              "description": "Maximum dead tuples"
-            },
-            {
-              "name": "num_dead_tuples",
-              "type": "gauge",
-              "description": "Current dead tuples"
-            },
-            {
-              "name": "pct_scan_completed",
-              "type": "gauge",
-              "description": "Vacuum scan progress percentage"
+              "description": "Minimum allocation size on this NUMA node"
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_progress_vacuum",
+      "collector": "vacuum_progress",
+      "sort": "data",
+      "queries": [
         {
-          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuple_bytes, p.dead_tuple_bytes, p.num_dead_item_ids, p.indexes_total, p.indexes_processed, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed, CASE WHEN p.indexes_total > 0 THEN round(100 * p.indexes_processed / p.indexes_total, 2) ELSE 0 END AS pct_index_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
-          "version": 17,
+          "query": "SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuple_bytes, p.dead_tuple_bytes, p.num_dead_item_ids, p.indexes_total, p.indexes_processed, p.delay_time, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed, CASE WHEN p.indexes_total > 0 THEN round(100 * p.indexes_processed / p.indexes_total, 2) ELSE 0 END AS pct_index_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
+          "version": 18,
           "columns": [
             {
               "name": "pid",
@@ -775,6 +850,11 @@
               "description": "Number of indexes processed"
             },
             {
+              "name": "delay_time",
+              "type": "gauge",
+              "description": "Total time spent in vacuum delay/throttling (milliseconds)"
+            },
+            {
               "name": "pct_scan_completed",
               "type": "gauge",
               "description": "Vacuum scan progress percentage"
@@ -786,951 +866,91 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_progress_vacuum",
-      "sort": "data",
-      "collector": "vacuum_progress"
+      ]
     },
     {
+      "tag": "pg_stat_progress_analyze",
+      "collector": "analyze_progress",
+      "sort": "data",
       "queries": [
         {
-          "query": "SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;",
-          "version": 14,
-          "columns": [
-            {
-              "name": "contexts",
-              "type": "gauge",
-              "description": "Number of memory contexts per parent."
-            },
-            {
-              "name": "parent",
-              "type": "label"
-            },
-            {
-              "name": "free_bytes",
-              "type": "gauge",
-              "description": "Free bytes per memory context."
-            },
-            {
-              "name": "used_bytes",
-              "type": "gauge",
-              "description": "Used bytes per memory context."
-            },
-            {
-              "name": "total_bytes",
-              "type": "gauge",
-              "description": "Total bytes per memory context."
-            }
-          ]
-        },
-        {
-          "query": "SELECT\n  COUNT(*) AS contexts,\n  type,\n  SUM(free_bytes) AS free_bytes,\n  SUM(used_bytes) AS used_bytes,\n  SUM(total_bytes) AS total_bytes\nFROM pg_backend_memory_contexts\nWHERE type!=''\nGROUP BY type;",
+          "query": "SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, p.delay_time, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;",
           "version": 18,
           "columns": [
             {
-              "name": "contexts",
-              "type": "gauge",
-              "description": "Number of memory contexts per type."
+              "name": "pid",
+              "type": "label"
             },
             {
-              "name": "type",
-              "type": "label",
-              "description": "Memory context type"
+              "name": "datname",
+              "type": "label"
             },
             {
-              "name": "free_bytes",
-              "type": "gauge",
-              "description": "Free bytes per memory context type."
+              "name": "usename",
+              "type": "label"
             },
             {
-              "name": "used_bytes",
-              "type": "gauge",
-              "description": "Used bytes per memory context type."
+              "name": "phase",
+              "type": "label"
             },
             {
-              "name": "total_bytes",
+              "name": "sample_blks_total",
               "type": "gauge",
-              "description": "Total bytes per memory context type."
+              "description": "Total blocks to sample"
+            },
+            {
+              "name": "sample_blks_scanned",
+              "type": "gauge",
+              "description": "Blocks sampled so far"
+            },
+            {
+              "name": "ext_stats_total",
+              "type": "gauge",
+              "description": "Total extended statistics to compute"
+            },
+            {
+              "name": "ext_stats_computed",
+              "type": "gauge",
+              "description": "Extended statistics computed"
+            },
+            {
+              "name": "child_tables_total",
+              "type": "gauge",
+              "description": "Total child tables to analyze"
+            },
+            {
+              "name": "child_tables_done",
+              "type": "gauge",
+              "description": "Child tables analyzed"
+            },
+            {
+              "name": "delay_time",
+              "type": "gauge",
+              "description": "Total time spent in analyze delay/throttling (milliseconds)"
+            },
+            {
+              "name": "pct_sample_completed",
+              "type": "gauge",
+              "description": "Percentage of sampling completed"
+            },
+            {
+              "name": "pct_child_tables_completed",
+              "type": "gauge",
+              "description": "Percentage of child tables completed"
             }
           ]
         }
-      ],
-      "tag": "pg_mem_ctx",
-      "collector": "mem_ctx"
+      ]
     },
     {
+      "tag": "pg_stat_user_tables_vacuum",
+      "collector": "stat_user_tables",
+      "sort": "data",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal;",
-          "version": 14,
-          "columns": [
-            {
-              "name": "wal_records",
-              "type": "counter",
-              "description": "Number of WAL records generated."
-            },
-            {
-              "name": "wal_fpi",
-              "type": "counter",
-              "description": "Number of WAL full page images generated."
-            },
-            {
-              "name": "wal_bytes",
-              "type": "counter",
-              "description": "Total bytes of generated WAL."
-            },
-            {
-              "name": "wal_buffers_full",
-              "type": "counter",
-              "description": "Number of disk writes due to WAL buffers being full."
-            },
-            {
-              "name": "wal_write",
-              "type": "counter",
-              "description": "Number of times WAL files were written to disk."
-            },
-            {
-              "name": "wal_sync",
-              "type": "counter",
-              "description": "Number of times WAL files were synced to disk."
-            },
-            {
-              "name": "wal_write_time",
-              "type": "counter",
-              "description": "Time taken for WAL files to be written to disk."
-            },
-            {
-              "name": "wal_sync_time",
-              "type": "counter",
-              "description": "Time taken for WAL files to be synced to disk."
-            }
-          ]
-        },
-        {
-          "query": "WITH wal_io AS (\n  SELECT\n    sum(writes) as wal_write,\n    sum(fsyncs) as wal_sync,\n    sum(write_time) as wal_write_time,\n    sum(fsync_time) as wal_sync_time\n  FROM pg_stat_io\n  WHERE object = 'wal'\n)\nSELECT\n  wal_records,\n  wal_fpi,\n  wal_bytes,\n  wal_buffers_full,\n  wal_write,\n  wal_sync,\n  wal_write_time,\n  wal_sync_time\nFROM pg_stat_wal, wal_io;",
+          "query": "SELECT schemaname, relname, seq_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds, seq_tup_read, idx_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_tup_newpage_upd, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count, total_vacuum_time, total_autovacuum_time, total_analyze_time, total_autoanalyze_time FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
           "version": 18,
-          "columns": [
-            {
-              "name": "wal_records",
-              "type": "counter",
-              "description": "Number of WAL records generated."
-            },
-            {
-              "name": "wal_fpi",
-              "type": "counter",
-              "description": "Number of WAL full page images generated."
-            },
-            {
-              "name": "wal_bytes",
-              "type": "counter",
-              "description": "Total bytes of generated WAL."
-            },
-            {
-              "name": "wal_buffers_full",
-              "type": "counter",
-              "description": "Number of disk writes due to WAL buffers being full."
-            },
-            {
-              "name": "wal_write",
-              "type": "counter",
-              "description": "Number of times WAL files were written to disk (from pg_stat_io)."
-            },
-            {
-              "name": "wal_sync",
-              "type": "counter",
-              "description": "Number of times WAL files were synced to disk (from pg_stat_io)."
-            },
-            {
-              "name": "wal_write_time",
-              "type": "counter",
-              "description": "Time taken for WAL files to be written to disk in milliseconds (from pg_stat_io)."
-            },
-            {
-              "name": "wal_sync_time",
-              "type": "counter",
-              "description": "Time taken for WAL files to be synced to disk in milliseconds (from pg_stat_io)."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_wal",
-      "collector": "stat_wal"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            }
-          ],
-          "version": 10
-        },
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            },
-            {
-              "name": "checksum_failures",
-              "type": "gauge",
-              "description": "pg_stat_database_checksum_failures"
-            }
-          ],
-          "version": 12
-        },
-        {
-          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
-          "version": 14,
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "blk_read_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_read_time"
-            },
-            {
-              "name": "blk_write_time",
-              "type": "counter",
-              "description": "pg_stat_database_blk_write_time"
-            },
-            {
-              "name": "blks_hit",
-              "type": "counter",
-              "description": "pg_stat_database_blks_hit"
-            },
-            {
-              "name": "blks_read",
-              "type": "counter",
-              "description": "pg_stat_database_blks_read"
-            },
-            {
-              "name": "deadlocks",
-              "type": "counter",
-              "description": "pg_stat_database_deadlocks"
-            },
-            {
-              "name": "temp_files",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_files"
-            },
-            {
-              "name": "temp_bytes",
-              "type": "gauge",
-              "description": "pg_stat_database_temp_bytes"
-            },
-            {
-              "name": "tup_returned",
-              "type": "counter",
-              "description": "pg_stat_database_tup_returned"
-            },
-            {
-              "name": "tup_fetched",
-              "type": "counter",
-              "description": "pg_stat_database_tup_fetched"
-            },
-            {
-              "name": "tup_inserted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_inserted"
-            },
-            {
-              "name": "tup_updated",
-              "type": "counter",
-              "description": "pg_stat_database_tup_updated"
-            },
-            {
-              "name": "tup_deleted",
-              "type": "counter",
-              "description": "pg_stat_database_tup_deleted"
-            },
-            {
-              "name": "xact_commit",
-              "type": "counter",
-              "description": "pg_stat_database_xact_commit"
-            },
-            {
-              "name": "xact_rollback",
-              "type": "counter",
-              "description": "pg_stat_database_xact_rollback"
-            },
-            {
-              "name": "conflicts",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts"
-            },
-            {
-              "name": "numbackends",
-              "type": "gauge",
-              "description": "pg_stat_database_numbackends"
-            },
-            {
-              "name": "checksum_failures",
-              "type": "gauge",
-              "description": "pg_stat_database_checksum_failures"
-            },
-            {
-              "name": "session_time",
-              "type": "gauge",
-              "description": "pg_stat_database_session_time"
-            },
-            {
-              "name": "active_time",
-              "type": "gauge",
-              "description": "pg_stat_database_active_time"
-            },
-            {
-              "name": "idle_in_transaction_time",
-              "type": "gauge",
-              "description": "pg_stat_database_idle_in_transaction_time"
-            },
-            {
-              "name": "sessions",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions"
-            },
-            {
-              "name": "sessions_abandoned",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions_abandoned"
-            },
-            {
-              "name": "sessions_fatal",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions_fatal"
-            },
-            {
-              "name": "sessions_killed",
-              "type": "gauge",
-              "description": "pg_stat_database_sessions_killed"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_database",
-      "collector": "stat_db"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT FLOOR( EXTRACT( EPOCH FROM (now() - stats_reset) ) ) FROM pg_stat_recovery_prefetch;",
-          "version": 15,
-          "columns": [
-            {
-              "type": "counter",
-              "description": "Seconds from last WAL prefetch stats reset."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_wal_prefetch_reset",
-      "collector": "wal_prefetch_reset"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE credentials_delegated = 't' AND datname IS NOT NULL;",
-          "columns": [
-            {
-              "type": "gauge",
-              "description": "Number of DB connections with delegated GSSAPI credentials."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_gssapi_credentials_delegated",
-      "collector": "gssapi_creds_delegated"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT backend_type, SUM(COALESCE(reads, 0)) AS reads, SUM(COALESCE(read_time, 0)) AS read_time, SUM(COALESCE(writes, 0)) AS writes, SUM(COALESCE(write_time, 0)) AS write_time, SUM(COALESCE(writebacks, 0)) AS writebacks, SUM(COALESCE(writeback_time, 0)) AS writeback_time, SUM(COALESCE(extends, 0)) AS extends, SUM(COALESCE(extend_time, 0)) AS extend_time, AVG(COALESCE(op_bytes, 0)) AS op_bytes, SUM(COALESCE(hits, 0)) AS hits, SUM(COALESCE(evictions, 0)) AS evictions, SUM(COALESCE(reuses, 0)) AS reuses, SUM(COALESCE(fsyncs, 0)) AS fsyncs, SUM(COALESCE(fsync_time, 0)) AS fsync_time FROM pg_stat_io GROUP BY backend_type;",
-          "columns": [
-            {
-              "name": "backend_type",
-              "type": "label"
-            },
-            {
-              "name": "reads",
-              "type": "counter",
-              "description": "Number of read operations."
-            },
-            {
-              "name": "read_time",
-              "type": "counter",
-              "description": "Total time spent on read operations in milliseconds."
-            },
-            {
-              "name": "writes",
-              "type": "counter",
-              "description": "Number of write operations."
-            },
-            {
-              "name": "write_time",
-              "type": "counter",
-              "description": "Total time spent on write operations in milliseconds."
-            },
-            {
-              "name": "writebacks",
-              "type": "counter",
-              "description": "Number of writeback to permanent storage requests sent to kernel."
-            },
-            {
-              "name": "writeback_time",
-              "type": "counter",
-              "description": "Total time spent on writeback operations in milliseconds."
-            },
-            {
-              "name": "extends",
-              "type": "counter",
-              "description": "Number of relation extend operations."
-            },
-            {
-              "name": "extend_time",
-              "type": "counter",
-              "description": "Total time spent on relation extend operations in milliseconds."
-            },
-            {
-              "name": "op_bytes",
-              "type": "gauge",
-              "description": "Bytes per unit of I/O read, written or extended."
-            },
-            {
-              "name": "hits",
-              "type": "counter",
-              "description": "The number of times a desired block was found in shared buffer."
-            },
-            {
-              "name": "evictions",
-              "type": "counter",
-              "description": "The number of times a block has been written out from shared or local buffer in order to make it available for another use."
-            },
-            {
-              "name": "reuses",
-              "type": "counter",
-              "description": "The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation."
-            },
-            {
-              "name": "fsyncs",
-              "type": "counter",
-              "description": "Number of fsync calls."
-            },
-            {
-              "name": "fsync_time",
-              "type": "counter",
-              "description": "Total time spent on fsync operations in milliseconds."
-            }
-          ]
-        },
-        {
-          "query": "SELECT\n  backend_type,\n  SUM(COALESCE(reads, 0)) AS reads,\n  SUM(COALESCE(read_bytes, 0)) AS read_bytes,\n  SUM(COALESCE(read_time, 0)) AS read_time,\n  SUM(COALESCE(writes, 0)) AS writes,\n  SUM(COALESCE(write_bytes, 0)) AS write_bytes,\n  SUM(COALESCE(write_time, 0)) AS write_time,\n  SUM(COALESCE(writebacks, 0)) AS writebacks,\n  SUM(COALESCE(writeback_time, 0)) AS writeback_time,\n  SUM(COALESCE(extends, 0)) AS extends,\n  SUM(COALESCE(extend_bytes, 0)) AS extend_bytes,\n  SUM(COALESCE(extend_time, 0)) AS extend_time,\n  SUM(COALESCE(hits, 0)) AS hits,\n  SUM(COALESCE(evictions, 0)) AS evictions,\n  SUM(COALESCE(reuses, 0)) AS reuses,\n  SUM(COALESCE(fsyncs, 0)) AS fsyncs,\n  SUM(COALESCE(fsync_time, 0)) AS fsync_time\nFROM pg_stat_io\nGROUP BY backend_type;",
-          "version": 18,
-          "columns": [
-            {
-              "name": "backend_type",
-              "type": "label"
-            },
-            {
-              "name": "reads",
-              "type": "counter",
-              "description": "Number of read operations."
-            },
-            {
-              "name": "read_bytes",
-              "type": "counter",
-              "description": "Total bytes read."
-            },
-            {
-              "name": "read_time",
-              "type": "counter",
-              "description": "Total time spent on read operations in milliseconds."
-            },
-            {
-              "name": "writes",
-              "type": "counter",
-              "description": "Number of write operations."
-            },
-            {
-              "name": "write_bytes",
-              "type": "counter",
-              "description": "Total bytes written."
-            },
-            {
-              "name": "write_time",
-              "type": "counter",
-              "description": "Total time spent on write operations in milliseconds."
-            },
-            {
-              "name": "writebacks",
-              "type": "counter",
-              "description": "Number of writeback to permanent storage requests sent to kernel."
-            },
-            {
-              "name": "writeback_time",
-              "type": "counter",
-              "description": "Total time spent on writeback operations in milliseconds."
-            },
-            {
-              "name": "extends",
-              "type": "counter",
-              "description": "Number of relation extend operations."
-            },
-            {
-              "name": "extend_bytes",
-              "type": "counter",
-              "description": "Total bytes extended."
-            },
-            {
-              "name": "extend_time",
-              "type": "counter",
-              "description": "Total time spent on relation extend operations in milliseconds."
-            },
-            {
-              "name": "hits",
-              "type": "counter",
-              "description": "The number of times a desired block was found in shared buffer."
-            },
-            {
-              "name": "evictions",
-              "type": "counter",
-              "description": "The number of times a block has been written out from shared or local buffer in order to make it available for another use."
-            },
-            {
-              "name": "reuses",
-              "type": "counter",
-              "description": "The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation."
-            },
-            {
-              "name": "fsyncs",
-              "type": "counter",
-              "description": "Number of fsync calls."
-            },
-            {
-              "name": "fsync_time",
-              "type": "counter",
-              "description": "Total time spent on fsync operations in milliseconds."
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_io",
-      "collector": "stat_io"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "confl_tablespace",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_tablespace"
-            },
-            {
-              "name": "confl_lock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_lock"
-            },
-            {
-              "name": "confl_snapshot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_snapshot"
-            },
-            {
-              "name": "confl_bufferpin",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_bufferpin"
-            },
-            {
-              "name": "confl_deadlock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_deadlock"
-            }
-          ],
-          "version": 10
-        },
-        {
-          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock, confl_active_logicalslot FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
-          "columns": [
-            {
-              "name": "database",
-              "type": "label"
-            },
-            {
-              "name": "confl_tablespace",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_tablespace"
-            },
-            {
-              "name": "confl_lock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_lock"
-            },
-            {
-              "name": "confl_snapshot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_snapshot"
-            },
-            {
-              "name": "confl_bufferpin",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_bufferpin"
-            },
-            {
-              "name": "confl_deadlock",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_dead"
-            },
-            {
-              "name": "confl_active_logicalslot",
-              "type": "counter",
-              "description": "pg_stat_database_conflicts_confl_active_logicalslot"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_database_conflicts",
-      "sort": "data",
-      "collector": "stat_conflicts"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes GROUP BY relname;",
-          "columns": [
-            {
-              "type": "counter",
-              "name": "idx_scans",
-              "description": "Number of index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_reads",
-              "description": "Number of index entries returned by scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_fetchs",
-              "description": "Number of rows fetched by simple index scans on the table's indexes."
-            },
-            {
-              "type": "label",
-              "name": "relname"
-            }
-          ],
-          "version": 10
-        },
-        {
-          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, COALESCE(MIN((EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;",
-          "columns": [
-            {
-              "type": "counter",
-              "name": "idx_scans",
-              "description": "Number of index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_reads",
-              "description": "Number of index entries returned by scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "idx_tup_fetchs",
-              "description": "Number of rows fetched by simple index scans on the table's indexes."
-            },
-            {
-              "type": "counter",
-              "name": "time_elapsed_ms",
-              "description": "Milliseconds since last scan of an index in the table."
-            },
-            {
-              "type": "label",
-              "name": "relname"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_stat_all_indexes",
-      "sort": "data",
-      "collector": "stat_all_indexes",
-      "database": "all"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT type, count(*) as count FROM pg_wait_events GROUP BY type ORDER BY count DESC;",
-          "columns": [
-            {
-              "name": "type",
-              "type": "label"
-            },
-            {
-              "name": "count",
-              "type": "gauge",
-              "description": "pg_wait_events_count"
-            }
-          ]
-        }
-      ],
-      "tag": "pg_wait_events",
-      "sort": "data",
-      "collector": "wait_events"
-    },
-    {
-      "queries": [
-        {
-          "query": "SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
-          "version": 13,
-          "columns": [
-            {
-              "name": "schemaname",
-              "type": "label"
-            },
-            {
-              "name": "relname",
-              "type": "label"
-            },
-            {
-              "name": "n_live_tup",
-              "type": "gauge",
-              "description": "Estimated number of live rows"
-            },
-            {
-              "name": "n_dead_tup",
-              "type": "gauge",
-              "description": "Estimated number of dead rows"
-            },
-            {
-              "name": "dead_rows_pct",
-              "type": "gauge",
-              "description": "Percentage of dead rows relative to live rows"
-            },
-            {
-              "name": "n_mod_since_analyze",
-              "type": "gauge",
-              "description": "Estimated number of rows modified since last analyze"
-            },
-            {
-              "name": "n_ins_since_vacuum",
-              "type": "gauge",
-              "description": "Estimated number of rows inserted since last vacuum"
-            },
-            {
-              "name": "last_vacuum_seconds",
-              "type": "gauge",
-              "description": "Seconds since last manual vacuum (-1 if never)"
-            },
-            {
-              "name": "last_autovacuum_seconds",
-              "type": "gauge",
-              "description": "Seconds since last autovacuum (-1 if never)"
-            },
-            {
-              "name": "last_analyze_seconds",
-              "type": "gauge",
-              "description": "Seconds since last manual analyze (-1 if never)"
-            },
-            {
-              "name": "last_autoanalyze_seconds",
-              "type": "gauge",
-              "description": "Seconds since last autoanalyze (-1 if never)"
-            },
-            {
-              "name": "vacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually vacuumed"
-            },
-            {
-              "name": "autovacuum_count",
-              "type": "counter",
-              "description": "Number of times this table has been vacuumed by autovacuum"
-            },
-            {
-              "name": "analyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been manually analyzed"
-            },
-            {
-              "name": "autoanalyze_count",
-              "type": "counter",
-              "description": "Number of times this table has been analyzed by autoanalyze"
-            }
-          ]
-        },
-        {
-          "query": "SELECT schemaname, relname, seq_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds, seq_tup_read, idx_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_tup_newpage_upd, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;",
-          "version": 16,
           "columns": [
             {
               "name": "schemaname",
@@ -1859,16 +1079,36 @@
               "name": "autoanalyze_count",
               "type": "counter",
               "description": "Number of times this table has been analyzed by autoanalyze"
+            },
+            {
+              "name": "total_vacuum_time",
+              "type": "counter",
+              "description": "Total time spent vacuuming this table, in milliseconds"
+            },
+            {
+              "name": "total_autovacuum_time",
+              "type": "counter",
+              "description": "Total time spent auto-vacuuming this table, in milliseconds"
+            },
+            {
+              "name": "total_analyze_time",
+              "type": "counter",
+              "description": "Total time spent analyzing this table, in milliseconds"
+            },
+            {
+              "name": "total_autoanalyze_time",
+              "type": "counter",
+              "description": "Total time spent auto-analyzing this table, in milliseconds"
             }
           ]
         }
-      ],
-      "tag": "pg_stat_user_tables_vacuum",
-      "sort": "data",
-      "collector": "stat_user_tables",
-      "database": "all"
+      ]
     },
     {
+      "tag": "pg_table_ratio",
+      "collector": "table_activity_ratio",
+      "sort": "data",
+      "database": "all",
       "queries": [
         {
           "query": "WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;",
@@ -1914,13 +1154,13 @@
             }
           ]
         }
-      ],
-      "tag": "pg_table_ratio",
-      "sort": "data",
-      "collector": "table_activity_ratio",
-      "database": "all"
+      ]
     },
     {
+      "tag": "pg_table_bloat",
+      "collector": "table_bloat",
+      "sort": "data",
+      "database": "all",
       "queries": [
         {
           "query": "SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;",
@@ -1966,71 +1206,535 @@
             }
           ]
         }
-      ],
-      "tag": "pg_table_bloat",
-      "sort": "data",
-      "collector": "table_bloat",
-      "database": "all"
+      ]
     },
     {
+      "tag": "pg_mem_ctx",
+      "collector": "mem_ctx",
       "queries": [
         {
-          "query": "SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;",
-          "version": 10,
+          "query": "SELECT COUNT(*) AS contexts, type, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE type!='' GROUP BY type;",
+          "version": 18,
           "columns": [
             {
-              "name": "blocked_pid",
-              "type": "label"
-            },
-            {
-              "name": "blocked_database",
-              "type": "label"
-            },
-            {
-              "name": "blocked_user",
-              "type": "label"
-            },
-            {
-              "name": "blocked_query",
-              "type": "label"
-            },
-            {
-              "name": "blocked_duration_seconds",
+              "name": "contexts",
               "type": "gauge",
-              "description": "Duration in seconds that the vacuum has been blocked"
+              "description": "Number of memory contexts per type."
             },
             {
-              "name": "blocking_pid",
-              "type": "label"
+              "name": "type",
+              "type": "label",
+              "description": "Memory context type"
             },
             {
-              "name": "blocking_database",
-              "type": "label"
-            },
-            {
-              "name": "blocking_user",
-              "type": "label"
-            },
-            {
-              "name": "blocking_query",
-              "type": "label"
-            },
-            {
-              "name": "blocking_duration_seconds",
+              "name": "free_bytes",
               "type": "gauge",
-              "description": "Duration in seconds that the blocking query has been running"
+              "description": "Free bytes per memory context type."
+            },
+            {
+              "name": "used_bytes",
+              "type": "gauge",
+              "description": "Used bytes per memory context type."
+            },
+            {
+              "name": "total_bytes",
+              "type": "gauge",
+              "description": "Total bytes per memory context type."
             }
           ]
         }
-      ],
-      "tag": "pg_blocked_vacuum",
-      "sort": "data",
-      "collector": "blocked_vacuum"
+      ]
     },
     {
+      "tag": "pg_stat_wal",
+      "collector": "stat_wal",
       "queries": [
         {
-          "query": "SELECT\n  num_timed,\n  num_requested,\n  num_done,\n  restartpoints_timed,\n  restartpoints_req,\n  restartpoints_done,\n  write_time,\n  sync_time,\n  buffers_written,\n  slru_written,\n  EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint AS stats_reset_seconds\nFROM pg_stat_checkpointer;",
+          "query": "WITH wal_io AS ( SELECT sum(writes) as wal_write, sum(fsyncs) as wal_sync, sum(write_time) as wal_write_time, sum(fsync_time) as wal_sync_time FROM pg_stat_io WHERE object = 'wal' ) SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal, wal_io;",
+          "version": 18,
+          "columns": [
+            {
+              "name": "wal_records",
+              "type": "counter",
+              "description": "Number of WAL records generated."
+            },
+            {
+              "name": "wal_fpi",
+              "type": "counter",
+              "description": "Number of WAL full page images generated."
+            },
+            {
+              "name": "wal_bytes",
+              "type": "counter",
+              "description": "Total bytes of generated WAL."
+            },
+            {
+              "name": "wal_buffers_full",
+              "type": "counter",
+              "description": "Number of disk writes due to WAL buffers being full."
+            },
+            {
+              "name": "wal_write",
+              "type": "counter",
+              "description": "Number of times WAL files were written to disk (from pg_stat_io)."
+            },
+            {
+              "name": "wal_sync",
+              "type": "counter",
+              "description": "Number of times WAL files were synced to disk (from pg_stat_io)."
+            },
+            {
+              "name": "wal_write_time",
+              "type": "counter",
+              "description": "Time taken for WAL files to be written to disk in milliseconds (from pg_stat_io)."
+            },
+            {
+              "name": "wal_sync_time",
+              "type": "counter",
+              "description": "Time taken for WAL files to be synced to disk in milliseconds (from pg_stat_io)."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_database",
+      "collector": "stat_db",
+      "queries": [
+        {
+          "query": "SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed, parallel_workers_to_launch, parallel_workers_launched FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;",
+          "version": 18,
+          "columns": [
+            {
+              "name": "database",
+              "type": "label"
+            },
+            {
+              "name": "blk_read_time",
+              "type": "counter",
+              "description": "pg_stat_database_blk_read_time"
+            },
+            {
+              "name": "blk_write_time",
+              "type": "counter",
+              "description": "pg_stat_database_blk_write_time"
+            },
+            {
+              "name": "blks_hit",
+              "type": "counter",
+              "description": "pg_stat_database_blks_hit"
+            },
+            {
+              "name": "blks_read",
+              "type": "counter",
+              "description": "pg_stat_database_blks_read"
+            },
+            {
+              "name": "deadlocks",
+              "type": "counter",
+              "description": "pg_stat_database_deadlocks"
+            },
+            {
+              "name": "temp_files",
+              "type": "gauge",
+              "description": "pg_stat_database_temp_files"
+            },
+            {
+              "name": "temp_bytes",
+              "type": "gauge",
+              "description": "pg_stat_database_temp_bytes"
+            },
+            {
+              "name": "tup_returned",
+              "type": "counter",
+              "description": "pg_stat_database_tup_returned"
+            },
+            {
+              "name": "tup_fetched",
+              "type": "counter",
+              "description": "pg_stat_database_tup_fetched"
+            },
+            {
+              "name": "tup_inserted",
+              "type": "counter",
+              "description": "pg_stat_database_tup_inserted"
+            },
+            {
+              "name": "tup_updated",
+              "type": "counter",
+              "description": "pg_stat_database_tup_updated"
+            },
+            {
+              "name": "tup_deleted",
+              "type": "counter",
+              "description": "pg_stat_database_tup_deleted"
+            },
+            {
+              "name": "xact_commit",
+              "type": "counter",
+              "description": "pg_stat_database_xact_commit"
+            },
+            {
+              "name": "xact_rollback",
+              "type": "counter",
+              "description": "pg_stat_database_xact_rollback"
+            },
+            {
+              "name": "conflicts",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts"
+            },
+            {
+              "name": "numbackends",
+              "type": "gauge",
+              "description": "pg_stat_database_numbackends"
+            },
+            {
+              "name": "checksum_failures",
+              "type": "gauge",
+              "description": "pg_stat_database_checksum_failures"
+            },
+            {
+              "name": "session_time",
+              "type": "gauge",
+              "description": "pg_stat_database_session_time"
+            },
+            {
+              "name": "active_time",
+              "type": "gauge",
+              "description": "pg_stat_database_active_time"
+            },
+            {
+              "name": "idle_in_transaction_time",
+              "type": "gauge",
+              "description": "pg_stat_database_idle_in_transaction_time"
+            },
+            {
+              "name": "sessions",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions"
+            },
+            {
+              "name": "sessions_abandoned",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions_abandoned"
+            },
+            {
+              "name": "sessions_fatal",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions_fatal"
+            },
+            {
+              "name": "sessions_killed",
+              "type": "gauge",
+              "description": "pg_stat_database_sessions_killed"
+            },
+            {
+              "name": "parallel_workers_to_launch",
+              "type": "gauge",
+              "description": "Number of parallel workers PostgreSQL attempted to launch"
+            },
+            {
+              "name": "parallel_workers_launched",
+              "type": "gauge",
+              "description": "Number of parallel workers successfully launched"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_subscription_stats",
+      "collector": "subscription_stats",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT subid, subname, apply_error_count, sync_error_count, confl_insert_exists, confl_update_origin_differs, confl_update_exists, confl_update_missing, confl_delete_origin_differs, confl_delete_missing, confl_multiple_unique_conflicts, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint AS stats_reset_seconds FROM pg_stat_subscription_stats;",
+          "version": 18,
+          "columns": [
+            {
+              "name": "subid",
+              "type": "label",
+              "description": "Subscription OID"
+            },
+            {
+              "name": "subname",
+              "type": "label",
+              "description": "Subscription name"
+            },
+            {
+              "name": "apply_error_count",
+              "type": "counter",
+              "description": "Number of errors during apply"
+            },
+            {
+              "name": "sync_error_count",
+              "type": "counter",
+              "description": "Number of errors during initial sync"
+            },
+            {
+              "name": "confl_insert_exists",
+              "type": "counter",
+              "description": "Number of conflicts where INSERT tried to insert existing row"
+            },
+            {
+              "name": "confl_update_origin_differs",
+              "type": "counter",
+              "description": "Number of conflicts where UPDATE had different origin"
+            },
+            {
+              "name": "confl_update_exists",
+              "type": "counter",
+              "description": "Number of conflicts where UPDATE target already exists"
+            },
+            {
+              "name": "confl_update_missing",
+              "type": "counter",
+              "description": "Number of conflicts where UPDATE target is missing"
+            },
+            {
+              "name": "confl_delete_origin_differs",
+              "type": "counter",
+              "description": "Number of conflicts where DELETE had different origin"
+            },
+            {
+              "name": "confl_delete_missing",
+              "type": "counter",
+              "description": "Number of conflicts where DELETE target is missing"
+            },
+            {
+              "name": "confl_multiple_unique_conflicts",
+              "type": "counter",
+              "description": "Number of conflicts with multiple unique constraint violations"
+            },
+            {
+              "name": "stats_reset_seconds",
+              "type": "counter",
+              "description": "Seconds since statistics were last reset"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_wal_prefetch_reset",
+      "collector": "wal_prefetch_reset",
+      "queries": [
+        {
+          "query": "SELECT FLOOR( EXTRACT( EPOCH FROM (now() - stats_reset) ) ) FROM pg_stat_recovery_prefetch;",
+          "version": 15,
+          "columns": [
+            {
+              "type": "counter",
+              "description": "Seconds from last WAL prefetch stats reset."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_gssapi_credentials_delegated",
+      "collector": "gssapi_creds_delegated",
+      "queries": [
+        {
+          "query": "SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE credentials_delegated = 't' AND datname IS NOT NULL;",
+          "version": 16,
+          "columns": [
+            {
+              "type": "gauge",
+              "description": "Number of DB connections with delegated GSSAPI credentials."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_io",
+      "collector": "stat_io",
+      "queries": [
+        {
+          "query": "SELECT backend_type, SUM(COALESCE(reads, 0)) AS reads, SUM(COALESCE(read_bytes, 0)) AS read_bytes, SUM(COALESCE(read_time, 0)) AS read_time, SUM(COALESCE(writes, 0)) AS writes, SUM(COALESCE(write_bytes, 0)) AS write_bytes, SUM(COALESCE(write_time, 0)) AS write_time, SUM(COALESCE(writebacks, 0)) AS writebacks, SUM(COALESCE(writeback_time, 0)) AS writeback_time, SUM(COALESCE(extends, 0)) AS extends, SUM(COALESCE(extend_bytes, 0)) AS extend_bytes, SUM(COALESCE(extend_time, 0)) AS extend_time, SUM(COALESCE(hits, 0)) AS hits, SUM(COALESCE(evictions, 0)) AS evictions, SUM(COALESCE(reuses, 0)) AS reuses, SUM(COALESCE(fsyncs, 0)) AS fsyncs, SUM(COALESCE(fsync_time, 0)) AS fsync_time FROM pg_stat_io GROUP BY backend_type;",
+          "version": 18,
+          "columns": [
+            {
+              "name": "backend_type",
+              "type": "label"
+            },
+            {
+              "name": "reads",
+              "type": "counter",
+              "description": "Number of read operations."
+            },
+            {
+              "name": "read_bytes",
+              "type": "counter",
+              "description": "Total bytes read."
+            },
+            {
+              "name": "read_time",
+              "type": "counter",
+              "description": "Total time spent on read operations in milliseconds."
+            },
+            {
+              "name": "writes",
+              "type": "counter",
+              "description": "Number of write operations."
+            },
+            {
+              "name": "write_bytes",
+              "type": "counter",
+              "description": "Total bytes written."
+            },
+            {
+              "name": "write_time",
+              "type": "counter",
+              "description": "Total time spent on write operations in milliseconds."
+            },
+            {
+              "name": "writebacks",
+              "type": "counter",
+              "description": "Number of writeback to permanent storage requests sent to kernel."
+            },
+            {
+              "name": "writeback_time",
+              "type": "counter",
+              "description": "Total time spent on writeback operations in milliseconds."
+            },
+            {
+              "name": "extends",
+              "type": "counter",
+              "description": "Number of relation extend operations."
+            },
+            {
+              "name": "extend_bytes",
+              "type": "counter",
+              "description": "Total bytes extended."
+            },
+            {
+              "name": "extend_time",
+              "type": "counter",
+              "description": "Total time spent on relation extend operations in milliseconds."
+            },
+            {
+              "name": "hits",
+              "type": "counter",
+              "description": "The number of times a desired block was found in shared buffer."
+            },
+            {
+              "name": "evictions",
+              "type": "counter",
+              "description": "The number of times a block has been written out from shared or local buffer in order to make it available for another use."
+            },
+            {
+              "name": "reuses",
+              "type": "counter",
+              "description": "The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation."
+            },
+            {
+              "name": "fsyncs",
+              "type": "counter",
+              "description": "Number of fsync calls."
+            },
+            {
+              "name": "fsync_time",
+              "type": "counter",
+              "description": "Total time spent on fsync operations in milliseconds."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_database_conflicts",
+      "collector": "stat_conflicts",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock, confl_active_logicalslot FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;",
+          "version": 16,
+          "columns": [
+            {
+              "name": "database",
+              "type": "label"
+            },
+            {
+              "name": "confl_tablespace",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_tablespace"
+            },
+            {
+              "name": "confl_lock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_lock"
+            },
+            {
+              "name": "confl_snapshot",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_snapshot"
+            },
+            {
+              "name": "confl_bufferpin",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_bufferpin"
+            },
+            {
+              "name": "confl_deadlock",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_dead"
+            },
+            {
+              "name": "confl_active_logicalslot",
+              "type": "counter",
+              "description": "pg_stat_database_conflicts_confl_active_logicalslot"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_all_indexes",
+      "collector": "stat_all_indexes",
+      "sort": "data",
+      "database": "all",
+      "queries": [
+        {
+          "query": "SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, COALESCE(MIN((EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;",
+          "version": 16,
+          "columns": [
+            {
+              "type": "counter",
+              "name": "idx_scans",
+              "description": "Number of index scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_reads",
+              "description": "Number of index entries returned by scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "idx_tup_fetchs",
+              "description": "Number of rows fetched by simple index scans on the table's indexes."
+            },
+            {
+              "type": "counter",
+              "name": "time_elapsed_ms",
+              "description": "Milliseconds since last scan of an index in the table."
+            },
+            {
+              "type": "label",
+              "name": "relname"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "pg_stat_checkpointer",
+      "collector": "stat_checkpointer",
+      "queries": [
+        {
+          "query": "SELECT num_timed, num_requested, num_done, restartpoints_timed, restartpoints_req, restartpoints_done, write_time, sync_time, buffers_written, slru_written, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint AS stats_reset_seconds FROM pg_stat_checkpointer;",
           "version": 18,
           "columns": [
             {
@@ -2090,14 +1794,15 @@
             }
           ]
         }
-      ],
-      "tag": "pg_stat_checkpointer",
-      "collector": "stat_checkpointer"
+      ]
     },
     {
+      "tag": "pg_aios",
+      "collector": "aios",
+      "sort": "data",
       "queries": [
         {
-          "query": "SELECT\n  state,\n  operation,\n  COUNT(*) AS total_operations,\n  SUM(length) AS total_bytes,\n  AVG(length) AS avg_bytes_per_op,\n  COUNT(*) FILTER (WHERE f_sync) AS sync_operations,\n  COUNT(*) FILTER (WHERE f_buffered) AS buffered_operations\nFROM pg_aios\nGROUP BY state, operation;",
+          "query": "SELECT state, operation, COUNT(*) AS total_operations, SUM(length) AS total_bytes, AVG(length) AS avg_bytes_per_op, COUNT(*) FILTER (WHERE f_sync) AS sync_operations, COUNT(*) FILTER (WHERE f_buffered) AS buffered_operations FROM pg_aios GROUP BY state, operation;",
           "version": 18,
           "columns": [
             {
@@ -2137,53 +1842,29 @@
             }
           ]
         }
-      ],
-      "tag": "pg_aios",
-      "sort": "data",
-      "collector": "aios"
+      ]
     },
     {
+      "tag": "pg_wait_events",
+      "collector": "wait_events",
+      "sort": "data",
       "queries": [
         {
-          "query": "SELECT\n  numa_node,\n  COUNT(*) AS allocations,\n  SUM(size) AS total_bytes,\n  AVG(size) AS avg_bytes,\n  MAX(size) AS max_bytes,\n  MIN(size) AS min_bytes\nFROM pg_shmem_allocations_numa\nGROUP BY numa_node\nORDER BY numa_node;",
-          "version": 18,
+          "query": "SELECT type, count(*) as count FROM pg_wait_events GROUP BY type ORDER BY count DESC;",
+          "version": 17,
           "columns": [
             {
-              "name": "numa_node",
-              "type": "label",
-              "description": "NUMA node number"
+              "name": "type",
+              "type": "label"
             },
             {
-              "name": "allocations",
+              "name": "count",
               "type": "gauge",
-              "description": "Number of shared memory allocations on this NUMA node"
-            },
-            {
-              "name": "total_bytes",
-              "type": "gauge",
-              "description": "Total bytes allocated on this NUMA node"
-            },
-            {
-              "name": "avg_bytes",
-              "type": "gauge",
-              "description": "Average allocation size on this NUMA node"
-            },
-            {
-              "name": "max_bytes",
-              "type": "gauge",
-              "description": "Maximum allocation size on this NUMA node"
-            },
-            {
-              "name": "min_bytes",
-              "type": "gauge",
-              "description": "Minimum allocation size on this NUMA node"
+              "description": "pg_wait_events_count"
             }
           ]
         }
-      ],
-      "tag": "pg_shmem_allocations_numa",
-      "sort": "data",
-      "collector": "shmem_numa"
+      ]
     }
   ]
 }

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -1,1154 +1,685 @@
-# This is the default minimum version for queries, unless specified otherwise
 version: 13
 metrics:
-
-#
-# PostgreSQL 10
-#
-
-# primary_information()
-  - queries:
-    - query: SELECT
-              (
-                CASE pg_is_in_recovery() WHEN 'f'
-                  THEN 't'
-                  ELSE 'f'
-                END
-              );
-      version: 10
-      columns:
-        - description: Is the PostgreSQL instance the primary
-          type: gauge
-    tag: postgresql_primary
-    sort: name
-    collector: primary
-    server: both
-
-# database_information()
-  - queries:
-    - query: SELECT
-                datname,
-                pg_database_size(datname)
-              FROM pg_database;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - description: Size of the database
-          type: gauge
-    tag: pg_database_size
-    sort: data
-    collector: db
-
-# locks_information()
-  - queries:
-    - query: SELECT
-                pg_database.datname as database,
-                tmp.mode,
-                COALESCE(count, 0) as count
-              FROM (
-                VALUES
-                  ('accesssharelock'),
-                  ('rowsharelock'),
-                  ('rowexclusivelock'),
-                  ('shareupdateexclusivelock'),
-                  ('sharelock'),
-                  ('sharerowexclusivelock'),
-                  ('exclusivelock'),
-                  ('accessexclusivelock'),
-                  ('sireadlock')
-              ) AS tmp(mode)
-              CROSS JOIN pg_database
-              LEFT JOIN
-              (
-                SELECT
-                  database,
-                  lower(mode) AS mode,
-                  count(*) AS count
-                FROM pg_locks
-                WHERE database IS NOT NULL
-                GROUP BY database, lower(mode)
-              ) AS tmp2
-              ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database
-              ORDER BY 1, 2;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - name: mode
-          type: label
-        - description: Lock count of a database
-          type: gauge
-    tag: pg_locks_count
-    sort: data
-    collector: locks
-
-# replication_information()
-  - queries:
-    - query: SELECT
-                slot_name,
-                slot_type,
-                database,
-                active,
-                temporary
-              FROM pg_replication_slots;
-      version: 10
-      columns:
-      - name: slot_name
-        type: label
-      - name: slot_type
-        type: label
-      - name: database
-        type: label
-      - description: Is the replication active
-        name: active
-        type: gauge
-      - description: Is the replication temporary
-        name: temporary
-        type: gauge
-    tag: pg_replication_slots
-    sort: data
-    collector: replication
-
-# stat_bgwriter_information()
-  - queries:
-    - query: SELECT
-                buffers_alloc,
-                buffers_backend,
-                buffers_backend_fsync,
-                buffers_checkpoint,
-                buffers_clean,
-                checkpoint_sync_time,
-                checkpoint_write_time,
-                checkpoints_req,
-                checkpoints_timed,
-                maxwritten_clean
-              FROM pg_stat_bgwriter;
-      version: 10
-      columns:
-        - description: pg_stat_bgwriter_buffers_alloc
-          name: buffers_alloc
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_backend
-          name: buffers_backend
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_backend_fsync
-          name: buffers_backend_fsync
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_checkpoint
-          name: buffers_checkpoint
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_clean
-          name: buffers_clean
-          type: gauge
-        - description: pg_stat_bgwriter_checkpoint_sync_time
-          name: checkpoint_sync_time
-          type: counter
-        - description: pg_stat_bgwriter_checkpoint_write_time
-          name: checkpoint_write_time
-          type: counter
-        - description: pg_stat_bgwriter_checkpoints_req
-          name: checkpoints_req
-          type: counter
-        - description: pg_stat_bgwriter_checkpoints_timed
-          name: checkpoints_timed
-          type: counter
-        - description: pg_stat_bgwriter_maxwritten_clean
-          name: maxwritten_clean
-          type: counter
-    tag: pg_stat_bgwriter
-    collector: stat_bgwriter
-
-# stat_database_conflicts_information()
-  - queries:
-    - query: SELECT datname,
-                confl_tablespace,
-                confl_lock,
-                confl_snapshot,
-                confl_bufferpin,
-                confl_deadlock
-              FROM pg_stat_database_conflicts
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - name: confl_tablespace
-          type: counter
-          description: pg_stat_database_conflicts_confl_tablespace
-        - name: confl_lock
-          type: counter
-          description: pg_stat_database_conflicts_confl_lock
-        - name: confl_snapshot
-          type: counter
-          description: pg_stat_database_conflicts_confl_snapshot
-        - name: confl_bufferpin
-          type: counter
-          description: pg_stat_database_conflicts_confl_bufferpin
-        - name: confl_deadlock
-          type: counter
-          description: pg_stat_database_conflicts_confl_deadlock
-    tag: pg_stat_database_conflicts
-    sort: data
-    collector: stat_conflicts
-
-# histogram sample
-  - queries:
-    - query: WITH
-              metrics AS (
-                SELECT
-                  application_name,
-                  SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum,
-                  COUNT(*) AS process_idle_seconds_count
-                FROM pg_stat_activity
-                WHERE state = 'idle'
-                GROUP BY application_name
-              ),
-              buckets AS (
-                SELECT
-                  application_name,
-                  le,
-                  SUM(
-                    CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le
-                      THEN 1
-                      ELSE 0
-                    END
-                  )::bigint AS bucket
-                FROM
-                  pg_stat_activity,
-                  UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le
-                GROUP BY application_name, le
-                ORDER BY application_name, le
-              )
-              SELECT
-                application_name,
-                process_idle_seconds_sum as seconds_sum,
-                process_idle_seconds_count as seconds_count,
-                ARRAY_AGG(le) AS seconds,
-                ARRAY_AGG(bucket) AS seconds_bucket
-              FROM metrics JOIN buckets USING (application_name)
-              GROUP BY 1, 2, 3;
-      version: 10
-      columns:
-        - name: application_name
-          type: label
-        - name: seconds
-          type: histogram
-          description: Histogram of idle processes
-    tag: pg_process_idle_seconds
-    collector: idle_procs
-
-# Get number of available extensions for installations.
-  - queries:
-    - query: SELECT COUNT(*) AS extensions
-              FROM pg_available_extensions;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of available extensions for installation.
-    tag: pg_available_extensions
-    collector: available_extensions
-
-# Get number of installed extensions.
-  - queries:
-    - query: SELECT
-                array_agg(extname) AS extensions,
-                count(*)
-              FROM pg_extension;
-      version: 10
-      columns:
-        - name: extensions
-          type: label
-        - type: gauge
-          description: Number of installed extensions.
-    tag: pg_installed_extensions
-    collector: installed_extensions
-
-# Get applied settings
-  - queries:
-    - query: SELECT
-                sourcefile,
-                COUNT(*),
-                (
-                  CASE applied WHEN 't'
-                    THEN 'true'
-                    ELSE 'false'
-                  END
-                ) as applied
-              FROM pg_file_settings
-              WHERE applied = 't'
-              GROUP BY sourcefile, applied;
-      version: 10
-      columns:
-        - name: sourcefile
-          type: label
-        - type: gauge
-          description: Settings that are applied.
-        - name: applied
-          type: label
-    tag: pg_file_settings
-    sort: data
-    collector: file_settings
-
-# Get indexes for schemas.
-  - queries:
-    - query: SELECT
-                schemaname,
-                tablename,
-                COUNT(*)
-              FROM pg_indexes
-              GROUP BY schemaname,tablename;
-      version: 10
-      columns:
-        - name: schemaname
-          type: label
-        - name: tablename
-          type: label
-        - type: gauge
-          description: Indexes for each schemaname for each tablename.
-    tag: pg_indexes
-    sort: data
-    collector: indexes
-
-# Get materialized views
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_matviews
-              WHERE ispopulated = 't'
-              GROUP BY ispopulated;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of applied Materialized views.
-    tag: pg_matviews
-    collector: matviews
-
-# Get number of roles
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_roles;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of roles.
-    tag: pg_role
-    collector: roles
-
-# Get number of rules
-  - queries:
-    - query: SELECT tablename, COUNT(*)
-              FROM pg_rules
-              GROUP BY tablename;
-      version: 10
-      columns:
-        - name: tablename
-          type: label
-        - type: gauge
-          description: Number of rules in table.
-    tag: pg_rule
-    sort: data
-    collector: rules
-
-# Get user auth data
-  - queries:
-    - query: SELECT (
-                CASE
-                  WHEN rolpassword LIKE 'md5%' THEN 'MD5'
-                  WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256'
-                  ELSE 'UNENCRYPTED'
-                END
-              ) AS encryption_type, COUNT(*)
-              FROM pg_authid
-              WHERE rolname != 'postgres'
-              GROUP BY encryption_type;
-      version: 10
-      columns:
-        - name: encryption_type
-          type: label
-        - type: gauge
-          description: Number of users with authentication type.
-    tag: pg_shadow
-    sort: data
-    collector: auth_type
-
-# Get user defined event-triggers
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_event_trigger
-              JOIN pg_authid
-              ON pg_event_trigger.oid = pg_authid.oid
-              WHERE rolname != 'postgres';
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of user defined event triggers.
-    tag: pg_usr_evt_trigger
-    collector: usr_evt_trigger
-
-# Get number of database connections
-  - queries:
-    - query: SELECT datname, count(*)
-              FROM pg_stat_activity
-              WHERE datname IS NOT NULL
-              GROUP BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - type: gauge
-          description: Number of database connections.
-    tag: pg_db_conn
-    sort: data
-    collector: connections
-
-# Get DB connections with SSL
-  - queries:
-    - query: SELECT datname, count(*)
-              FROM pg_stat_ssl
-              JOIN pg_stat_activity
-              ON pg_stat_activity.pid = pg_stat_ssl.pid
-              WHERE ssl = 't' AND datname IS NOT NULL
-              GROUP BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - type: gauge
-          description: Number of DB connections with SSL.
-    tag: pg_db_conn_ssl
-    sort: data
-    collector: connections
-
-# All tables statio
-  - queries:
-    - query: SELECT
-                COUNT(heap_blks_read) AS heap_blks_read,
-                COUNT(heap_blks_hit) AS heap_blks_hit,
-                COUNT(idx_blks_read) as idx_blks_read,
-                COUNT(idx_blks_hit) AS idx_blks_hit,
-                COUNT(toast_blks_read) AS toast_blks_read,
-                COUNT(toast_blks_hit) AS toast_blks_hit,
-                COUNT(tidx_blks_read) AS tidx_blks_read,
-                COUNT(tidx_blks_hit) AS tidx_blks_hit
-              FROM pg_statio_all_tables;
-      version: 10
-      columns:
-        - name: heap_blks_read
-          type: counter
-          description: Number of disk blocks read in postgres db.
-        - name: heap_blks_hit
-          type: counter
-          description: Number of buffer hits read in postgres db.
-        - name: idx_blks_read
-          type: counter
-          description: Number of disk blocks reads from all indexes in postgres db.
-        - name: idx_blks_hit
-          type: counter
-          description: Number of buffer hits read from all indexes in postgres db.
-        - name: toast_blks_read
-          type: counter
-          description: Number of disk blocks reads from postgres db's TOAST tables.
-        - name: toast_blks_hit
-          type: counter
-          description: Number of buffer hits read from postgres db's TOAST tables.
-        - name: tidx_blks_read
-          type: counter
-          description: Number of disk blocks reads from postgres db's TOAST table indexes.
-        - name: tidx_blks_hit
-          type: counter
-          description: Number of buffer hits read from postgres db's TOAST table indexes.
-    tag: pg_statio_all_tables
-    collector: statio_all_tables
-
-# All sequences statio
-  - queries:
-    - query: SELECT
-                COUNT(blks_read) AS blks_read,
-                COUNT(blks_hit) AS blks_hit
-              FROM pg_statio_all_sequences;
-      version: 10
-      columns:
-        - name: blks_read
-          type: counter
-          description: Number of disk blocks read from sequences in postgres db.
-        - name: blks_hit
-          type: counter
-          description: Number of buffer hits read from sequences in postgres db.
-    tag: pg_statio_all_sequences
-    collector: statio_all_sequences
-
-# Stat user functions
-  - queries:
-    - query: SELECT
-                funcname,
-                calls,
-                self_time,
-                total_time
-              FROM pg_stat_user_functions;
-      version: 10
-      columns:
-        - name: funcname
-          type: label
-        - name: calls
-          type: counter
-          description: Number of times function is called.
-        - name: self_time
-          type: counter
-          description: Total time spent in milliseconds on the function itself.
-        - name: total_time
-          type: counter
-          description: Total time spent in milliseconds by the function and any other functions called by it.
-    tag: pg_stat_user_functions
-    sort: data
-    collector: stat_user_functions
-
-# Number of streaming WAL connections per application.
-  - queries:
-    - query: SELECT COUNT(*), application_name
-              FROM pg_stat_replication
-              WHERE state = 'streaming'
-              GROUP BY application_name;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of streaming WAL connections per application.
-        - name: application_name
-          type: label
-    tag: pg_stat_replication
-    sort: data
-    collector: stat_replication
-
-  - queries:
-    - query: SELECT
-                archived_count,
-                (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms,
-                failed_count,
-                (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms
-              FROM pg_stat_archiver;
-      version: 10
-      columns:
-        - type: counter
-          name: archived_count
-          description: Number of successful archived WAL files.
-        - type: counter
-          name: success_time_elapsed_ms
-          description: Milliseconds since successful archived WAL file.
-        - type: counter
-          name: failed_count
-          description: Number of failed archival operation on WAL files.
-        - type: counter
-          name: failure_time_elapsed_ms
-          description: Milliseconds since last failed archival operation on WAL files.
-    tag: pg_stat_archiver
-    sort: data
-    collector: stat_archiver
-
-  - queries:
-    - query: SELECT
-                SUM(idx_scan) AS idx_scans,
-                SUM(idx_tup_read) AS idx_tup_reads,
-                SUM(idx_tup_fetch) AS idx_tup_fetchs,
-                relname
-              FROM pg_stat_all_indexes
-              WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%')
-              GROUP BY relname;
-      version: 10
-      columns:
-        - type: counter
-          name: idx_scans
-          description: Number of index scans on the table's indexes.
-        - type: counter
-          name: idx_tup_reads
-          description: Number of index entries returned by scans on the table's indexes.
-        - type: counter
-          name: idx_tup_fetchs
-          description: Number of rows fetched by simple index scans on the table's indexes.
-        - type: label
-          name: relname
-    tag: stat_all_indexes
-    sort: data
-    collector: pg_stat_all_indexes
-    database: all
-
-  - queries:
-    - query: SELECT
-                datname,
-                age(datfrozenxid) as age
-              FROM pg_database;
-      version: 10
-      columns:
-        - type: label
-          name: datname
-          description: Database name.
-        - type: counter
-          name: age
-          description: Age since last vaccum.
-    tag: pg_db_vacuum
-    sort: data
-    collector: db_vacuum
-
-  - queries:
-    - query: SELECT
-                c.oid::regclass as table_name,
-                greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age
-              FROM pg_class c
-              LEFT JOIN pg_class t ON c.reltoastrelid = t.oid
-              WHERE c.relkind IN ('r', 'm');
-      version: 10
-      columns:
-        - type: label
-          name: datname
-          description: View name.
-        - type: counter
-          name: age
-          description: Age since last vaccum.
-    tag: pg_view_vacuum
-    sort: data
-    collector: db_vacuum
-# Blocked vacuum operations
-  - queries:
-    - query: SELECT
-                blocked.pid AS blocked_pid,
-                blocked.datname AS blocked_database,
-                blocked.usename AS blocked_user,
-                blocked.query AS blocked_query,
-                EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds,
-                blocking.pid AS blocking_pid,
-                blocking.datname AS blocking_database,
-                blocking.usename AS blocking_user,
-                blocking.query AS blocking_query,
-                EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds
-              FROM pg_stat_activity blocked
-              JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
-              JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation
-                AND blocked_locks.pid != blocking_locks.pid
-              JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid
-              WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%')
-                AND NOT blocked_locks.granted
-                AND blocking_locks.granted
-              ORDER BY blocked_duration_seconds DESC;
-      version: 10
-      columns:
-        - name: blocked_pid
-          type: label
-        - name: blocked_database
-          type: label
-        - name: blocked_user
-          type: label
-        - name: blocked_query
-          type: label
-        - name: blocked_duration_seconds
-          type: gauge
-          description: Duration in seconds that the vacuum has been blocked
-        - name: blocking_pid
-          type: label
-        - name: blocking_database
-          type: label
-        - name: blocking_user
-          type: label
-        - name: blocking_query
-          type: label
-        - name: blocking_duration_seconds
-          type: gauge
-          description: Duration in seconds that the blocking query has been running
-    tag: pg_blocked_vacuum
-    sort: data
-    collector: blocked_vacuum
-#
-# PostgreSQL 11
-#
-
-# WAL last sent
-  - queries:
-    - query: SELECT
-              CASE
-                WHEN sender_host LIKE '/%' THEN sender_host
-                ELSE sender_host || ':' || sender_port::text
-              END AS sender,
-              (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms
-              FROM pg_stat_wal_receiver;
-      version: 11
-      columns:
-        - name: sender
-          type: label
-        - type: counter
-          description: Time since last message received from WAL sender
-    tag: pg_wal_last_received
-    collector: wal_last_received
-    server: replica
-
-#
-# PostgreSQL 12
-#
-
-# GSS Authenticated DB Connections
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE gss_authenticated = 't' AND datname IS NOT NULL;
-      version: 12
-      columns:
-        - type: gauge
-          description: Number of GSSAPI authenticated DB connections.
-    tag: pg_gss_auth
-    collector: gssapi
-
-# Encrypted DB Connections
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE encrypted = 't' AND datname IS NOT NULL;
-      version: 12
-      columns:
-        - type: gauge
-          description: Number of encrypted DB connections.
-    tag: pg_encrypted_conn
-    collector: encryted_conns
-
-# stat_database_information()
-  - queries:
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends
-              FROM pg_stat_database
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-      version: 10
-
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends,
-                checksum_failures
-              FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
-      version: 12
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-        - name: checksum_failures
-          type: gauge
-          description: pg_stat_database_checksum_failures
-    tag: pg_stat_database
-    collector: stat_db
-    sort: data
-
-#
-# PostgreSQL 13
-#
-
-# Shared memory histogram
-  - queries:
-    - query: SELECT
-                SUM(sum) AS size_sum,
-                '1' AS size_count,
-                array_agg((bucket - 1) * (50000))::int[] AS size,
-                array_agg(count)::int[] AS size_bucket
-              FROM (
-                  SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size)
-                  FROM pg_shmem_allocations
-                  GROUP BY bucket
-                  ORDER BY bucket
-              ) t;
-      columns:
-        - name: size
-          type: histogram
-          description: Histogram of shared memory sizes.
-    tag: pg_shmem_allocations
-    collector: shmem_size
-
-# Vacuum progress information
-  - queries:
-    - query: SELECT
-                p.pid,
-                a.datname,
-                a.usename,
-                a.query,
-                p.phase,
-                p.heap_blks_total,
-                p.heap_blks_scanned,
-                p.heap_blks_vacuumed,
-                p.index_vacuum_count,
-                p.max_dead_tuples,
-                p.num_dead_tuples,
-                CASE WHEN p.heap_blks_total > 0
-                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
-                     ELSE 0
-                END AS pct_scan_completed
-              FROM pg_stat_progress_vacuum p
-              JOIN pg_stat_activity a USING (pid)
-              ORDER BY p.pid;
-      version: 13
-      columns:
-        - name: pid
-          type: label
-        - name: datname
-          type: label
-        - name: usename
-          type: label
-        - name: query
-          type: label
-        - name: phase
-          type: label
-        - name: heap_blks_total
-          type: gauge
-          description: Total heap blocks in table
-        - name: heap_blks_scanned
-          type: gauge
-          description: Heap blocks scanned
-        - name: heap_blks_vacuumed
-          type: gauge
-          description: Heap blocks vacuumed
-        - name: index_vacuum_count
-          type: gauge
-          description: Number of index vacuum cycles completed
-        - name: max_dead_tuples
-          type: gauge
-          description: Maximum dead tuples
-        - name: num_dead_tuples
-          type: gauge
-          description: Current dead tuples
-        - name: pct_scan_completed
-          type: gauge
-          description: Vacuum scan progress percentage
-    tag: pg_stat_progress_vacuum
-    sort: data
-    collector: vacuum_progress
-
-# Table-level vacuum and analyze statistics
-  - queries:
-    - query: SELECT
-                schemaname,
-                relname,
-                n_live_tup,
-                n_dead_tup,
-                CASE 
-                  WHEN n_live_tup > 0 
-                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
-                  ELSE 0
-                END AS dead_rows_pct,
-                n_mod_since_analyze,
-                n_ins_since_vacuum,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
-                vacuum_count,
-                autovacuum_count,
-                analyze_count,
-                autoanalyze_count
-              FROM pg_stat_user_tables
-              ORDER BY n_dead_tup DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: n_live_tup
-          type: gauge
-          description: Estimated number of live rows
-        - name: n_dead_tup
-          type: gauge
-          description: Estimated number of dead rows
-        - name: dead_rows_pct
-          type: gauge
-          description: Percentage of dead rows relative to live rows
-        - name: n_mod_since_analyze
-          type: gauge
-          description: Estimated number of rows modified since last analyze
-        - name: n_ins_since_vacuum
-          type: gauge
-          description: Estimated number of rows inserted since last vacuum
-        - name: last_vacuum_seconds
-          type: gauge
-          description: Seconds since last manual vacuum (-1 if never)
-        - name: last_autovacuum_seconds
-          type: gauge
-          description: Seconds since last autovacuum (-1 if never)
-        - name: last_analyze_seconds
-          type: gauge
-          description: Seconds since last manual analyze (-1 if never)
-        - name: last_autoanalyze_seconds
-          type: gauge
-          description: Seconds since last autoanalyze (-1 if never)
-        - name: vacuum_count
-          type: counter
-          description: Number of times this table has been manually vacuumed
-        - name: autovacuum_count
-          type: counter
-          description: Number of times this table has been vacuumed by autovacuum
-        - name: analyze_count
-          type: counter
-          description: Number of times this table has been manually analyzed
-        - name: autoanalyze_count
-          type: counter
-          description: Number of times this table has been analyzed by autoanalyze
-    tag: pg_stat_user_tables_vacuum
-    sort: data
-    collector: stat_user_tables
-    database: all
-
-# Table read/write activity ratios
-  - queries:
-    - query: WITH table_activity AS (
-                SELECT
-                  s.schemaname,
-                  s.relname,
-                  si.heap_blks_read + si.idx_blks_read AS blocks_read,
-                  s.seq_tup_read + s.idx_tup_fetch AS tuples_read,
-                  c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) /
-                    CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write,
-                  s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write
-                FROM pg_stat_user_tables AS s
-                JOIN pg_statio_user_tables AS si ON s.relid = si.relid
-                JOIN pg_class c ON c.oid = s.relid
-                WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0
-                  AND (si.heap_blks_read + si.idx_blks_read) > 0
-              )
-              SELECT
-                schemaname,
-                relname,
-                blocks_read,
-                tuples_read,
-                blocks_write,
-                tuples_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int
-                END AS ratio_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int
-                END AS ratio_read
-              FROM table_activity
-              ORDER BY (blocks_read + blocks_write) DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: blocks_read
-          type: counter
-          description: Total blocks read from disk (heap + index)
-        - name: tuples_read
-          type: counter
-          description: Total number of tuples read (sequential + index scans)
-        - name: blocks_write
-          type: gauge
-          description: Estimated blocks affected by write operations
-        - name: tuples_write
-          type: counter
-          description: Total number of tuples inserted, updated, or deleted
-        - name: ratio_write
-          type: gauge
-          description: Percentage of I/O activity that is writes (0-100)
-        - name: ratio_read
-          type: gauge
-          description: Percentage of I/O activity that is reads (0-100)
-    tag: pg_table_ratio
-    sort: data
-    collector: table_activity_ratio
-    database: all
-
-# Table bloat analysis
-  - queries:
-    - query: SELECT
-                schemaname,
-                tblname,
-                real_size AS table_size,
-                extra_size AS bloat_size,
-                ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct,
-                tblpages,
-                est_tblpages,
-                bs AS block_size
-              FROM (
-                SELECT
-                  schemaname,
-                  tblname,
-                  bs*tblpages AS real_size,
-                  (tblpages-est_tblpages)*bs AS extra_size,
-                  CASE WHEN tblpages > 0
-                    THEN 100 * (tblpages-est_tblpages)/tblpages::numeric
-                    ELSE 0
-                  END AS extra_ratio,
-                  tblpages,
-                  est_tblpages,
-                  bs
-                FROM (
-                  SELECT
-                    n.nspname AS schemaname,
-                    c.relname AS tblname,
-                    c.relpages AS tblpages,
-                    CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages,
-                    current_setting('block_size')::integer AS bs
-                  FROM pg_class c
-                  JOIN pg_namespace n ON n.oid = c.relnamespace
-                  WHERE c.relkind = 'r'
-                  AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
-                  AND n.nspname NOT LIKE 'pg_temp_%'
-                ) AS bloat_calc
-              ) AS bloat_summary
-              WHERE tblpages > 0
-              ORDER BY extra_size DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: tblname
-          type: label
-        - name: table_size
-          type: gauge
-          description: Actual table size in bytes
-        - name: bloat_size
-          type: gauge
-          description: Estimated bloat size in bytes
-        - name: bloat_ratio_pct
-          type: gauge
-          description: Bloat ratio as percentage
-        - name: tblpages
-          type: gauge
-          description: Actual number of pages used by table
-        - name: est_tblpages
-          type: gauge
-          description: Estimated number of pages needed
-        - name: block_size
-          type: gauge
-          description: Database block size in bytes
-    tag: pg_table_bloat
-    sort: data
-    collector: table_bloat
-    database: all
+- tag: postgresql_primary
+  collector: primary
+  sort: name
+  server: both
+  queries:
+  - query: SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );
+    version: 10
+    columns:
+    - description: Is the PostgreSQL instance the primary
+      type: gauge
+- tag: pg_database_size
+  collector: db
+  sort: data
+  queries:
+  - query: SELECT datname, pg_database_size(datname) FROM pg_database;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - description: Size of the database
+      type: gauge
+- tag: pg_locks_count
+  collector: locks
+  sort: data
+  queries:
+  - query: SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - name: mode
+      type: label
+    - description: Lock count of a database
+      type: gauge
+- tag: pg_replication_slots
+  collector: replication
+  sort: data
+  queries:
+  - query: SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;
+    version: 10
+    columns:
+    - name: slot_name
+      type: label
+    - name: slot_type
+      type: label
+    - name: database
+      type: label
+    - description: Is the replication active
+      name: active
+      type: gauge
+    - description: Is the replication temporary
+      name: temporary
+      type: gauge
+- tag: pg_stat_bgwriter
+  collector: stat_bgwriter
+  queries:
+  - query: SELECT buffers_alloc, buffers_backend, buffers_backend_fsync, buffers_checkpoint, buffers_clean, checkpoint_sync_time, checkpoint_write_time, checkpoints_req, checkpoints_timed, maxwritten_clean FROM pg_stat_bgwriter;
+    version: 10
+    columns:
+    - description: pg_stat_bgwriter_buffers_alloc
+      name: buffers_alloc
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_backend
+      name: buffers_backend
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_backend_fsync
+      name: buffers_backend_fsync
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_checkpoint
+      name: buffers_checkpoint
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_clean
+      name: buffers_clean
+      type: gauge
+    - description: pg_stat_bgwriter_checkpoint_sync_time
+      name: checkpoint_sync_time
+      type: counter
+    - description: pg_stat_bgwriter_checkpoint_write_time
+      name: checkpoint_write_time
+      type: counter
+    - description: pg_stat_bgwriter_checkpoints_req
+      name: checkpoints_req
+      type: counter
+    - description: pg_stat_bgwriter_checkpoints_timed
+      name: checkpoints_timed
+      type: counter
+    - description: pg_stat_bgwriter_maxwritten_clean
+      name: maxwritten_clean
+      type: counter
+- tag: pg_process_idle_seconds
+  collector: idle_procs
+  queries:
+  - query: WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;
+    version: 10
+    columns:
+    - name: application_name
+      type: label
+    - name: seconds
+      type: histogram
+      description: Histogram of idle processes
+- tag: pg_available_extensions
+  collector: available_extensions
+  queries:
+  - query: SELECT COUNT(*) AS extensions FROM pg_available_extensions;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of available extensions for installation.
+- tag: pg_installed_extensions
+  collector: installed_extensions
+  queries:
+  - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
+    version: 10
+    columns:
+    - name: extensions
+      type: label
+    - type: gauge
+      description: Number of installed extensions.
+- tag: pg_file_settings
+  collector: file_settings
+  sort: data
+  queries:
+  - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
+    version: 10
+    columns:
+    - name: sourcefile
+      type: label
+    - type: gauge
+      description: Settings that are applied.
+    - name: applied
+      type: label
+- tag: pg_indexes
+  collector: indexes
+  sort: data
+  queries:
+  - query: SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;
+    version: 10
+    columns:
+    - name: schemaname
+      type: label
+    - name: tablename
+      type: label
+    - type: gauge
+      description: Indexes for each schemaname for each tablename.
+- tag: pg_matviews
+  collector: matviews
+  queries:
+  - query: SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of applied Materialized views.
+- tag: pg_role
+  collector: roles
+  queries:
+  - query: SELECT COUNT(*) FROM pg_roles;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of roles.
+- tag: pg_rule
+  collector: rules
+  sort: data
+  queries:
+  - query: SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;
+    version: 10
+    columns:
+    - name: tablename
+      type: label
+    - type: gauge
+      description: Number of rules in table.
+- tag: pg_shadow
+  collector: auth_type
+  sort: data
+  queries:
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+    version: 10
+    columns:
+    - name: encryption_type
+      type: label
+    - type: gauge
+      description: Number of users with authentication type.
+- tag: pg_usr_evt_trigger
+  collector: usr_evt_trigger
+  queries:
+  - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of user defined event triggers.
+- tag: pg_db_conn
+  collector: connections
+  sort: data
+  queries:
+  - query: SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - type: gauge
+      description: Number of database connections.
+- tag: pg_db_conn_ssl
+  collector: connections
+  sort: data
+  queries:
+  - query: SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - type: gauge
+      description: Number of DB connections with SSL.
+- tag: pg_statio_all_tables
+  collector: statio_all_tables
+  queries:
+  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+    version: 10
+    columns:
+    - name: heap_blks_read
+      type: counter
+      description: Number of disk blocks read in postgres db.
+    - name: heap_blks_hit
+      type: counter
+      description: Number of buffer hits read in postgres db.
+    - name: idx_blks_read
+      type: counter
+      description: Number of disk blocks reads from all indexes in postgres db.
+    - name: idx_blks_hit
+      type: counter
+      description: Number of buffer hits read from all indexes in postgres db.
+    - name: toast_blks_read
+      type: counter
+      description: Number of disk blocks reads from postgres db's TOAST tables.
+    - name: toast_blks_hit
+      type: counter
+      description: Number of buffer hits read from postgres db's TOAST tables.
+    - name: tidx_blks_read
+      type: counter
+      description: Number of disk blocks reads from postgres db's TOAST table indexes.
+    - name: tidx_blks_hit
+      type: counter
+      description: Number of buffer hits read from postgres db's TOAST table indexes.
+- tag: pg_statio_all_sequences
+  collector: statio_all_sequences
+  queries:
+  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+    version: 10
+    columns:
+    - name: blks_read
+      type: counter
+      description: Number of disk blocks read from sequences in postgres db.
+    - name: blks_hit
+      type: counter
+      description: Number of buffer hits read from sequences in postgres db.
+- tag: pg_stat_user_functions
+  collector: stat_user_functions
+  sort: data
+  queries:
+  - query: SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;
+    version: 10
+    columns:
+    - name: funcname
+      type: label
+    - name: calls
+      type: counter
+      description: Number of times function is called.
+    - name: self_time
+      type: counter
+      description: Total time spent in milliseconds on the function itself.
+    - name: total_time
+      type: counter
+      description: Total time spent in milliseconds by the function and any other functions called by it.
+- tag: pg_stat_replication
+  collector: stat_replication
+  sort: data
+  queries:
+  - query: SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of streaming WAL connections per application.
+    - name: application_name
+      type: label
+- tag: pg_stat_archiver
+  collector: stat_archiver
+  sort: data
+  queries:
+  - query: SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;
+    version: 10
+    columns:
+    - type: counter
+      name: archived_count
+      description: Number of successful archived WAL files.
+    - type: counter
+      name: success_time_elapsed_ms
+      description: Milliseconds since successful archived WAL file.
+    - type: counter
+      name: failed_count
+      description: Number of failed archival operation on WAL files.
+    - type: counter
+      name: failure_time_elapsed_ms
+      description: Milliseconds since last failed archival operation on WAL files.
+- tag: pg_db_vacuum
+  collector: db_vacuum
+  sort: data
+  queries:
+  - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
+    version: 10
+    columns:
+    - type: label
+      name: datname
+      description: Database name.
+    - type: counter
+      name: age
+      description: Age since last vaccum.
+- tag: pg_view_vacuum
+  collector: db_vacuum
+  sort: data
+  queries:
+  - query: SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');
+    version: 10
+    columns:
+    - type: label
+      name: datname
+      description: View name.
+    - type: counter
+      name: age
+      description: Age since last vaccum.
+- tag: pg_blocked_vacuum
+  collector: blocked_vacuum
+  sort: data
+  queries:
+  - query: SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;
+    version: 10
+    columns:
+    - name: blocked_pid
+      type: label
+    - name: blocked_database
+      type: label
+    - name: blocked_user
+      type: label
+    - name: blocked_query
+      type: label
+    - name: blocked_duration_seconds
+      type: gauge
+      description: Duration in seconds that the vacuum has been blocked
+    - name: blocking_pid
+      type: label
+    - name: blocking_database
+      type: label
+    - name: blocking_user
+      type: label
+    - name: blocking_query
+      type: label
+    - name: blocking_duration_seconds
+      type: gauge
+      description: Duration in seconds that the blocking query has been running
+- tag: pg_wal_last_received
+  collector: wal_last_received
+  server: replica
+  queries:
+  - query: SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;
+    version: 11
+    columns:
+    - name: sender
+      type: label
+    - type: counter
+      description: Time since last message received from WAL sender
+- tag: pg_gss_auth
+  collector: gssapi
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;
+    version: 12
+    columns:
+    - type: gauge
+      description: Number of GSSAPI authenticated DB connections.
+- tag: pg_encrypted_conn
+  collector: encryted_conns
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;
+    version: 12
+    columns:
+    - type: gauge
+      description: Number of encrypted DB connections.
+- tag: pg_shmem_allocations
+  collector: shmem_size
+  queries:
+  - query: SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;
+    version: 13
+    columns:
+    - name: size
+      type: histogram
+      description: Histogram of shared memory sizes.
+- tag: pg_stat_progress_vacuum
+  collector: vacuum_progress
+  sort: data
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 13
+    columns:
+    - name: pid
+      type: label
+    - name: datname
+      type: label
+    - name: usename
+      type: label
+    - name: query
+      type: label
+    - name: phase
+      type: label
+    - name: heap_blks_total
+      type: gauge
+      description: Total heap blocks in table
+    - name: heap_blks_scanned
+      type: gauge
+      description: Heap blocks scanned
+    - name: heap_blks_vacuumed
+      type: gauge
+      description: Heap blocks vacuumed
+    - name: index_vacuum_count
+      type: gauge
+      description: Number of index vacuum cycles completed
+    - name: max_dead_tuples
+      type: gauge
+      description: Maximum dead tuples
+    - name: num_dead_tuples
+      type: gauge
+      description: Current dead tuples
+    - name: pct_scan_completed
+      type: gauge
+      description: Vacuum scan progress percentage
+- tag: pg_stat_progress_analyze
+  collector: analyze_progress
+  sort: data
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 13
+    columns:
+    - name: pid
+      type: label
+    - name: datname
+      type: label
+    - name: usename
+      type: label
+    - name: phase
+      type: label
+    - name: sample_blks_total
+      type: gauge
+      description: Total blocks to sample
+    - name: sample_blks_scanned
+      type: gauge
+      description: Blocks sampled so far
+    - name: ext_stats_total
+      type: gauge
+      description: Total extended statistics to compute
+    - name: ext_stats_computed
+      type: gauge
+      description: Extended statistics computed
+    - name: child_tables_total
+      type: gauge
+      description: Total child tables to analyze
+    - name: child_tables_done
+      type: gauge
+      description: Child tables analyzed
+    - name: pct_sample_completed
+      type: gauge
+      description: Percentage of sampling completed
+    - name: pct_child_tables_completed
+      type: gauge
+      description: Percentage of child tables completed
+- tag: pg_stat_user_tables_vacuum
+  collector: stat_user_tables
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
+    - name: n_live_tup
+      type: gauge
+      description: Estimated number of live rows
+    - name: n_dead_tup
+      type: gauge
+      description: Estimated number of dead rows
+    - name: dead_rows_pct
+      type: gauge
+      description: Percentage of dead rows relative to live rows
+    - name: n_mod_since_analyze
+      type: gauge
+      description: Estimated number of rows modified since last analyze
+    - name: n_ins_since_vacuum
+      type: gauge
+      description: Estimated number of rows inserted since last vacuum
+    - name: last_vacuum_seconds
+      type: gauge
+      description: Seconds since last manual vacuum (-1 if never)
+    - name: last_autovacuum_seconds
+      type: gauge
+      description: Seconds since last autovacuum (-1 if never)
+    - name: last_analyze_seconds
+      type: gauge
+      description: Seconds since last manual analyze (-1 if never)
+    - name: last_autoanalyze_seconds
+      type: gauge
+      description: Seconds since last autoanalyze (-1 if never)
+    - name: vacuum_count
+      type: counter
+      description: Number of times this table has been manually vacuumed
+    - name: autovacuum_count
+      type: counter
+      description: Number of times this table has been vacuumed by autovacuum
+    - name: analyze_count
+      type: counter
+      description: Number of times this table has been manually analyzed
+    - name: autoanalyze_count
+      type: counter
+      description: Number of times this table has been analyzed by autoanalyze
+- tag: pg_table_ratio
+  collector: table_activity_ratio
+  sort: data
+  database: all
+  queries:
+  - query: WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
+    - name: blocks_read
+      type: counter
+      description: Total blocks read from disk (heap + index)
+    - name: tuples_read
+      type: counter
+      description: Total number of tuples read (sequential + index scans)
+    - name: blocks_write
+      type: gauge
+      description: Estimated blocks affected by write operations
+    - name: tuples_write
+      type: counter
+      description: Total number of tuples inserted, updated, or deleted
+    - name: ratio_write
+      type: gauge
+      description: Percentage of I/O activity that is writes (0-100)
+    - name: ratio_read
+      type: gauge
+      description: Percentage of I/O activity that is reads (0-100)
+- tag: pg_table_bloat
+  collector: table_bloat
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: tblname
+      type: label
+    - name: table_size
+      type: gauge
+      description: Actual table size in bytes
+    - name: bloat_size
+      type: gauge
+      description: Estimated bloat size in bytes
+    - name: bloat_ratio_pct
+      type: gauge
+      description: Bloat ratio as percentage
+    - name: tblpages
+      type: gauge
+      description: Actual number of pages used by table
+    - name: est_tblpages
+      type: gauge
+      description: Estimated number of pages needed
+    - name: block_size
+      type: gauge
+      description: Database block size in bytes
+- tag: pg_stat_database
+  collector: stat_db
+  queries:
+  - query: SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
+    version: 12
+    columns:
+    - name: database
+      type: label
+    - name: blk_read_time
+      type: counter
+      description: pg_stat_database_blk_read_time
+    - name: blk_write_time
+      type: counter
+      description: pg_stat_database_blk_write_time
+    - name: blks_hit
+      type: counter
+      description: pg_stat_database_blks_hit
+    - name: blks_read
+      type: counter
+      description: pg_stat_database_blks_read
+    - name: deadlocks
+      type: counter
+      description: pg_stat_database_deadlocks
+    - name: temp_files
+      type: gauge
+      description: pg_stat_database_temp_files
+    - name: temp_bytes
+      type: gauge
+      description: pg_stat_database_temp_bytes
+    - name: tup_returned
+      type: counter
+      description: pg_stat_database_tup_returned
+    - name: tup_fetched
+      type: counter
+      description: pg_stat_database_tup_fetched
+    - name: tup_inserted
+      type: counter
+      description: pg_stat_database_tup_inserted
+    - name: tup_updated
+      type: counter
+      description: pg_stat_database_tup_updated
+    - name: tup_deleted
+      type: counter
+      description: pg_stat_database_tup_deleted
+    - name: xact_commit
+      type: counter
+      description: pg_stat_database_xact_commit
+    - name: xact_rollback
+      type: counter
+      description: pg_stat_database_xact_rollback
+    - name: conflicts
+      type: counter
+      description: pg_stat_database_conflicts
+    - name: numbackends
+      type: gauge
+      description: pg_stat_database_numbackends
+    - name: checksum_failures
+      type: gauge
+      description: pg_stat_database_checksum_failures
+- tag: pg_stat_database_conflicts
+  collector: stat_conflicts
+  sort: data
+  queries:
+  - query: SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - name: confl_tablespace
+      type: counter
+      description: pg_stat_database_conflicts_confl_tablespace
+    - name: confl_lock
+      type: counter
+      description: pg_stat_database_conflicts_confl_lock
+    - name: confl_snapshot
+      type: counter
+      description: pg_stat_database_conflicts_confl_snapshot
+    - name: confl_bufferpin
+      type: counter
+      description: pg_stat_database_conflicts_confl_bufferpin
+    - name: confl_deadlock
+      type: counter
+      description: pg_stat_database_conflicts_confl_deadlock
+- tag: pg_stat_all_indexes
+  collector: stat_all_indexes
+  sort: data
+  database: all
+  queries:
+  - query: SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes GROUP BY relname;
+    version: 10
+    columns:
+    - type: counter
+      name: idx_scans
+      description: Number of index scans on the table's indexes.
+    - type: counter
+      name: idx_tup_reads
+      description: Number of index entries returned by scans on the table's indexes.
+    - type: counter
+      name: idx_tup_fetchs
+      description: Number of rows fetched by simple index scans on the table's indexes.
+    - type: label
+      name: relname

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -1,1329 +1,756 @@
-# This is the default minimum version for queries, unless specified otherwise
 version: 14
 metrics:
-
-#
-# PostgreSQL 10
-#
-
-# primary_information()
-  - queries:
-    - query: SELECT
-              (
-                CASE pg_is_in_recovery() WHEN 'f'
-                  THEN 't'
-                  ELSE 'f'
-                END
-              );
-      version: 10
-      columns:
-        - description: Is the PostgreSQL instance the primary
-          type: gauge
-    tag: postgresql_primary
-    sort: name
-    collector: primary
-    server: both
-
-# database_information()
-  - queries:
-    - query: SELECT
-                datname,
-                pg_database_size(datname)
-              FROM pg_database;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - description: Size of the database
-          type: gauge
-    tag: pg_database_size
-    sort: data
-    collector: db
-
-# locks_information()
-  - queries:
-    - query: SELECT
-                pg_database.datname as database,
-                tmp.mode,
-                COALESCE(count, 0) as count
-              FROM (
-                VALUES
-                  ('accesssharelock'),
-                  ('rowsharelock'),
-                  ('rowexclusivelock'),
-                  ('shareupdateexclusivelock'),
-                  ('sharelock'),
-                  ('sharerowexclusivelock'),
-                  ('exclusivelock'),
-                  ('accessexclusivelock'),
-                  ('sireadlock')
-              ) AS tmp(mode)
-              CROSS JOIN pg_database
-              LEFT JOIN
-              (
-                SELECT
-                  database,
-                  lower(mode) AS mode,
-                  count(*) AS count
-                FROM pg_locks
-                WHERE database IS NOT NULL
-                GROUP BY database, lower(mode)
-              ) AS tmp2
-              ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database
-              ORDER BY 1, 2;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - name: mode
-          type: label
-        - description: Lock count of a database
-          type: gauge
-    tag: pg_locks_count
-    sort: data
-    collector: locks
-
-# replication_information()
-  - queries:
-    - query: SELECT
-                slot_name,
-                slot_type,
-                database,
-                active,
-                temporary
-              FROM pg_replication_slots;
-      version: 10
-      columns:
-      - name: slot_name
-        type: label
-      - name: slot_type
-        type: label
-      - name: database
-        type: label
-      - description: Is the replication active
-        name: active
-        type: gauge
-      - description: Is the replication temporary
-        name: temporary
-        type: gauge
-    tag: pg_replication_slots
-    sort: data
-    collector: replication
-
-# stat_bgwriter_information()
-  - queries:
-    - query: SELECT
-                buffers_alloc,
-                buffers_backend,
-                buffers_backend_fsync,
-                buffers_checkpoint,
-                buffers_clean,
-                checkpoint_sync_time,
-                checkpoint_write_time,
-                checkpoints_req,
-                checkpoints_timed,
-                maxwritten_clean
-              FROM pg_stat_bgwriter;
-      version: 10
-      columns:
-        - description: pg_stat_bgwriter_buffers_alloc
-          name: buffers_alloc
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_backend
-          name: buffers_backend
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_backend_fsync
-          name: buffers_backend_fsync
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_checkpoint
-          name: buffers_checkpoint
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_clean
-          name: buffers_clean
-          type: gauge
-        - description: pg_stat_bgwriter_checkpoint_sync_time
-          name: checkpoint_sync_time
-          type: counter
-        - description: pg_stat_bgwriter_checkpoint_write_time
-          name: checkpoint_write_time
-          type: counter
-        - description: pg_stat_bgwriter_checkpoints_req
-          name: checkpoints_req
-          type: counter
-        - description: pg_stat_bgwriter_checkpoints_timed
-          name: checkpoints_timed
-          type: counter
-        - description: pg_stat_bgwriter_maxwritten_clean
-          name: maxwritten_clean
-          type: counter
-    tag: pg_stat_bgwriter
-    collector: stat_bgwriter
-
-# stat_database_conflicts_information()
-  - queries:
-    - query: SELECT datname,
-                confl_tablespace,
-                confl_lock,
-                confl_snapshot,
-                confl_bufferpin,
-                confl_deadlock
-              FROM pg_stat_database_conflicts
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - name: confl_tablespace
-          type: counter
-          description: pg_stat_database_conflicts_confl_tablespace
-        - name: confl_lock
-          type: counter
-          description: pg_stat_database_conflicts_confl_lock
-        - name: confl_snapshot
-          type: counter
-          description: pg_stat_database_conflicts_confl_snapshot
-        - name: confl_bufferpin
-          type: counter
-          description: pg_stat_database_conflicts_confl_bufferpin
-        - name: confl_deadlock
-          type: counter
-          description: pg_stat_database_conflicts_confl_deadlock
-    tag: pg_stat_database_conflicts
-    sort: data
-    collector: stat_conflicts
-
-# histogram sample
-  - queries:
-    - query: WITH
-              metrics AS (
-                SELECT
-                  application_name,
-                  SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum,
-                  COUNT(*) AS process_idle_seconds_count
-                FROM pg_stat_activity
-                WHERE state = 'idle'
-                GROUP BY application_name
-              ),
-              buckets AS (
-                SELECT
-                  application_name,
-                  le,
-                  SUM(
-                    CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le
-                      THEN 1
-                      ELSE 0
-                    END
-                  )::bigint AS bucket
-                FROM
-                  pg_stat_activity,
-                  UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le
-                GROUP BY application_name, le
-                ORDER BY application_name, le
-              )
-              SELECT
-                application_name,
-                process_idle_seconds_sum as seconds_sum,
-                process_idle_seconds_count as seconds_count,
-                ARRAY_AGG(le) AS seconds,
-                ARRAY_AGG(bucket) AS seconds_bucket
-              FROM metrics JOIN buckets USING (application_name)
-              GROUP BY 1, 2, 3;
-      version: 10
-      columns:
-        - name: application_name
-          type: label
-        - name: seconds
-          type: histogram
-          description: Histogram of idle processes
-    tag: pg_process_idle_seconds
-    collector: idle_procs
-
-# Get number of available extensions for installations.
-  - queries:
-    - query: SELECT COUNT(*) AS extensions
-              FROM pg_available_extensions;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of available extensions for installation.
-    tag: pg_available_extensions
-    collector: available_extensions
-
-# Get number of installed extensions.
-  - queries:
-    - query: SELECT
-                array_agg(extname) AS extensions,
-                count(*)
-              FROM pg_extension;
-      version: 10
-      columns:
-        - name: extensions
-          type: label
-        - type: gauge
-          description: Number of installed extensions.
-    tag: pg_installed_extensions
-    collector: installed_extensions
-
-# Get applied settings
-  - queries:
-    - query: SELECT
-                sourcefile,
-                COUNT(*),
-                (
-                  CASE applied WHEN 't'
-                    THEN 'true'
-                    ELSE 'false'
-                  END
-                ) as applied
-              FROM pg_file_settings
-              WHERE applied = 't'
-              GROUP BY sourcefile, applied;
-      version: 10
-      columns:
-        - name: sourcefile
-          type: label
-        - type: gauge
-          description: Settings that are applied.
-        - name: applied
-          type: label
-    tag: pg_file_settings
-    sort: data
-    collector: file_settings
-
-# Get indexes for schemas.
-  - queries:
-    - query: SELECT
-                schemaname,
-                tablename,
-                COUNT(*)
-              FROM pg_indexes
-              GROUP BY schemaname,tablename;
-      version: 10
-      columns:
-        - name: schemaname
-          type: label
-        - name: tablename
-          type: label
-        - type: gauge
-          description: Indexes for each schemaname for each tablename.
-    tag: pg_indexes
-    sort: data
-    collector: indexes
-
-# Get materialized views
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_matviews
-              WHERE ispopulated = 't'
-              GROUP BY ispopulated;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of applied Materialized views.
-    tag: pg_matviews
-    collector: matviews
-
-# Get number of roles
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_roles;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of roles.
-    tag: pg_role
-    collector: roles
-
-# Get number of rules
-  - queries:
-    - query: SELECT tablename, COUNT(*)
-              FROM pg_rules
-              GROUP BY tablename;
-      version: 10
-      columns:
-        - name: tablename
-          type: label
-        - type: gauge
-          description: Number of rules in table.
-    tag: pg_rule
-    sort: data
-    collector: rules
-
-# Get user auth data
-  - queries:
-    - query: SELECT (
-                CASE
-                  WHEN rolpassword LIKE 'md5%' THEN 'MD5'
-                  WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256'
-                  ELSE 'UNENCRYPTED'
-                END
-              ) AS encryption_type, COUNT(*)
-              FROM pg_authid
-              WHERE rolname != 'postgres'
-              GROUP BY encryption_type;
-      version: 10
-      columns:
-        - name: encryption_type
-          type: label
-        - type: gauge
-          description: Number of users with authentication type.
-    tag: pg_shadow
-    sort: data
-    collector: auth_type
-
-# Get user defined event-triggers
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_event_trigger
-              JOIN pg_authid
-              ON pg_event_trigger.oid = pg_authid.oid
-              WHERE rolname != 'postgres';
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of user defined event triggers.
-    tag: pg_usr_evt_trigger
-    collector: usr_evt_trigger
-
-# Get number of database connections
-  - queries:
-    - query: SELECT datname, count(*)
-              FROM pg_stat_activity
-              WHERE datname IS NOT NULL
-              GROUP BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - type: gauge
-          description: Number of database connections.
-    tag: pg_db_conn
-    sort: data
-    collector: connections
-
-# Get DB connections with SSL
-  - queries:
-    - query: SELECT datname, count(*)
-              FROM pg_stat_ssl
-              JOIN pg_stat_activity
-              ON pg_stat_activity.pid = pg_stat_ssl.pid
-              WHERE ssl = 't' AND datname IS NOT NULL
-              GROUP BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - type: gauge
-          description: Number of DB connections with SSL.
-    tag: pg_db_conn_ssl
-    sort: data
-    collector: connections
-
-# All tables statio
-  - queries:
-    - query: SELECT
-                COUNT(heap_blks_read) AS heap_blks_read,
-                COUNT(heap_blks_hit) AS heap_blks_hit,
-                COUNT(idx_blks_read) as idx_blks_read,
-                COUNT(idx_blks_hit) AS idx_blks_hit,
-                COUNT(toast_blks_read) AS toast_blks_read,
-                COUNT(toast_blks_hit) AS toast_blks_hit,
-                COUNT(tidx_blks_read) AS tidx_blks_read,
-                COUNT(tidx_blks_hit) AS tidx_blks_hit
-              FROM pg_statio_all_tables;
-      version: 10
-      columns:
-        - name: heap_blks_read
-          type: counter
-          description: Number of disk blocks read in postgres db.
-        - name: heap_blks_hit
-          type: counter
-          description: Number of buffer hits read in postgres db.
-        - name: idx_blks_read
-          type: counter
-          description: Number of disk blocks reads from all indexes in postgres db.
-        - name: idx_blks_hit
-          type: counter
-          description: Number of buffer hits read from all indexes in postgres db.
-        - name: toast_blks_read
-          type: counter
-          description: Number of disk blocks reads from postgres db's TOAST tables.
-        - name: toast_blks_hit
-          type: counter
-          description: Number of buffer hits read from postgres db's TOAST tables.
-        - name: tidx_blks_read
-          type: counter
-          description: Number of disk blocks reads from postgres db's TOAST table indexes.
-        - name: tidx_blks_hit
-          type: counter
-          description: Number of buffer hits read from postgres db's TOAST table indexes.
-    tag: pg_statio_all_tables
-    collector: statio_all_tables
-
-# All sequences statio
-  - queries:
-    - query: SELECT
-                COUNT(blks_read) AS blks_read,
-                COUNT(blks_hit) AS blks_hit
-              FROM pg_statio_all_sequences;
-      version: 10
-      columns:
-        - name: blks_read
-          type: counter
-          description: Number of disk blocks read from sequences in postgres db.
-        - name: blks_hit
-          type: counter
-          description: Number of buffer hits read from sequences in postgres db.
-    tag: pg_statio_all_sequences
-    collector: statio_all_sequences
-
-# Stat user functions
-  - queries:
-    - query: SELECT
-                funcname,
-                calls,
-                self_time,
-                total_time
-              FROM pg_stat_user_functions;
-      version: 10
-      columns:
-        - name: funcname
-          type: label
-        - name: calls
-          type: counter
-          description: Number of times function is called.
-        - name: self_time
-          type: counter
-          description: Total time spent in milliseconds on the function itself.
-        - name: total_time
-          type: counter
-          description: Total time spent in milliseconds by the function and any other functions called by it.
-    tag: pg_stat_user_functions
-    sort: data
-    collector: stat_user_functions
-
-# Number of streaming WAL connections per application.
-  - queries:
-    - query: SELECT COUNT(*), application_name
-              FROM pg_stat_replication
-              WHERE state = 'streaming'
-              GROUP BY application_name;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of streaming WAL connections per application.
-        - name: application_name
-          type: label
-    tag: pg_stat_replication
-    sort: data
-    collector: stat_replication
-
-  - queries:
-    - query: SELECT
-                archived_count,
-                (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms,
-                failed_count,
-                (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms
-              FROM pg_stat_archiver;
-      version: 10
-      columns:
-        - type: counter
-          name: archived_count
-          description: Number of successful archived WAL files.
-        - type: counter
-          name: success_time_elapsed_ms
-          description: Milliseconds since successful archived WAL file.
-        - type: counter
-          name: failed_count
-          description: Number of failed archival operation on WAL files.
-        - type: counter
-          name: failure_time_elapsed_ms
-          description: Milliseconds since last failed archival operation on WAL files.
-    tag: pg_stat_archiver
-    sort: data
-    collector: stat_archiver
-
-  - queries:
-    - query: SELECT
-                SUM(idx_scan) AS idx_scans,
-                SUM(idx_tup_read) AS idx_tup_reads,
-                SUM(idx_tup_fetch) AS idx_tup_fetchs,
-                relname
-              FROM pg_stat_all_indexes
-              WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%')
-              GROUP BY relname;
-      version: 10
-      columns:
-        - type: counter
-          name: idx_scans
-          description: Number of index scans on the table's indexes.
-        - type: counter
-          name: idx_tup_reads
-          description: Number of index entries returned by scans on the table's indexes.
-        - type: counter
-          name: idx_tup_fetchs
-          description: Number of rows fetched by simple index scans on the table's indexes.
-        - type: label
-          name: relname
-    tag: stat_all_indexes
-    sort: data
-    collector: pg_stat_all_indexes
-    database: all
-
-  - queries:
-    - query: SELECT
-                datname,
-                age(datfrozenxid) as age
-              FROM pg_database;
-      version: 10
-      columns:
-        - type: label
-          name: datname
-          description: Database name.
-        - type: counter
-          name: age
-          description: Age since last vaccum.
-    tag: pg_db_vacuum
-    sort: data
-    collector: db_vacuum
-
-  - queries:
-    - query: SELECT
-                c.oid::regclass as table_name,
-                greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age
-              FROM pg_class c
-              LEFT JOIN pg_class t ON c.reltoastrelid = t.oid
-              WHERE c.relkind IN ('r', 'm');
-      version: 10
-      columns:
-        - type: label
-          name: datname
-          description: View name.
-        - type: counter
-          name: age
-          description: Age since last vaccum.
-    tag: pg_view_vacuum
-    sort: data
-    collector: db_vacuum
-# Blocked vacuum operations
-  - queries:
-    - query: SELECT
-                blocked.pid AS blocked_pid,
-                blocked.datname AS blocked_database,
-                blocked.usename AS blocked_user,
-                blocked.query AS blocked_query,
-                EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds,
-                blocking.pid AS blocking_pid,
-                blocking.datname AS blocking_database,
-                blocking.usename AS blocking_user,
-                blocking.query AS blocking_query,
-                EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds
-              FROM pg_stat_activity blocked
-              JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
-              JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation
-                AND blocked_locks.pid != blocking_locks.pid
-              JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid
-              WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%')
-                AND NOT blocked_locks.granted
-                AND blocking_locks.granted
-              ORDER BY blocked_duration_seconds DESC;
-      version: 10
-      columns:
-        - name: blocked_pid
-          type: label
-        - name: blocked_database
-          type: label
-        - name: blocked_user
-          type: label
-        - name: blocked_query
-          type: label
-        - name: blocked_duration_seconds
-          type: gauge
-          description: Duration in seconds that the vacuum has been blocked
-        - name: blocking_pid
-          type: label
-        - name: blocking_database
-          type: label
-        - name: blocking_user
-          type: label
-        - name: blocking_query
-          type: label
-        - name: blocking_duration_seconds
-          type: gauge
-          description: Duration in seconds that the blocking query has been running
-    tag: pg_blocked_vacuum
-    sort: data
-    collector: blocked_vacuum
-#
-# PostgreSQL 11
-#
-
-# WAL last sent
-  - queries:
-    - query: SELECT
-              CASE
-                WHEN sender_host LIKE '/%' THEN sender_host
-                ELSE sender_host || ':' || sender_port::text
-              END AS sender,
-              (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms
-              FROM pg_stat_wal_receiver;
-      version: 11
-      columns:
-        - name: sender
-          type: label
-        - type: counter
-          description: Time since last message received from WAL sender
-    tag: pg_wal_last_received
-    collector: wal_last_received
-    server: replica
-
-#
-# PostgreSQL 12
-#
-
-# GSS Authenticated DB Connections
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE gss_authenticated = 't' AND datname IS NOT NULL;
-      version: 12
-      columns:
-        - type: gauge
-          description: Number of GSSAPI authenticated DB connections.
-    tag: pg_gss_auth
-    collector: gssapi
-
-# Encrypted DB Connections
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE encrypted = 't' AND datname IS NOT NULL;
-      version: 12
-      columns:
-        - type: gauge
-          description: Number of encrypted DB connections.
-    tag: pg_encrypted_conn
-    collector: encryted_conns
-
-#
-# PostgreSQL 13
-#
-
-# Shared memory histogram
-  - queries:
-    - query: SELECT
-                SUM(sum) AS size_sum,
-                '1' AS size_count,
-                array_agg((bucket - 1) * (50000))::int[] AS size,
-                array_agg(count)::int[] AS size_bucket
-              FROM (
-                  SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size)
-                  FROM pg_shmem_allocations
-                  GROUP BY bucket
-                  ORDER BY bucket
-              ) t;
-      version: 13
-      columns:
-        - name: size
-          type: histogram
-          description: Histogram of shared memory sizes.
-    tag: pg_shmem_allocations
-    collector: shmem_size
-
-# Vacuum progress information
-  - queries:
-    - query: SELECT
-                p.pid,
-                a.datname,
-                a.usename,
-                a.query,
-                p.phase,
-                p.heap_blks_total,
-                p.heap_blks_scanned,
-                p.heap_blks_vacuumed,
-                p.index_vacuum_count,
-                p.max_dead_tuples,
-                p.num_dead_tuples,
-                CASE WHEN p.heap_blks_total > 0
-                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
-                     ELSE 0
-                END AS pct_scan_completed
-              FROM pg_stat_progress_vacuum p
-              JOIN pg_stat_activity a USING (pid)
-              ORDER BY p.pid;
-      version: 13
-      columns:
-        - name: pid
-          type: label
-        - name: datname
-          type: label
-        - name: usename
-          type: label
-        - name: query
-          type: label
-        - name: phase
-          type: label
-        - name: heap_blks_total
-          type: gauge
-          description: Total heap blocks in table
-        - name: heap_blks_scanned
-          type: gauge
-          description: Heap blocks scanned
-        - name: heap_blks_vacuumed
-          type: gauge
-          description: Heap blocks vacuumed
-        - name: index_vacuum_count
-          type: gauge
-          description: Number of index vacuum cycles completed
-        - name: max_dead_tuples
-          type: gauge
-          description: Maximum dead tuples
-        - name: num_dead_tuples
-          type: gauge
-          description: Current dead tuples
-        - name: pct_scan_completed
-          type: gauge
-          description: Vacuum scan progress percentage
-    tag: pg_stat_progress_vacuum
-    sort: data
-    collector: vacuum_progress
-
-# Table-level vacuum and analyze statistics
-  - queries:
-    - query: SELECT
-                schemaname,
-                relname,
-                n_live_tup,
-                n_dead_tup,
-                CASE 
-                  WHEN n_live_tup > 0 
-                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
-                  ELSE 0
-                END AS dead_rows_pct,
-                n_mod_since_analyze,
-                n_ins_since_vacuum,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
-                vacuum_count,
-                autovacuum_count,
-                analyze_count,
-                autoanalyze_count
-              FROM pg_stat_user_tables
-              ORDER BY n_dead_tup DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: n_live_tup
-          type: gauge
-          description: Estimated number of live rows
-        - name: n_dead_tup
-          type: gauge
-          description: Estimated number of dead rows
-        - name: dead_rows_pct
-          type: gauge
-          description: Percentage of dead rows relative to live rows
-        - name: n_mod_since_analyze
-          type: gauge
-          description: Estimated number of rows modified since last analyze
-        - name: n_ins_since_vacuum
-          type: gauge
-          description: Estimated number of rows inserted since last vacuum
-        - name: last_vacuum_seconds
-          type: gauge
-          description: Seconds since last manual vacuum (-1 if never)
-        - name: last_autovacuum_seconds
-          type: gauge
-          description: Seconds since last autovacuum (-1 if never)
-        - name: last_analyze_seconds
-          type: gauge
-          description: Seconds since last manual analyze (-1 if never)
-        - name: last_autoanalyze_seconds
-          type: gauge
-          description: Seconds since last autoanalyze (-1 if never)
-        - name: vacuum_count
-          type: counter
-          description: Number of times this table has been manually vacuumed
-        - name: autovacuum_count
-          type: counter
-          description: Number of times this table has been vacuumed by autovacuum
-        - name: analyze_count
-          type: counter
-          description: Number of times this table has been manually analyzed
-        - name: autoanalyze_count
-          type: counter
-          description: Number of times this table has been analyzed by autoanalyze
-    tag: pg_stat_user_tables_vacuum
-    sort: data
-    collector: stat_user_tables
-    database: all
-
-# Table read/write activity ratios
-  - queries:
-    - query: WITH table_activity AS (
-                SELECT
-                  s.schemaname,
-                  s.relname,
-                  si.heap_blks_read + si.idx_blks_read AS blocks_read,
-                  s.seq_tup_read + s.idx_tup_fetch AS tuples_read,
-                  c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) /
-                    CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write,
-                  s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write
-                FROM pg_stat_user_tables AS s
-                JOIN pg_statio_user_tables AS si ON s.relid = si.relid
-                JOIN pg_class c ON c.oid = s.relid
-                WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0
-                  AND (si.heap_blks_read + si.idx_blks_read) > 0
-              )
-              SELECT
-                schemaname,
-                relname,
-                blocks_read,
-                tuples_read,
-                blocks_write,
-                tuples_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int
-                END AS ratio_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int
-                END AS ratio_read
-              FROM table_activity
-              ORDER BY (blocks_read + blocks_write) DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: blocks_read
-          type: counter
-          description: Total blocks read from disk (heap + index)
-        - name: tuples_read
-          type: counter
-          description: Total number of tuples read (sequential + index scans)
-        - name: blocks_write
-          type: gauge
-          description: Estimated blocks affected by write operations
-        - name: tuples_write
-          type: counter
-          description: Total number of tuples inserted, updated, or deleted
-        - name: ratio_write
-          type: gauge
-          description: Percentage of I/O activity that is writes (0-100)
-        - name: ratio_read
-          type: gauge
-          description: Percentage of I/O activity that is reads (0-100)
-    tag: pg_table_ratio
-    sort: data
-    collector: table_activity_ratio
-    database: all
-
-# Table bloat analysis
-  - queries:
-    - query: SELECT
-                schemaname,
-                tblname,
-                real_size AS table_size,
-                extra_size AS bloat_size,
-                ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct,
-                tblpages,
-                est_tblpages,
-                bs AS block_size
-              FROM (
-                SELECT
-                  schemaname,
-                  tblname,
-                  bs*tblpages AS real_size,
-                  (tblpages-est_tblpages)*bs AS extra_size,
-                  CASE WHEN tblpages > 0
-                    THEN 100 * (tblpages-est_tblpages)/tblpages::numeric
-                    ELSE 0
-                  END AS extra_ratio,
-                  tblpages,
-                  est_tblpages,
-                  bs
-                FROM (
-                  SELECT
-                    n.nspname AS schemaname,
-                    c.relname AS tblname,
-                    c.relpages AS tblpages,
-                    CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages,
-                    current_setting('block_size')::integer AS bs
-                  FROM pg_class c
-                  JOIN pg_namespace n ON n.oid = c.relnamespace
-                  WHERE c.relkind = 'r'
-                  AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
-                  AND n.nspname NOT LIKE 'pg_temp_%'
-                ) AS bloat_calc
-              ) AS bloat_summary
-              WHERE tblpages > 0
-              ORDER BY extra_size DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: tblname
-          type: label
-        - name: table_size
-          type: gauge
-          description: Actual table size in bytes
-        - name: bloat_size
-          type: gauge
-          description: Estimated bloat size in bytes
-        - name: bloat_ratio_pct
-          type: gauge
-          description: Bloat ratio as percentage
-        - name: tblpages
-          type: gauge
-          description: Actual number of pages used by table
-        - name: est_tblpages
-          type: gauge
-          description: Estimated number of pages needed
-        - name: block_size
-          type: gauge
-          description: Database block size in bytes
-    tag: pg_table_bloat
-    sort: data
-    collector: table_bloat
-    database: all
-#
-# PostgreSQL 14
-#
-
-# Memory context information
-  - queries:
-    - query: SELECT
-                COUNT(*) AS contexts,
-                parent,
-                SUM(free_bytes) AS free_bytes,
-                SUM(used_bytes) AS used_bytes,
-                SUM(total_bytes) AS total_bytes
-              FROM pg_backend_memory_contexts
-              WHERE parent!=''
-              GROUP BY parent;
-      columns:
-        - name: contexts
-          type: gauge
-          description: Number of memory contexts per parent.
-        - name: parent
-          type: label
-        - name: free_bytes
-          type: gauge
-          description: Free bytes per memory context.
-        - name: used_bytes
-          type: gauge
-          description: Used bytes per memory context.
-        - name: total_bytes
-          type: gauge
-          description: Total bytes per memory context.
-    tag: pg_mem_ctx
-    collector: mem_ctx
-
-# Memory context information
-  - queries:
-    - query: SELECT
-                wal_records,
-                wal_fpi,
-                wal_bytes,
-                wal_buffers_full,
-                wal_write,
-                wal_sync,
-                wal_write_time,
-                wal_sync_time
-              FROM pg_stat_wal;
-      columns:
-        - name: wal_records
-          type: counter
-          description: Number of WAL records generated.
-        - name: wal_fpi
-          type: counter
-          description: Number of WAL full page images generated.
-        - name: wal_bytes
-          type: counter
-          description: Total bytes of generated WAL.
-        - name: wal_buffers_full
-          type: counter
-          description: Number of disk writes due to WAL buffers being full.
-        - name: wal_write
-          type: counter
-          description: Number of times WAL files were written to disk.
-        - name: wal_sync
-          type: counter
-          description: Number of times WAL files were synced to disk.
-        - name: wal_write_time
-          type: counter
-          description: Time taken for WAL files to be written to disk.
-        - name: wal_sync_time
-          type: counter
-          description: Time taken for WAL files to be synced to disk.
-    tag: pg_stat_wal
-    collector: stat_wal
-
-# stat_database_information()
-  - queries:
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends
-              FROM pg_stat_database
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-      version: 10
-
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends,
-                checksum_failures
-              FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-        - name: checksum_failures
-          type: gauge
-          description: pg_stat_database_checksum_failures
-      version: 12
-
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends,
-                checksum_failures,
-                session_time,
-                active_time,
-                idle_in_transaction_time,
-                sessions,
-                sessions_abandoned,
-                sessions_fatal,
-                sessions_killed
-              FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-        - name: checksum_failures
-          type: gauge
-          description: pg_stat_database_checksum_failures
-        - name: session_time
-          type: gauge
-          description: pg_stat_database_session_time
-        - name: active_time
-          type: gauge
-          description: pg_stat_database_active_time
-        - name: idle_in_transaction_time
-          type: gauge
-          description: pg_stat_database_idle_in_transaction_time
-        - name: sessions
-          type: gauge
-          description: pg_stat_database_sessions
-        - name: sessions_abandoned
-          type: gauge
-          description: pg_stat_database_sessions_abandoned
-        - name: sessions_fatal
-          type: gauge
-          description: pg_stat_database_sessions_fatal
-        - name: sessions_killed
-          type: gauge
-          description: pg_stat_database_sessions_killed
-    tag: pg_stat_database
-    collector: stat_db
+- tag: postgresql_primary
+  collector: primary
+  sort: name
+  server: both
+  queries:
+  - query: SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );
+    version: 10
+    columns:
+    - description: Is the PostgreSQL instance the primary
+      type: gauge
+- tag: pg_database_size
+  collector: db
+  sort: data
+  queries:
+  - query: SELECT datname, pg_database_size(datname) FROM pg_database;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - description: Size of the database
+      type: gauge
+- tag: pg_locks_count
+  collector: locks
+  sort: data
+  queries:
+  - query: SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - name: mode
+      type: label
+    - description: Lock count of a database
+      type: gauge
+- tag: pg_replication_slots
+  collector: replication
+  sort: data
+  queries:
+  - query: SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;
+    version: 10
+    columns:
+    - name: slot_name
+      type: label
+    - name: slot_type
+      type: label
+    - name: database
+      type: label
+    - description: Is the replication active
+      name: active
+      type: gauge
+    - description: Is the replication temporary
+      name: temporary
+      type: gauge
+- tag: pg_stat_bgwriter
+  collector: stat_bgwriter
+  queries:
+  - query: SELECT buffers_alloc, buffers_backend, buffers_backend_fsync, buffers_checkpoint, buffers_clean, checkpoint_sync_time, checkpoint_write_time, checkpoints_req, checkpoints_timed, maxwritten_clean FROM pg_stat_bgwriter;
+    version: 10
+    columns:
+    - description: pg_stat_bgwriter_buffers_alloc
+      name: buffers_alloc
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_backend
+      name: buffers_backend
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_backend_fsync
+      name: buffers_backend_fsync
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_checkpoint
+      name: buffers_checkpoint
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_clean
+      name: buffers_clean
+      type: gauge
+    - description: pg_stat_bgwriter_checkpoint_sync_time
+      name: checkpoint_sync_time
+      type: counter
+    - description: pg_stat_bgwriter_checkpoint_write_time
+      name: checkpoint_write_time
+      type: counter
+    - description: pg_stat_bgwriter_checkpoints_req
+      name: checkpoints_req
+      type: counter
+    - description: pg_stat_bgwriter_checkpoints_timed
+      name: checkpoints_timed
+      type: counter
+    - description: pg_stat_bgwriter_maxwritten_clean
+      name: maxwritten_clean
+      type: counter
+- tag: pg_process_idle_seconds
+  collector: idle_procs
+  queries:
+  - query: WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;
+    version: 10
+    columns:
+    - name: application_name
+      type: label
+    - name: seconds
+      type: histogram
+      description: Histogram of idle processes
+- tag: pg_available_extensions
+  collector: available_extensions
+  queries:
+  - query: SELECT COUNT(*) AS extensions FROM pg_available_extensions;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of available extensions for installation.
+- tag: pg_installed_extensions
+  collector: installed_extensions
+  queries:
+  - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
+    version: 10
+    columns:
+    - name: extensions
+      type: label
+    - type: gauge
+      description: Number of installed extensions.
+- tag: pg_file_settings
+  collector: file_settings
+  sort: data
+  queries:
+  - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
+    version: 10
+    columns:
+    - name: sourcefile
+      type: label
+    - type: gauge
+      description: Settings that are applied.
+    - name: applied
+      type: label
+- tag: pg_indexes
+  collector: indexes
+  sort: data
+  queries:
+  - query: SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;
+    version: 10
+    columns:
+    - name: schemaname
+      type: label
+    - name: tablename
+      type: label
+    - type: gauge
+      description: Indexes for each schemaname for each tablename.
+- tag: pg_matviews
+  collector: matviews
+  queries:
+  - query: SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of applied Materialized views.
+- tag: pg_role
+  collector: roles
+  queries:
+  - query: SELECT COUNT(*) FROM pg_roles;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of roles.
+- tag: pg_rule
+  collector: rules
+  sort: data
+  queries:
+  - query: SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;
+    version: 10
+    columns:
+    - name: tablename
+      type: label
+    - type: gauge
+      description: Number of rules in table.
+- tag: pg_shadow
+  collector: auth_type
+  sort: data
+  queries:
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+    version: 10
+    columns:
+    - name: encryption_type
+      type: label
+    - type: gauge
+      description: Number of users with authentication type.
+- tag: pg_usr_evt_trigger
+  collector: usr_evt_trigger
+  queries:
+  - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of user defined event triggers.
+- tag: pg_db_conn
+  collector: connections
+  sort: data
+  queries:
+  - query: SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - type: gauge
+      description: Number of database connections.
+- tag: pg_db_conn_ssl
+  collector: connections
+  sort: data
+  queries:
+  - query: SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - type: gauge
+      description: Number of DB connections with SSL.
+- tag: pg_statio_all_tables
+  collector: statio_all_tables
+  queries:
+  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+    version: 10
+    columns:
+    - name: heap_blks_read
+      type: counter
+      description: Number of disk blocks read in postgres db.
+    - name: heap_blks_hit
+      type: counter
+      description: Number of buffer hits read in postgres db.
+    - name: idx_blks_read
+      type: counter
+      description: Number of disk blocks reads from all indexes in postgres db.
+    - name: idx_blks_hit
+      type: counter
+      description: Number of buffer hits read from all indexes in postgres db.
+    - name: toast_blks_read
+      type: counter
+      description: Number of disk blocks reads from postgres db's TOAST tables.
+    - name: toast_blks_hit
+      type: counter
+      description: Number of buffer hits read from postgres db's TOAST tables.
+    - name: tidx_blks_read
+      type: counter
+      description: Number of disk blocks reads from postgres db's TOAST table indexes.
+    - name: tidx_blks_hit
+      type: counter
+      description: Number of buffer hits read from postgres db's TOAST table indexes.
+- tag: pg_statio_all_sequences
+  collector: statio_all_sequences
+  queries:
+  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+    version: 10
+    columns:
+    - name: blks_read
+      type: counter
+      description: Number of disk blocks read from sequences in postgres db.
+    - name: blks_hit
+      type: counter
+      description: Number of buffer hits read from sequences in postgres db.
+- tag: pg_stat_user_functions
+  collector: stat_user_functions
+  sort: data
+  queries:
+  - query: SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;
+    version: 10
+    columns:
+    - name: funcname
+      type: label
+    - name: calls
+      type: counter
+      description: Number of times function is called.
+    - name: self_time
+      type: counter
+      description: Total time spent in milliseconds on the function itself.
+    - name: total_time
+      type: counter
+      description: Total time spent in milliseconds by the function and any other functions called by it.
+- tag: pg_stat_replication
+  collector: stat_replication
+  sort: data
+  queries:
+  - query: SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of streaming WAL connections per application.
+    - name: application_name
+      type: label
+- tag: pg_stat_archiver
+  collector: stat_archiver
+  sort: data
+  queries:
+  - query: SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;
+    version: 10
+    columns:
+    - type: counter
+      name: archived_count
+      description: Number of successful archived WAL files.
+    - type: counter
+      name: success_time_elapsed_ms
+      description: Milliseconds since successful archived WAL file.
+    - type: counter
+      name: failed_count
+      description: Number of failed archival operation on WAL files.
+    - type: counter
+      name: failure_time_elapsed_ms
+      description: Milliseconds since last failed archival operation on WAL files.
+- tag: pg_db_vacuum
+  collector: db_vacuum
+  sort: data
+  queries:
+  - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
+    version: 10
+    columns:
+    - type: label
+      name: datname
+      description: Database name.
+    - type: counter
+      name: age
+      description: Age since last vaccum.
+- tag: pg_view_vacuum
+  collector: db_vacuum
+  sort: data
+  queries:
+  - query: SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');
+    version: 10
+    columns:
+    - type: label
+      name: datname
+      description: View name.
+    - type: counter
+      name: age
+      description: Age since last vaccum.
+- tag: pg_blocked_vacuum
+  collector: blocked_vacuum
+  sort: data
+  queries:
+  - query: SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;
+    version: 10
+    columns:
+    - name: blocked_pid
+      type: label
+    - name: blocked_database
+      type: label
+    - name: blocked_user
+      type: label
+    - name: blocked_query
+      type: label
+    - name: blocked_duration_seconds
+      type: gauge
+      description: Duration in seconds that the vacuum has been blocked
+    - name: blocking_pid
+      type: label
+    - name: blocking_database
+      type: label
+    - name: blocking_user
+      type: label
+    - name: blocking_query
+      type: label
+    - name: blocking_duration_seconds
+      type: gauge
+      description: Duration in seconds that the blocking query has been running
+- tag: pg_wal_last_received
+  collector: wal_last_received
+  server: replica
+  queries:
+  - query: SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;
+    version: 11
+    columns:
+    - name: sender
+      type: label
+    - type: counter
+      description: Time since last message received from WAL sender
+- tag: pg_gss_auth
+  collector: gssapi
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;
+    version: 12
+    columns:
+    - type: gauge
+      description: Number of GSSAPI authenticated DB connections.
+- tag: pg_encrypted_conn
+  collector: encryted_conns
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;
+    version: 12
+    columns:
+    - type: gauge
+      description: Number of encrypted DB connections.
+- tag: pg_shmem_allocations
+  collector: shmem_size
+  queries:
+  - query: SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;
+    version: 13
+    columns:
+    - name: size
+      type: histogram
+      description: Histogram of shared memory sizes.
+- tag: pg_stat_progress_vacuum
+  collector: vacuum_progress
+  sort: data
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 13
+    columns:
+    - name: pid
+      type: label
+    - name: datname
+      type: label
+    - name: usename
+      type: label
+    - name: query
+      type: label
+    - name: phase
+      type: label
+    - name: heap_blks_total
+      type: gauge
+      description: Total heap blocks in table
+    - name: heap_blks_scanned
+      type: gauge
+      description: Heap blocks scanned
+    - name: heap_blks_vacuumed
+      type: gauge
+      description: Heap blocks vacuumed
+    - name: index_vacuum_count
+      type: gauge
+      description: Number of index vacuum cycles completed
+    - name: max_dead_tuples
+      type: gauge
+      description: Maximum dead tuples
+    - name: num_dead_tuples
+      type: gauge
+      description: Current dead tuples
+    - name: pct_scan_completed
+      type: gauge
+      description: Vacuum scan progress percentage
+- tag: pg_stat_progress_analyze
+  collector: analyze_progress
+  sort: data
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 13
+    columns:
+    - name: pid
+      type: label
+    - name: datname
+      type: label
+    - name: usename
+      type: label
+    - name: phase
+      type: label
+    - name: sample_blks_total
+      type: gauge
+      description: Total blocks to sample
+    - name: sample_blks_scanned
+      type: gauge
+      description: Blocks sampled so far
+    - name: ext_stats_total
+      type: gauge
+      description: Total extended statistics to compute
+    - name: ext_stats_computed
+      type: gauge
+      description: Extended statistics computed
+    - name: child_tables_total
+      type: gauge
+      description: Total child tables to analyze
+    - name: child_tables_done
+      type: gauge
+      description: Child tables analyzed
+    - name: pct_sample_completed
+      type: gauge
+      description: Percentage of sampling completed
+    - name: pct_child_tables_completed
+      type: gauge
+      description: Percentage of child tables completed
+- tag: pg_stat_user_tables_vacuum
+  collector: stat_user_tables
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
+    - name: n_live_tup
+      type: gauge
+      description: Estimated number of live rows
+    - name: n_dead_tup
+      type: gauge
+      description: Estimated number of dead rows
+    - name: dead_rows_pct
+      type: gauge
+      description: Percentage of dead rows relative to live rows
+    - name: n_mod_since_analyze
+      type: gauge
+      description: Estimated number of rows modified since last analyze
+    - name: n_ins_since_vacuum
+      type: gauge
+      description: Estimated number of rows inserted since last vacuum
+    - name: last_vacuum_seconds
+      type: gauge
+      description: Seconds since last manual vacuum (-1 if never)
+    - name: last_autovacuum_seconds
+      type: gauge
+      description: Seconds since last autovacuum (-1 if never)
+    - name: last_analyze_seconds
+      type: gauge
+      description: Seconds since last manual analyze (-1 if never)
+    - name: last_autoanalyze_seconds
+      type: gauge
+      description: Seconds since last autoanalyze (-1 if never)
+    - name: vacuum_count
+      type: counter
+      description: Number of times this table has been manually vacuumed
+    - name: autovacuum_count
+      type: counter
+      description: Number of times this table has been vacuumed by autovacuum
+    - name: analyze_count
+      type: counter
+      description: Number of times this table has been manually analyzed
+    - name: autoanalyze_count
+      type: counter
+      description: Number of times this table has been analyzed by autoanalyze
+- tag: pg_table_ratio
+  collector: table_activity_ratio
+  sort: data
+  database: all
+  queries:
+  - query: WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
+    - name: blocks_read
+      type: counter
+      description: Total blocks read from disk (heap + index)
+    - name: tuples_read
+      type: counter
+      description: Total number of tuples read (sequential + index scans)
+    - name: blocks_write
+      type: gauge
+      description: Estimated blocks affected by write operations
+    - name: tuples_write
+      type: counter
+      description: Total number of tuples inserted, updated, or deleted
+    - name: ratio_write
+      type: gauge
+      description: Percentage of I/O activity that is writes (0-100)
+    - name: ratio_read
+      type: gauge
+      description: Percentage of I/O activity that is reads (0-100)
+- tag: pg_table_bloat
+  collector: table_bloat
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: tblname
+      type: label
+    - name: table_size
+      type: gauge
+      description: Actual table size in bytes
+    - name: bloat_size
+      type: gauge
+      description: Estimated bloat size in bytes
+    - name: bloat_ratio_pct
+      type: gauge
+      description: Bloat ratio as percentage
+    - name: tblpages
+      type: gauge
+      description: Actual number of pages used by table
+    - name: est_tblpages
+      type: gauge
+      description: Estimated number of pages needed
+    - name: block_size
+      type: gauge
+      description: Database block size in bytes
+- tag: pg_mem_ctx
+  collector: mem_ctx
+  queries:
+  - query: SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;
+    version: 14
+    columns:
+    - name: contexts
+      type: gauge
+      description: Number of memory contexts per parent.
+    - name: parent
+      type: label
+    - name: free_bytes
+      type: gauge
+      description: Free bytes per memory context.
+    - name: used_bytes
+      type: gauge
+      description: Used bytes per memory context.
+    - name: total_bytes
+      type: gauge
+      description: Total bytes per memory context.
+- tag: pg_stat_wal
+  collector: stat_wal
+  queries:
+  - query: SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal;
+    version: 14
+    columns:
+    - name: wal_records
+      type: counter
+      description: Number of WAL records generated.
+    - name: wal_fpi
+      type: counter
+      description: Number of WAL full page images generated.
+    - name: wal_bytes
+      type: counter
+      description: Total bytes of generated WAL.
+    - name: wal_buffers_full
+      type: counter
+      description: Number of disk writes due to WAL buffers being full.
+    - name: wal_write
+      type: counter
+      description: Number of times WAL files were written to disk.
+    - name: wal_sync
+      type: counter
+      description: Number of times WAL files were synced to disk.
+    - name: wal_write_time
+      type: counter
+      description: Time taken for WAL files to be written to disk.
+    - name: wal_sync_time
+      type: counter
+      description: Time taken for WAL files to be synced to disk.
+- tag: pg_stat_database
+  collector: stat_db
+  queries:
+  - query: SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
+    version: 14
+    columns:
+    - name: database
+      type: label
+    - name: blk_read_time
+      type: counter
+      description: pg_stat_database_blk_read_time
+    - name: blk_write_time
+      type: counter
+      description: pg_stat_database_blk_write_time
+    - name: blks_hit
+      type: counter
+      description: pg_stat_database_blks_hit
+    - name: blks_read
+      type: counter
+      description: pg_stat_database_blks_read
+    - name: deadlocks
+      type: counter
+      description: pg_stat_database_deadlocks
+    - name: temp_files
+      type: gauge
+      description: pg_stat_database_temp_files
+    - name: temp_bytes
+      type: gauge
+      description: pg_stat_database_temp_bytes
+    - name: tup_returned
+      type: counter
+      description: pg_stat_database_tup_returned
+    - name: tup_fetched
+      type: counter
+      description: pg_stat_database_tup_fetched
+    - name: tup_inserted
+      type: counter
+      description: pg_stat_database_tup_inserted
+    - name: tup_updated
+      type: counter
+      description: pg_stat_database_tup_updated
+    - name: tup_deleted
+      type: counter
+      description: pg_stat_database_tup_deleted
+    - name: xact_commit
+      type: counter
+      description: pg_stat_database_xact_commit
+    - name: xact_rollback
+      type: counter
+      description: pg_stat_database_xact_rollback
+    - name: conflicts
+      type: counter
+      description: pg_stat_database_conflicts
+    - name: numbackends
+      type: gauge
+      description: pg_stat_database_numbackends
+    - name: checksum_failures
+      type: gauge
+      description: pg_stat_database_checksum_failures
+    - name: session_time
+      type: gauge
+      description: pg_stat_database_session_time
+    - name: active_time
+      type: gauge
+      description: pg_stat_database_active_time
+    - name: idle_in_transaction_time
+      type: gauge
+      description: pg_stat_database_idle_in_transaction_time
+    - name: sessions
+      type: gauge
+      description: pg_stat_database_sessions
+    - name: sessions_abandoned
+      type: gauge
+      description: pg_stat_database_sessions_abandoned
+    - name: sessions_fatal
+      type: gauge
+      description: pg_stat_database_sessions_fatal
+    - name: sessions_killed
+      type: gauge
+      description: pg_stat_database_sessions_killed
+- tag: pg_stat_database_conflicts
+  collector: stat_conflicts
+  sort: data
+  queries:
+  - query: SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - name: confl_tablespace
+      type: counter
+      description: pg_stat_database_conflicts_confl_tablespace
+    - name: confl_lock
+      type: counter
+      description: pg_stat_database_conflicts_confl_lock
+    - name: confl_snapshot
+      type: counter
+      description: pg_stat_database_conflicts_confl_snapshot
+    - name: confl_bufferpin
+      type: counter
+      description: pg_stat_database_conflicts_confl_bufferpin
+    - name: confl_deadlock
+      type: counter
+      description: pg_stat_database_conflicts_confl_deadlock
+- tag: pg_stat_all_indexes
+  collector: stat_all_indexes
+  sort: data
+  database: all
+  queries:
+  - query: SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes GROUP BY relname;
+    version: 10
+    columns:
+    - type: counter
+      name: idx_scans
+      description: Number of index scans on the table's indexes.
+    - type: counter
+      name: idx_tup_reads
+      description: Number of index entries returned by scans on the table's indexes.
+    - type: counter
+      name: idx_tup_fetchs
+      description: Number of rows fetched by simple index scans on the table's indexes.
+    - type: label
+      name: relname

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -1,1351 +1,764 @@
-# This is the default minimum version for queries, unless specified otherwise
 version: 15
 metrics:
-
-#
-# PostgreSQL 10
-#
-
-# primary_information()
-  - queries:
-    - query: SELECT
-              (
-                CASE pg_is_in_recovery() WHEN 'f'
-                  THEN 't'
-                  ELSE 'f'
-                END
-              );
-      version: 10
-      columns:
-        - description: Is the PostgreSQL instance the primary
-          type: gauge
-    tag: postgresql_primary
-    sort: name
-    collector: primary
-    server: both
-
-# database_information()
-  - queries:
-    - query: SELECT
-                datname,
-                pg_database_size(datname)
-              FROM pg_database;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - description: Size of the database
-          type: gauge
-    tag: pg_database_size
-    sort: data
-    collector: db
-
-# locks_information()
-  - queries:
-    - query: SELECT
-                pg_database.datname as database,
-                tmp.mode,
-                COALESCE(count, 0) as count
-              FROM (
-                VALUES
-                  ('accesssharelock'),
-                  ('rowsharelock'),
-                  ('rowexclusivelock'),
-                  ('shareupdateexclusivelock'),
-                  ('sharelock'),
-                  ('sharerowexclusivelock'),
-                  ('exclusivelock'),
-                  ('accessexclusivelock'),
-                  ('sireadlock')
-              ) AS tmp(mode)
-              CROSS JOIN pg_database
-              LEFT JOIN
-              (
-                SELECT
-                  database,
-                  lower(mode) AS mode,
-                  count(*) AS count
-                FROM pg_locks
-                WHERE database IS NOT NULL
-                GROUP BY database, lower(mode)
-              ) AS tmp2
-              ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database
-              ORDER BY 1, 2;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - name: mode
-          type: label
-        - description: Lock count of a database
-          type: gauge
-    tag: pg_locks_count
-    sort: data
-    collector: locks
-
-# replication_information()
-  - queries:
-    - query: SELECT
-                slot_name,
-                slot_type,
-                database,
-                active,
-                temporary
-              FROM pg_replication_slots;
-      version: 10
-      columns:
-      - name: slot_name
-        type: label
-      - name: slot_type
-        type: label
-      - name: database
-        type: label
-      - description: Is the replication active
-        name: active
-        type: gauge
-      - description: Is the replication temporary
-        name: temporary
-        type: gauge
-    tag: pg_replication_slots
-    sort: data
-    collector: replication
-
-# stat_bgwriter_information()
-  - queries:
-    - query: SELECT
-                buffers_alloc,
-                buffers_backend,
-                buffers_backend_fsync,
-                buffers_checkpoint,
-                buffers_clean,
-                checkpoint_sync_time,
-                checkpoint_write_time,
-                checkpoints_req,
-                checkpoints_timed,
-                maxwritten_clean
-              FROM pg_stat_bgwriter;
-      version: 10
-      columns:
-        - description: pg_stat_bgwriter_buffers_alloc
-          name: buffers_alloc
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_backend
-          name: buffers_backend
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_backend_fsync
-          name: buffers_backend_fsync
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_checkpoint
-          name: buffers_checkpoint
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_clean
-          name: buffers_clean
-          type: gauge
-        - description: pg_stat_bgwriter_checkpoint_sync_time
-          name: checkpoint_sync_time
-          type: counter
-        - description: pg_stat_bgwriter_checkpoint_write_time
-          name: checkpoint_write_time
-          type: counter
-        - description: pg_stat_bgwriter_checkpoints_req
-          name: checkpoints_req
-          type: counter
-        - description: pg_stat_bgwriter_checkpoints_timed
-          name: checkpoints_timed
-          type: counter
-        - description: pg_stat_bgwriter_maxwritten_clean
-          name: maxwritten_clean
-          type: counter
-    tag: pg_stat_bgwriter
-    collector: stat_bgwriter
-
-# stat_database_conflicts_information()
-  - queries:
-    - query: SELECT datname,
-                confl_tablespace,
-                confl_lock,
-                confl_snapshot,
-                confl_bufferpin,
-                confl_deadlock
-              FROM pg_stat_database_conflicts
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - name: confl_tablespace
-          type: counter
-          description: pg_stat_database_conflicts_confl_tablespace
-        - name: confl_lock
-          type: counter
-          description: pg_stat_database_conflicts_confl_lock
-        - name: confl_snapshot
-          type: counter
-          description: pg_stat_database_conflicts_confl_snapshot
-        - name: confl_bufferpin
-          type: counter
-          description: pg_stat_database_conflicts_confl_bufferpin
-        - name: confl_deadlock
-          type: counter
-          description: pg_stat_database_conflicts_confl_deadlock
-    tag: pg_stat_database_conflicts
-    sort: data
-    collector: stat_conflicts
-
-# histogram sample
-  - queries:
-    - query: WITH
-              metrics AS (
-                SELECT
-                  application_name,
-                  SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum,
-                  COUNT(*) AS process_idle_seconds_count
-                FROM pg_stat_activity
-                WHERE state = 'idle'
-                GROUP BY application_name
-              ),
-              buckets AS (
-                SELECT
-                  application_name,
-                  le,
-                  SUM(
-                    CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le
-                      THEN 1
-                      ELSE 0
-                    END
-                  )::bigint AS bucket
-                FROM
-                  pg_stat_activity,
-                  UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le
-                GROUP BY application_name, le
-                ORDER BY application_name, le
-              )
-              SELECT
-                application_name,
-                process_idle_seconds_sum as seconds_sum,
-                process_idle_seconds_count as seconds_count,
-                ARRAY_AGG(le) AS seconds,
-                ARRAY_AGG(bucket) AS seconds_bucket
-              FROM metrics JOIN buckets USING (application_name)
-              GROUP BY 1, 2, 3;
-      version: 10
-      columns:
-        - name: application_name
-          type: label
-        - name: seconds
-          type: histogram
-          description: Histogram of idle processes
-    tag: pg_process_idle_seconds
-    collector: idle_procs
-
-# Get number of available extensions for installations.
-  - queries:
-    - query: SELECT COUNT(*) AS extensions
-              FROM pg_available_extensions;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of available extensions for installation.
-    tag: pg_available_extensions
-    collector: available_extensions
-
-# Get number of installed extensions.
-  - queries:
-    - query: SELECT
-                array_agg(extname) AS extensions,
-                count(*)
-              FROM pg_extension;
-      version: 10
-      columns:
-        - name: extensions
-          type: label
-        - type: gauge
-          description: Number of installed extensions.
-    tag: pg_installed_extensions
-    collector: installed_extensions
-
-# Get applied settings
-  - queries:
-    - query: SELECT
-                sourcefile,
-                COUNT(*),
-                (
-                  CASE applied WHEN 't'
-                    THEN 'true'
-                    ELSE 'false'
-                  END
-                ) as applied
-              FROM pg_file_settings
-              WHERE applied = 't'
-              GROUP BY sourcefile, applied;
-      version: 10
-      columns:
-        - name: sourcefile
-          type: label
-        - type: gauge
-          description: Settings that are applied.
-        - name: applied
-          type: label
-    tag: pg_file_settings
-    sort: data
-    collector: file_settings
-
-# Get indexes for schemas.
-  - queries:
-    - query: SELECT
-                schemaname,
-                tablename,
-                COUNT(*)
-              FROM pg_indexes
-              GROUP BY schemaname,tablename;
-      version: 10
-      columns:
-        - name: schemaname
-          type: label
-        - name: tablename
-          type: label
-        - type: gauge
-          description: Indexes for each schemaname for each tablename.
-    tag: pg_indexes
-    sort: data
-    collector: indexes
-
-# Get materialized views
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_matviews
-              WHERE ispopulated = 't'
-              GROUP BY ispopulated;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of applied Materialized views.
-    tag: pg_matviews
-    collector: matviews
-
-# Get number of roles
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_roles;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of roles.
-    tag: pg_role
-    collector: roles
-
-# Get number of rules
-  - queries:
-    - query: SELECT tablename, COUNT(*)
-              FROM pg_rules
-              GROUP BY tablename;
-      version: 10
-      columns:
-        - name: tablename
-          type: label
-        - type: gauge
-          description: Number of rules in table.
-    tag: pg_rule
-    sort: data
-    collector: rules
-
-# Get user auth data
-  - queries:
-    - query: SELECT (
-                CASE
-                  WHEN rolpassword LIKE 'md5%' THEN 'MD5'
-                  WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256'
-                  ELSE 'UNENCRYPTED'
-                END
-              ) AS encryption_type, COUNT(*)
-              FROM pg_authid
-              WHERE rolname != 'postgres'
-              GROUP BY encryption_type;
-      version: 10
-      columns:
-        - name: encryption_type
-          type: label
-        - type: gauge
-          description: Number of users with authentication type.
-    tag: pg_shadow
-    sort: data
-    collector: auth_type
-
-# Get user defined event-triggers
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_event_trigger
-              JOIN pg_authid
-              ON pg_event_trigger.oid = pg_authid.oid
-              WHERE rolname != 'postgres';
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of user defined event triggers.
-    tag: pg_usr_evt_trigger
-    collector: usr_evt_trigger
-
-# Get number of database connections
-  - queries:
-    - query: SELECT datname, count(*)
-              FROM pg_stat_activity
-              WHERE datname IS NOT NULL
-              GROUP BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - type: gauge
-          description: Number of database connections.
-    tag: pg_db_conn
-    sort: data
-    collector: connections
-
-# Get DB connections with SSL
-  - queries:
-    - query: SELECT datname, count(*)
-              FROM pg_stat_ssl
-              JOIN pg_stat_activity
-              ON pg_stat_activity.pid = pg_stat_ssl.pid
-              WHERE ssl = 't' AND datname IS NOT NULL
-              GROUP BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - type: gauge
-          description: Number of DB connections with SSL.
-    tag: pg_db_conn_ssl
-    sort: data
-    collector: connections
-
-# All tables statio
-  - queries:
-    - query: SELECT
-                COUNT(heap_blks_read) AS heap_blks_read,
-                COUNT(heap_blks_hit) AS heap_blks_hit,
-                COUNT(idx_blks_read) as idx_blks_read,
-                COUNT(idx_blks_hit) AS idx_blks_hit,
-                COUNT(toast_blks_read) AS toast_blks_read,
-                COUNT(toast_blks_hit) AS toast_blks_hit,
-                COUNT(tidx_blks_read) AS tidx_blks_read,
-                COUNT(tidx_blks_hit) AS tidx_blks_hit
-              FROM pg_statio_all_tables;
-      version: 10
-      columns:
-        - name: heap_blks_read
-          type: counter
-          description: Number of disk blocks read in postgres db.
-        - name: heap_blks_hit
-          type: counter
-          description: Number of buffer hits read in postgres db.
-        - name: idx_blks_read
-          type: counter
-          description: Number of disk blocks reads from all indexes in postgres db.
-        - name: idx_blks_hit
-          type: counter
-          description: Number of buffer hits read from all indexes in postgres db.
-        - name: toast_blks_read
-          type: counter
-          description: Number of disk blocks reads from postgres db's TOAST tables.
-        - name: toast_blks_hit
-          type: counter
-          description: Number of buffer hits read from postgres db's TOAST tables.
-        - name: tidx_blks_read
-          type: counter
-          description: Number of disk blocks reads from postgres db's TOAST table indexes.
-        - name: tidx_blks_hit
-          type: counter
-          description: Number of buffer hits read from postgres db's TOAST table indexes.
-    tag: pg_statio_all_tables
-    collector: statio_all_tables
-
-# All sequences statio
-  - queries:
-    - query: SELECT
-                COUNT(blks_read) AS blks_read,
-                COUNT(blks_hit) AS blks_hit
-              FROM pg_statio_all_sequences;
-      version: 10
-      columns:
-        - name: blks_read
-          type: counter
-          description: Number of disk blocks read from sequences in postgres db.
-        - name: blks_hit
-          type: counter
-          description: Number of buffer hits read from sequences in postgres db.
-    tag: pg_statio_all_sequences
-    collector: statio_all_sequences
-
-# Stat user functions
-  - queries:
-    - query: SELECT
-                funcname,
-                calls,
-                self_time,
-                total_time
-              FROM pg_stat_user_functions;
-      version: 10
-      columns:
-        - name: funcname
-          type: label
-        - name: calls
-          type: counter
-          description: Number of times function is called.
-        - name: self_time
-          type: counter
-          description: Total time spent in milliseconds on the function itself.
-        - name: total_time
-          type: counter
-          description: Total time spent in milliseconds by the function and any other functions called by it.
-    tag: pg_stat_user_functions
-    sort: data
-    collector: stat_user_functions
-
-# Number of streaming WAL connections per application.
-  - queries:
-    - query: SELECT COUNT(*), application_name
-              FROM pg_stat_replication
-              WHERE state = 'streaming'
-              GROUP BY application_name;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of streaming WAL connections per application.
-        - name: application_name
-          type: label
-    tag: pg_stat_replication
-    sort: data
-    collector: stat_replication
-
-  - queries:
-    - query: SELECT
-                archived_count,
-                (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms,
-                failed_count,
-                (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms
-              FROM pg_stat_archiver;
-      version: 10
-      columns:
-        - type: counter
-          name: archived_count
-          description: Number of successful archived WAL files.
-        - type: counter
-          name: success_time_elapsed_ms
-          description: Milliseconds since successful archived WAL file.
-        - type: counter
-          name: failed_count
-          description: Number of failed archival operation on WAL files.
-        - type: counter
-          name: failure_time_elapsed_ms
-          description: Milliseconds since last failed archival operation on WAL files.
-    tag: pg_stat_archiver
-    sort: data
-    collector: stat_archiver
-
-  - queries:
-    - query: SELECT
-                SUM(idx_scan) AS idx_scans,
-                SUM(idx_tup_read) AS idx_tup_reads,
-                SUM(idx_tup_fetch) AS idx_tup_fetchs,
-                relname
-              FROM pg_stat_all_indexes
-              WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%')
-              GROUP BY relname;
-      version: 10
-      columns:
-        - type: counter
-          name: idx_scans
-          description: Number of index scans on the table's indexes.
-        - type: counter
-          name: idx_tup_reads
-          description: Number of index entries returned by scans on the table's indexes.
-        - type: counter
-          name: idx_tup_fetchs
-          description: Number of rows fetched by simple index scans on the table's indexes.
-        - type: label
-          name: relname
-    tag: stat_all_indexes
-    sort: data
-    collector: pg_stat_all_indexes
-    database: all
-
-  - queries:
-    - query: SELECT
-                datname,
-                age(datfrozenxid) as age
-              FROM pg_database;
-      version: 10
-      columns:
-        - type: label
-          name: datname
-          description: Database name.
-        - type: counter
-          name: age
-          description: Age since last vaccum.
-    tag: pg_db_vacuum
-    sort: data
-    collector: db_vacuum
-
-  - queries:
-    - query: SELECT
-                c.oid::regclass as table_name,
-                greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age
-              FROM pg_class c
-              LEFT JOIN pg_class t ON c.reltoastrelid = t.oid
-              WHERE c.relkind IN ('r', 'm');
-      version: 10
-      columns:
-        - type: label
-          name: datname
-          description: View name.
-        - type: counter
-          name: age
-          description: Age since last vaccum.
-    tag: pg_view_vacuum
-    sort: data
-    collector: db_vacuum
-# Blocked vacuum operations
-  - queries:
-    - query: SELECT
-                blocked.pid AS blocked_pid,
-                blocked.datname AS blocked_database,
-                blocked.usename AS blocked_user,
-                blocked.query AS blocked_query,
-                EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds,
-                blocking.pid AS blocking_pid,
-                blocking.datname AS blocking_database,
-                blocking.usename AS blocking_user,
-                blocking.query AS blocking_query,
-                EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds
-              FROM pg_stat_activity blocked
-              JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
-              JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation
-                AND blocked_locks.pid != blocking_locks.pid
-              JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid
-              WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%')
-                AND NOT blocked_locks.granted
-                AND blocking_locks.granted
-              ORDER BY blocked_duration_seconds DESC;
-      version: 10
-      columns:
-        - name: blocked_pid
-          type: label
-        - name: blocked_database
-          type: label
-        - name: blocked_user
-          type: label
-        - name: blocked_query
-          type: label
-        - name: blocked_duration_seconds
-          type: gauge
-          description: Duration in seconds that the vacuum has been blocked
-        - name: blocking_pid
-          type: label
-        - name: blocking_database
-          type: label
-        - name: blocking_user
-          type: label
-        - name: blocking_query
-          type: label
-        - name: blocking_duration_seconds
-          type: gauge
-          description: Duration in seconds that the blocking query has been running
-    tag: pg_blocked_vacuum
-    sort: data
-    collector: blocked_vacuum
-#
-# PostgreSQL 11
-#
-
-# WAL last sent
-  - queries:
-    - query: SELECT
-              CASE
-                WHEN sender_host LIKE '/%' THEN sender_host
-                ELSE sender_host || ':' || sender_port::text
-              END AS sender,
-              (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms
-              FROM pg_stat_wal_receiver;
-      version: 11
-      columns:
-        - name: sender
-          type: label
-        - type: counter
-          description: Time since last message received from WAL sender
-    tag: pg_wal_last_received
-    collector: wal_last_received
-    server: replica
-
-#
-# PostgreSQL 12
-#
-
-# GSS Authenticated DB Connections
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE gss_authenticated = 't' AND datname IS NOT NULL;
-      version: 12
-      columns:
-        - type: gauge
-          description: Number of GSSAPI authenticated DB connections.
-    tag: pg_gss_auth
-    collector: gssapi
-
-# Encrypted DB Connections
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE encrypted = 't' AND datname IS NOT NULL;
-      version: 12
-      columns:
-        - type: gauge
-          description: Number of encrypted DB connections.
-    tag: pg_encrypted_conn
-    collector: encryted_conns
-
-#
-# PostgreSQL 13
-#
-
-# Shared memory histogram
-  - queries:
-    - query: SELECT
-                SUM(sum) AS size_sum,
-                '1' AS size_count,
-                array_agg((bucket - 1) * (50000))::int[] AS size,
-                array_agg(count)::int[] AS size_bucket
-              FROM (
-                  SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size)
-                  FROM pg_shmem_allocations
-                  GROUP BY bucket
-                  ORDER BY bucket
-              ) t;
-      version: 13
-      columns:
-        - name: size
-          type: histogram
-          description: Histogram of shared memory sizes.
-    tag: pg_shmem_allocations
-    collector: shmem_size
-
-# Vacuum progress information
-  - queries:
-    - query: SELECT
-                p.pid,
-                a.datname,
-                a.usename,
-                a.query,
-                p.phase,
-                p.heap_blks_total,
-                p.heap_blks_scanned,
-                p.heap_blks_vacuumed,
-                p.index_vacuum_count,
-                p.max_dead_tuples,
-                p.num_dead_tuples,
-                CASE WHEN p.heap_blks_total > 0
-                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
-                     ELSE 0
-                END AS pct_scan_completed
-              FROM pg_stat_progress_vacuum p
-              JOIN pg_stat_activity a USING (pid)
-              ORDER BY p.pid;
-      version: 13
-      columns:
-        - name: pid
-          type: label
-        - name: datname
-          type: label
-        - name: usename
-          type: label
-        - name: query
-          type: label
-        - name: phase
-          type: label
-        - name: heap_blks_total
-          type: gauge
-          description: Total heap blocks in table
-        - name: heap_blks_scanned
-          type: gauge
-          description: Heap blocks scanned
-        - name: heap_blks_vacuumed
-          type: gauge
-          description: Heap blocks vacuumed
-        - name: index_vacuum_count
-          type: gauge
-          description: Number of index vacuum cycles completed
-        - name: max_dead_tuples
-          type: gauge
-          description: Maximum dead tuples
-        - name: num_dead_tuples
-          type: gauge
-          description: Current dead tuples
-        - name: pct_scan_completed
-          type: gauge
-          description: Vacuum scan progress percentage
-    tag: pg_stat_progress_vacuum
-    sort: data
-    collector: vacuum_progress
-
-# Table-level vacuum and analyze statistics
-  - queries:
-    - query: SELECT
-                schemaname,
-                relname,
-                n_live_tup,
-                n_dead_tup,
-                CASE 
-                  WHEN n_live_tup > 0 
-                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
-                  ELSE 0
-                END AS dead_rows_pct,
-                n_mod_since_analyze,
-                n_ins_since_vacuum,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
-                vacuum_count,
-                autovacuum_count,
-                analyze_count,
-                autoanalyze_count
-              FROM pg_stat_user_tables
-              ORDER BY n_dead_tup DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: n_live_tup
-          type: gauge
-          description: Estimated number of live rows
-        - name: n_dead_tup
-          type: gauge
-          description: Estimated number of dead rows
-        - name: dead_rows_pct
-          type: gauge
-          description: Percentage of dead rows relative to live rows
-        - name: n_mod_since_analyze
-          type: gauge
-          description: Estimated number of rows modified since last analyze
-        - name: n_ins_since_vacuum
-          type: gauge
-          description: Estimated number of rows inserted since last vacuum
-        - name: last_vacuum_seconds
-          type: gauge
-          description: Seconds since last manual vacuum (-1 if never)
-        - name: last_autovacuum_seconds
-          type: gauge
-          description: Seconds since last autovacuum (-1 if never)
-        - name: last_analyze_seconds
-          type: gauge
-          description: Seconds since last manual analyze (-1 if never)
-        - name: last_autoanalyze_seconds
-          type: gauge
-          description: Seconds since last autoanalyze (-1 if never)
-        - name: vacuum_count
-          type: counter
-          description: Number of times this table has been manually vacuumed
-        - name: autovacuum_count
-          type: counter
-          description: Number of times this table has been vacuumed by autovacuum
-        - name: analyze_count
-          type: counter
-          description: Number of times this table has been manually analyzed
-        - name: autoanalyze_count
-          type: counter
-          description: Number of times this table has been analyzed by autoanalyze
-    tag: pg_stat_user_tables_vacuum
-    sort: data
-    collector: stat_user_tables
-    database: all
-
-# Table read/write activity ratios
-  - queries:
-    - query: WITH table_activity AS (
-                SELECT
-                  s.schemaname,
-                  s.relname,
-                  si.heap_blks_read + si.idx_blks_read AS blocks_read,
-                  s.seq_tup_read + s.idx_tup_fetch AS tuples_read,
-                  c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) /
-                    CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write,
-                  s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write
-                FROM pg_stat_user_tables AS s
-                JOIN pg_statio_user_tables AS si ON s.relid = si.relid
-                JOIN pg_class c ON c.oid = s.relid
-                WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0
-                  AND (si.heap_blks_read + si.idx_blks_read) > 0
-              )
-              SELECT
-                schemaname,
-                relname,
-                blocks_read,
-                tuples_read,
-                blocks_write,
-                tuples_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int
-                END AS ratio_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int
-                END AS ratio_read
-              FROM table_activity
-              ORDER BY (blocks_read + blocks_write) DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: blocks_read
-          type: counter
-          description: Total blocks read from disk (heap + index)
-        - name: tuples_read
-          type: counter
-          description: Total number of tuples read (sequential + index scans)
-        - name: blocks_write
-          type: gauge
-          description: Estimated blocks affected by write operations
-        - name: tuples_write
-          type: counter
-          description: Total number of tuples inserted, updated, or deleted
-        - name: ratio_write
-          type: gauge
-          description: Percentage of I/O activity that is writes (0-100)
-        - name: ratio_read
-          type: gauge
-          description: Percentage of I/O activity that is reads (0-100)
-    tag: pg_table_ratio
-    sort: data
-    collector: table_activity_ratio
-    database: all
-
-# Table bloat analysis
-  - queries:
-    - query: SELECT
-                schemaname,
-                tblname,
-                real_size AS table_size,
-                extra_size AS bloat_size,
-                ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct,
-                tblpages,
-                est_tblpages,
-                bs AS block_size
-              FROM (
-                SELECT
-                  schemaname,
-                  tblname,
-                  bs*tblpages AS real_size,
-                  (tblpages-est_tblpages)*bs AS extra_size,
-                  CASE WHEN tblpages > 0
-                    THEN 100 * (tblpages-est_tblpages)/tblpages::numeric
-                    ELSE 0
-                  END AS extra_ratio,
-                  tblpages,
-                  est_tblpages,
-                  bs
-                FROM (
-                  SELECT
-                    n.nspname AS schemaname,
-                    c.relname AS tblname,
-                    c.relpages AS tblpages,
-                    CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages,
-                    current_setting('block_size')::integer AS bs
-                  FROM pg_class c
-                  JOIN pg_namespace n ON n.oid = c.relnamespace
-                  WHERE c.relkind = 'r'
-                  AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
-                  AND n.nspname NOT LIKE 'pg_temp_%'
-                ) AS bloat_calc
-              ) AS bloat_summary
-              WHERE tblpages > 0
-              ORDER BY extra_size DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: tblname
-          type: label
-        - name: table_size
-          type: gauge
-          description: Actual table size in bytes
-        - name: bloat_size
-          type: gauge
-          description: Estimated bloat size in bytes
-        - name: bloat_ratio_pct
-          type: gauge
-          description: Bloat ratio as percentage
-        - name: tblpages
-          type: gauge
-          description: Actual number of pages used by table
-        - name: est_tblpages
-          type: gauge
-          description: Estimated number of pages needed
-        - name: block_size
-          type: gauge
-          description: Database block size in bytes
-    tag: pg_table_bloat
-    sort: data
-    collector: table_bloat
-    database: all
-#
-# PostgreSQL 14
-#
-
-# Memory context information
-  - queries:
-    - query: SELECT
-                COUNT(*) AS contexts,
-                parent,
-                SUM(free_bytes) AS free_bytes,
-                SUM(used_bytes) AS used_bytes,
-                SUM(total_bytes) AS total_bytes
-              FROM pg_backend_memory_contexts
-              WHERE parent!=''
-              GROUP BY parent;
-      version: 14
-      columns:
-        - name: contexts
-          type: gauge
-          description: Number of memory contexts per parent.
-        - name: parent
-          type: label
-        - name: free_bytes
-          type: gauge
-          description: Free bytes per memory context.
-        - name: used_bytes
-          type: gauge
-          description: Used bytes per memory context.
-        - name: total_bytes
-          type: gauge
-          description: Total bytes per memory context.
-    tag: pg_mem_ctx
-    collector: mem_ctx
-
-# Memory context information
-  - queries:
-    - query: SELECT
-                wal_records,
-                wal_fpi,
-                wal_bytes,
-                wal_buffers_full,
-                wal_write,
-                wal_sync,
-                wal_write_time,
-                wal_sync_time
-              FROM pg_stat_wal;
-      version: 14
-      columns:
-        - name: wal_records
-          type: counter
-          description: Number of WAL records generated.
-        - name: wal_fpi
-          type: counter
-          description: Number of WAL full page images generated.
-        - name: wal_bytes
-          type: counter
-          description: Total bytes of generated WAL.
-        - name: wal_buffers_full
-          type: counter
-          description: Number of disk writes due to WAL buffers being full.
-        - name: wal_write
-          type: counter
-          description: Number of times WAL files were written to disk.
-        - name: wal_sync
-          type: counter
-          description: Number of times WAL files were synced to disk.
-        - name: wal_write_time
-          type: counter
-          description: Time taken for WAL files to be written to disk.
-        - name: wal_sync_time
-          type: counter
-          description: Time taken for WAL files to be synced to disk.
-    tag: pg_stat_wal
-    collector: stat_wal
-
-# stat_database_information()
-  - queries:
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends
-              FROM pg_stat_database
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-      version: 10
-
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends,
-                checksum_failures
-              FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-        - name: checksum_failures
-          type: gauge
-          description: pg_stat_database_checksum_failures
-      version: 12
-
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends,
-                checksum_failures,
-                session_time,
-                active_time,
-                idle_in_transaction_time,
-                sessions,
-                sessions_abandoned,
-                sessions_fatal,
-                sessions_killed
-              FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
-      version: 14
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-        - name: checksum_failures
-          type: gauge
-          description: pg_stat_database_checksum_failures
-        - name: session_time
-          type: gauge
-          description: pg_stat_database_session_time
-        - name: active_time
-          type: gauge
-          description: pg_stat_database_active_time
-        - name: idle_in_transaction_time
-          type: gauge
-          description: pg_stat_database_idle_in_transaction_time
-        - name: sessions
-          type: gauge
-          description: pg_stat_database_sessions
-        - name: sessions_abandoned
-          type: gauge
-          description: pg_stat_database_sessions_abandoned
-        - name: sessions_fatal
-          type: gauge
-          description: pg_stat_database_sessions_fatal
-        - name: sessions_killed
-          type: gauge
-          description: pg_stat_database_sessions_killed
-    tag: pg_stat_database
-    collector: stat_db
-
-#
-# PostgreSQL 15
-#
-
-# WAL prefetch last stat reset
-  - queries:
-    - query: SELECT
-                FLOOR(
-                  EXTRACT(
-                    EPOCH FROM (now() - stats_reset)
-                  )
-                )
-              FROM pg_stat_recovery_prefetch;
-      columns:
-        - type: counter
-          description: Seconds from last WAL prefetch stats reset.
-    tag: pg_wal_prefetch_reset
-    collector: wal_prefetch_reset
+- tag: postgresql_primary
+  collector: primary
+  sort: name
+  server: both
+  queries:
+  - query: SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );
+    version: 10
+    columns:
+    - description: Is the PostgreSQL instance the primary
+      type: gauge
+- tag: pg_database_size
+  collector: db
+  sort: data
+  queries:
+  - query: SELECT datname, pg_database_size(datname) FROM pg_database;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - description: Size of the database
+      type: gauge
+- tag: pg_locks_count
+  collector: locks
+  sort: data
+  queries:
+  - query: SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - name: mode
+      type: label
+    - description: Lock count of a database
+      type: gauge
+- tag: pg_replication_slots
+  collector: replication
+  sort: data
+  queries:
+  - query: SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;
+    version: 10
+    columns:
+    - name: slot_name
+      type: label
+    - name: slot_type
+      type: label
+    - name: database
+      type: label
+    - description: Is the replication active
+      name: active
+      type: gauge
+    - description: Is the replication temporary
+      name: temporary
+      type: gauge
+- tag: pg_stat_bgwriter
+  collector: stat_bgwriter
+  queries:
+  - query: SELECT buffers_alloc, buffers_backend, buffers_backend_fsync, buffers_checkpoint, buffers_clean, checkpoint_sync_time, checkpoint_write_time, checkpoints_req, checkpoints_timed, maxwritten_clean FROM pg_stat_bgwriter;
+    version: 10
+    columns:
+    - description: pg_stat_bgwriter_buffers_alloc
+      name: buffers_alloc
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_backend
+      name: buffers_backend
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_backend_fsync
+      name: buffers_backend_fsync
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_checkpoint
+      name: buffers_checkpoint
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_clean
+      name: buffers_clean
+      type: gauge
+    - description: pg_stat_bgwriter_checkpoint_sync_time
+      name: checkpoint_sync_time
+      type: counter
+    - description: pg_stat_bgwriter_checkpoint_write_time
+      name: checkpoint_write_time
+      type: counter
+    - description: pg_stat_bgwriter_checkpoints_req
+      name: checkpoints_req
+      type: counter
+    - description: pg_stat_bgwriter_checkpoints_timed
+      name: checkpoints_timed
+      type: counter
+    - description: pg_stat_bgwriter_maxwritten_clean
+      name: maxwritten_clean
+      type: counter
+- tag: pg_process_idle_seconds
+  collector: idle_procs
+  queries:
+  - query: WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;
+    version: 10
+    columns:
+    - name: application_name
+      type: label
+    - name: seconds
+      type: histogram
+      description: Histogram of idle processes
+- tag: pg_available_extensions
+  collector: available_extensions
+  queries:
+  - query: SELECT COUNT(*) AS extensions FROM pg_available_extensions;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of available extensions for installation.
+- tag: pg_installed_extensions
+  collector: installed_extensions
+  queries:
+  - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
+    version: 10
+    columns:
+    - name: extensions
+      type: label
+    - type: gauge
+      description: Number of installed extensions.
+- tag: pg_file_settings
+  collector: file_settings
+  sort: data
+  queries:
+  - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
+    version: 10
+    columns:
+    - name: sourcefile
+      type: label
+    - type: gauge
+      description: Settings that are applied.
+    - name: applied
+      type: label
+- tag: pg_indexes
+  collector: indexes
+  sort: data
+  queries:
+  - query: SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;
+    version: 10
+    columns:
+    - name: schemaname
+      type: label
+    - name: tablename
+      type: label
+    - type: gauge
+      description: Indexes for each schemaname for each tablename.
+- tag: pg_matviews
+  collector: matviews
+  queries:
+  - query: SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of applied Materialized views.
+- tag: pg_role
+  collector: roles
+  queries:
+  - query: SELECT COUNT(*) FROM pg_roles;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of roles.
+- tag: pg_rule
+  collector: rules
+  sort: data
+  queries:
+  - query: SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;
+    version: 10
+    columns:
+    - name: tablename
+      type: label
+    - type: gauge
+      description: Number of rules in table.
+- tag: pg_shadow
+  collector: auth_type
+  sort: data
+  queries:
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+    version: 10
+    columns:
+    - name: encryption_type
+      type: label
+    - type: gauge
+      description: Number of users with authentication type.
+- tag: pg_usr_evt_trigger
+  collector: usr_evt_trigger
+  queries:
+  - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of user defined event triggers.
+- tag: pg_db_conn
+  collector: connections
+  sort: data
+  queries:
+  - query: SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - type: gauge
+      description: Number of database connections.
+- tag: pg_db_conn_ssl
+  collector: connections
+  sort: data
+  queries:
+  - query: SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - type: gauge
+      description: Number of DB connections with SSL.
+- tag: pg_statio_all_tables
+  collector: statio_all_tables
+  queries:
+  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+    version: 10
+    columns:
+    - name: heap_blks_read
+      type: counter
+      description: Number of disk blocks read in postgres db.
+    - name: heap_blks_hit
+      type: counter
+      description: Number of buffer hits read in postgres db.
+    - name: idx_blks_read
+      type: counter
+      description: Number of disk blocks reads from all indexes in postgres db.
+    - name: idx_blks_hit
+      type: counter
+      description: Number of buffer hits read from all indexes in postgres db.
+    - name: toast_blks_read
+      type: counter
+      description: Number of disk blocks reads from postgres db's TOAST tables.
+    - name: toast_blks_hit
+      type: counter
+      description: Number of buffer hits read from postgres db's TOAST tables.
+    - name: tidx_blks_read
+      type: counter
+      description: Number of disk blocks reads from postgres db's TOAST table indexes.
+    - name: tidx_blks_hit
+      type: counter
+      description: Number of buffer hits read from postgres db's TOAST table indexes.
+- tag: pg_statio_all_sequences
+  collector: statio_all_sequences
+  queries:
+  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+    version: 10
+    columns:
+    - name: blks_read
+      type: counter
+      description: Number of disk blocks read from sequences in postgres db.
+    - name: blks_hit
+      type: counter
+      description: Number of buffer hits read from sequences in postgres db.
+- tag: pg_stat_user_functions
+  collector: stat_user_functions
+  sort: data
+  queries:
+  - query: SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;
+    version: 10
+    columns:
+    - name: funcname
+      type: label
+    - name: calls
+      type: counter
+      description: Number of times function is called.
+    - name: self_time
+      type: counter
+      description: Total time spent in milliseconds on the function itself.
+    - name: total_time
+      type: counter
+      description: Total time spent in milliseconds by the function and any other functions called by it.
+- tag: pg_stat_replication
+  collector: stat_replication
+  sort: data
+  queries:
+  - query: SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of streaming WAL connections per application.
+    - name: application_name
+      type: label
+- tag: pg_stat_archiver
+  collector: stat_archiver
+  sort: data
+  queries:
+  - query: SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;
+    version: 10
+    columns:
+    - type: counter
+      name: archived_count
+      description: Number of successful archived WAL files.
+    - type: counter
+      name: success_time_elapsed_ms
+      description: Milliseconds since successful archived WAL file.
+    - type: counter
+      name: failed_count
+      description: Number of failed archival operation on WAL files.
+    - type: counter
+      name: failure_time_elapsed_ms
+      description: Milliseconds since last failed archival operation on WAL files.
+- tag: pg_db_vacuum
+  collector: db_vacuum
+  sort: data
+  queries:
+  - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
+    version: 10
+    columns:
+    - type: label
+      name: datname
+      description: Database name.
+    - type: counter
+      name: age
+      description: Age since last vaccum.
+- tag: pg_view_vacuum
+  collector: db_vacuum
+  sort: data
+  queries:
+  - query: SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');
+    version: 10
+    columns:
+    - type: label
+      name: datname
+      description: View name.
+    - type: counter
+      name: age
+      description: Age since last vaccum.
+- tag: pg_blocked_vacuum
+  collector: blocked_vacuum
+  sort: data
+  queries:
+  - query: SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;
+    version: 10
+    columns:
+    - name: blocked_pid
+      type: label
+    - name: blocked_database
+      type: label
+    - name: blocked_user
+      type: label
+    - name: blocked_query
+      type: label
+    - name: blocked_duration_seconds
+      type: gauge
+      description: Duration in seconds that the vacuum has been blocked
+    - name: blocking_pid
+      type: label
+    - name: blocking_database
+      type: label
+    - name: blocking_user
+      type: label
+    - name: blocking_query
+      type: label
+    - name: blocking_duration_seconds
+      type: gauge
+      description: Duration in seconds that the blocking query has been running
+- tag: pg_wal_last_received
+  collector: wal_last_received
+  server: replica
+  queries:
+  - query: SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;
+    version: 11
+    columns:
+    - name: sender
+      type: label
+    - type: counter
+      description: Time since last message received from WAL sender
+- tag: pg_gss_auth
+  collector: gssapi
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;
+    version: 12
+    columns:
+    - type: gauge
+      description: Number of GSSAPI authenticated DB connections.
+- tag: pg_encrypted_conn
+  collector: encryted_conns
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;
+    version: 12
+    columns:
+    - type: gauge
+      description: Number of encrypted DB connections.
+- tag: pg_shmem_allocations
+  collector: shmem_size
+  queries:
+  - query: SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;
+    version: 13
+    columns:
+    - name: size
+      type: histogram
+      description: Histogram of shared memory sizes.
+- tag: pg_stat_progress_vacuum
+  collector: vacuum_progress
+  sort: data
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 13
+    columns:
+    - name: pid
+      type: label
+    - name: datname
+      type: label
+    - name: usename
+      type: label
+    - name: query
+      type: label
+    - name: phase
+      type: label
+    - name: heap_blks_total
+      type: gauge
+      description: Total heap blocks in table
+    - name: heap_blks_scanned
+      type: gauge
+      description: Heap blocks scanned
+    - name: heap_blks_vacuumed
+      type: gauge
+      description: Heap blocks vacuumed
+    - name: index_vacuum_count
+      type: gauge
+      description: Number of index vacuum cycles completed
+    - name: max_dead_tuples
+      type: gauge
+      description: Maximum dead tuples
+    - name: num_dead_tuples
+      type: gauge
+      description: Current dead tuples
+    - name: pct_scan_completed
+      type: gauge
+      description: Vacuum scan progress percentage
+- tag: pg_stat_progress_analyze
+  collector: analyze_progress
+  sort: data
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 13
+    columns:
+    - name: pid
+      type: label
+    - name: datname
+      type: label
+    - name: usename
+      type: label
+    - name: phase
+      type: label
+    - name: sample_blks_total
+      type: gauge
+      description: Total blocks to sample
+    - name: sample_blks_scanned
+      type: gauge
+      description: Blocks sampled so far
+    - name: ext_stats_total
+      type: gauge
+      description: Total extended statistics to compute
+    - name: ext_stats_computed
+      type: gauge
+      description: Extended statistics computed
+    - name: child_tables_total
+      type: gauge
+      description: Total child tables to analyze
+    - name: child_tables_done
+      type: gauge
+      description: Child tables analyzed
+    - name: pct_sample_completed
+      type: gauge
+      description: Percentage of sampling completed
+    - name: pct_child_tables_completed
+      type: gauge
+      description: Percentage of child tables completed
+- tag: pg_stat_user_tables_vacuum
+  collector: stat_user_tables
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
+    - name: n_live_tup
+      type: gauge
+      description: Estimated number of live rows
+    - name: n_dead_tup
+      type: gauge
+      description: Estimated number of dead rows
+    - name: dead_rows_pct
+      type: gauge
+      description: Percentage of dead rows relative to live rows
+    - name: n_mod_since_analyze
+      type: gauge
+      description: Estimated number of rows modified since last analyze
+    - name: n_ins_since_vacuum
+      type: gauge
+      description: Estimated number of rows inserted since last vacuum
+    - name: last_vacuum_seconds
+      type: gauge
+      description: Seconds since last manual vacuum (-1 if never)
+    - name: last_autovacuum_seconds
+      type: gauge
+      description: Seconds since last autovacuum (-1 if never)
+    - name: last_analyze_seconds
+      type: gauge
+      description: Seconds since last manual analyze (-1 if never)
+    - name: last_autoanalyze_seconds
+      type: gauge
+      description: Seconds since last autoanalyze (-1 if never)
+    - name: vacuum_count
+      type: counter
+      description: Number of times this table has been manually vacuumed
+    - name: autovacuum_count
+      type: counter
+      description: Number of times this table has been vacuumed by autovacuum
+    - name: analyze_count
+      type: counter
+      description: Number of times this table has been manually analyzed
+    - name: autoanalyze_count
+      type: counter
+      description: Number of times this table has been analyzed by autoanalyze
+- tag: pg_table_ratio
+  collector: table_activity_ratio
+  sort: data
+  database: all
+  queries:
+  - query: WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
+    - name: blocks_read
+      type: counter
+      description: Total blocks read from disk (heap + index)
+    - name: tuples_read
+      type: counter
+      description: Total number of tuples read (sequential + index scans)
+    - name: blocks_write
+      type: gauge
+      description: Estimated blocks affected by write operations
+    - name: tuples_write
+      type: counter
+      description: Total number of tuples inserted, updated, or deleted
+    - name: ratio_write
+      type: gauge
+      description: Percentage of I/O activity that is writes (0-100)
+    - name: ratio_read
+      type: gauge
+      description: Percentage of I/O activity that is reads (0-100)
+- tag: pg_table_bloat
+  collector: table_bloat
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: tblname
+      type: label
+    - name: table_size
+      type: gauge
+      description: Actual table size in bytes
+    - name: bloat_size
+      type: gauge
+      description: Estimated bloat size in bytes
+    - name: bloat_ratio_pct
+      type: gauge
+      description: Bloat ratio as percentage
+    - name: tblpages
+      type: gauge
+      description: Actual number of pages used by table
+    - name: est_tblpages
+      type: gauge
+      description: Estimated number of pages needed
+    - name: block_size
+      type: gauge
+      description: Database block size in bytes
+- tag: pg_mem_ctx
+  collector: mem_ctx
+  queries:
+  - query: SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;
+    version: 14
+    columns:
+    - name: contexts
+      type: gauge
+      description: Number of memory contexts per parent.
+    - name: parent
+      type: label
+    - name: free_bytes
+      type: gauge
+      description: Free bytes per memory context.
+    - name: used_bytes
+      type: gauge
+      description: Used bytes per memory context.
+    - name: total_bytes
+      type: gauge
+      description: Total bytes per memory context.
+- tag: pg_stat_wal
+  collector: stat_wal
+  queries:
+  - query: SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal;
+    version: 14
+    columns:
+    - name: wal_records
+      type: counter
+      description: Number of WAL records generated.
+    - name: wal_fpi
+      type: counter
+      description: Number of WAL full page images generated.
+    - name: wal_bytes
+      type: counter
+      description: Total bytes of generated WAL.
+    - name: wal_buffers_full
+      type: counter
+      description: Number of disk writes due to WAL buffers being full.
+    - name: wal_write
+      type: counter
+      description: Number of times WAL files were written to disk.
+    - name: wal_sync
+      type: counter
+      description: Number of times WAL files were synced to disk.
+    - name: wal_write_time
+      type: counter
+      description: Time taken for WAL files to be written to disk.
+    - name: wal_sync_time
+      type: counter
+      description: Time taken for WAL files to be synced to disk.
+- tag: pg_stat_database
+  collector: stat_db
+  queries:
+  - query: SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
+    version: 14
+    columns:
+    - name: database
+      type: label
+    - name: blk_read_time
+      type: counter
+      description: pg_stat_database_blk_read_time
+    - name: blk_write_time
+      type: counter
+      description: pg_stat_database_blk_write_time
+    - name: blks_hit
+      type: counter
+      description: pg_stat_database_blks_hit
+    - name: blks_read
+      type: counter
+      description: pg_stat_database_blks_read
+    - name: deadlocks
+      type: counter
+      description: pg_stat_database_deadlocks
+    - name: temp_files
+      type: gauge
+      description: pg_stat_database_temp_files
+    - name: temp_bytes
+      type: gauge
+      description: pg_stat_database_temp_bytes
+    - name: tup_returned
+      type: counter
+      description: pg_stat_database_tup_returned
+    - name: tup_fetched
+      type: counter
+      description: pg_stat_database_tup_fetched
+    - name: tup_inserted
+      type: counter
+      description: pg_stat_database_tup_inserted
+    - name: tup_updated
+      type: counter
+      description: pg_stat_database_tup_updated
+    - name: tup_deleted
+      type: counter
+      description: pg_stat_database_tup_deleted
+    - name: xact_commit
+      type: counter
+      description: pg_stat_database_xact_commit
+    - name: xact_rollback
+      type: counter
+      description: pg_stat_database_xact_rollback
+    - name: conflicts
+      type: counter
+      description: pg_stat_database_conflicts
+    - name: numbackends
+      type: gauge
+      description: pg_stat_database_numbackends
+    - name: checksum_failures
+      type: gauge
+      description: pg_stat_database_checksum_failures
+    - name: session_time
+      type: gauge
+      description: pg_stat_database_session_time
+    - name: active_time
+      type: gauge
+      description: pg_stat_database_active_time
+    - name: idle_in_transaction_time
+      type: gauge
+      description: pg_stat_database_idle_in_transaction_time
+    - name: sessions
+      type: gauge
+      description: pg_stat_database_sessions
+    - name: sessions_abandoned
+      type: gauge
+      description: pg_stat_database_sessions_abandoned
+    - name: sessions_fatal
+      type: gauge
+      description: pg_stat_database_sessions_fatal
+    - name: sessions_killed
+      type: gauge
+      description: pg_stat_database_sessions_killed
+- tag: pg_wal_prefetch_reset
+  collector: wal_prefetch_reset
+  queries:
+  - query: SELECT FLOOR( EXTRACT( EPOCH FROM (now() - stats_reset) ) ) FROM pg_stat_recovery_prefetch;
+    version: 15
+    columns:
+    - type: counter
+      description: Seconds from last WAL prefetch stats reset.
+- tag: pg_stat_database_conflicts
+  collector: stat_conflicts
+  sort: data
+  queries:
+  - query: SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - name: confl_tablespace
+      type: counter
+      description: pg_stat_database_conflicts_confl_tablespace
+    - name: confl_lock
+      type: counter
+      description: pg_stat_database_conflicts_confl_lock
+    - name: confl_snapshot
+      type: counter
+      description: pg_stat_database_conflicts_confl_snapshot
+    - name: confl_bufferpin
+      type: counter
+      description: pg_stat_database_conflicts_confl_bufferpin
+    - name: confl_deadlock
+      type: counter
+      description: pg_stat_database_conflicts_confl_deadlock
+- tag: pg_stat_all_indexes
+  collector: stat_all_indexes
+  sort: data
+  database: all
+  queries:
+  - query: SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname FROM pg_stat_all_indexes GROUP BY relname;
+    version: 10
+    columns:
+    - type: counter
+      name: idx_scans
+      description: Number of index scans on the table's indexes.
+    - type: counter
+      name: idx_tup_reads
+      description: Number of index entries returned by scans on the table's indexes.
+    - type: counter
+      name: idx_tup_fetchs
+      description: Number of rows fetched by simple index scans on the table's indexes.
+    - type: label
+      name: relname

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -1,1605 +1,883 @@
-# This is the default minimum version for queries, unless specified otherwise
 version: 16
 metrics:
-
-#
-# PostgreSQL 10
-#
-
-# primary_information()
-  - queries:
-    - query: SELECT
-              (
-                CASE pg_is_in_recovery() WHEN 'f'
-                  THEN 't'
-                  ELSE 'f'
-                END
-              );
-      version: 10
-      columns:
-        - description: Is the PostgreSQL instance the primary
-          type: gauge
-    tag: postgresql_primary
-    sort: name
-    collector: primary
-    server: both
-
-# database_information()
-  - queries:
-    - query: SELECT
-                datname,
-                pg_database_size(datname)
-              FROM pg_database;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - description: Size of the database
-          type: gauge
-    tag: pg_database_size
-    sort: data
-    collector: db
-
-# locks_information()
-  - queries:
-    - query: SELECT
-                pg_database.datname as database,
-                tmp.mode,
-                COALESCE(count, 0) as count
-              FROM (
-                VALUES
-                  ('accesssharelock'),
-                  ('rowsharelock'),
-                  ('rowexclusivelock'),
-                  ('shareupdateexclusivelock'),
-                  ('sharelock'),
-                  ('sharerowexclusivelock'),
-                  ('exclusivelock'),
-                  ('accessexclusivelock'),
-                  ('sireadlock')
-              ) AS tmp(mode)
-              CROSS JOIN pg_database
-              LEFT JOIN
-              (
-                SELECT
-                  database,
-                  lower(mode) AS mode,
-                  count(*) AS count
-                FROM pg_locks
-                WHERE database IS NOT NULL
-                GROUP BY database, lower(mode)
-              ) AS tmp2
-              ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database
-              ORDER BY 1, 2;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - name: mode
-          type: label
-        - description: Lock count of a database
-          type: gauge
-    tag: pg_locks_count
-    sort: data
-    collector: locks
-
-# replication_information()
-  - queries:
-    - query: SELECT
-                slot_name,
-                slot_type,
-                database,
-                active,
-                temporary
-              FROM pg_replication_slots;
-      version: 10
-      columns:
-      - name: slot_name
-        type: label
-      - name: slot_type
-        type: label
-      - name: database
-        type: label
-      - description: Is the replication active
-        name: active
-        type: gauge
-      - description: Is the replication temporary
-        name: temporary
-        type: gauge
-    tag: pg_replication_slots
-    sort: data
-    collector: replication
-
-# stat_bgwriter_information()
-  - queries:
-    - query: SELECT
-                buffers_alloc,
-                buffers_backend,
-                buffers_backend_fsync,
-                buffers_checkpoint,
-                buffers_clean,
-                checkpoint_sync_time,
-                checkpoint_write_time,
-                checkpoints_req,
-                checkpoints_timed,
-                maxwritten_clean
-              FROM pg_stat_bgwriter;
-      version: 10
-      columns:
-        - description: pg_stat_bgwriter_buffers_alloc
-          name: buffers_alloc
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_backend
-          name: buffers_backend
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_backend_fsync
-          name: buffers_backend_fsync
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_checkpoint
-          name: buffers_checkpoint
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_clean
-          name: buffers_clean
-          type: gauge
-        - description: pg_stat_bgwriter_checkpoint_sync_time
-          name: checkpoint_sync_time
-          type: counter
-        - description: pg_stat_bgwriter_checkpoint_write_time
-          name: checkpoint_write_time
-          type: counter
-        - description: pg_stat_bgwriter_checkpoints_req
-          name: checkpoints_req
-          type: counter
-        - description: pg_stat_bgwriter_checkpoints_timed
-          name: checkpoints_timed
-          type: counter
-        - description: pg_stat_bgwriter_maxwritten_clean
-          name: maxwritten_clean
-          type: counter
-    tag: pg_stat_bgwriter
-    collector: stat_bgwriter
-
-# histogram sample
-  - queries:
-    - query: WITH
-              metrics AS (
-                SELECT
-                  application_name,
-                  SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum,
-                  COUNT(*) AS process_idle_seconds_count
-                FROM pg_stat_activity
-                WHERE state = 'idle'
-                GROUP BY application_name
-              ),
-              buckets AS (
-                SELECT
-                  application_name,
-                  le,
-                  SUM(
-                    CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le
-                      THEN 1
-                      ELSE 0
-                    END
-                  )::bigint AS bucket
-                FROM
-                  pg_stat_activity,
-                  UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le
-                GROUP BY application_name, le
-                ORDER BY application_name, le
-              )
-              SELECT
-                application_name,
-                process_idle_seconds_sum as seconds_sum,
-                process_idle_seconds_count as seconds_count,
-                ARRAY_AGG(le) AS seconds,
-                ARRAY_AGG(bucket) AS seconds_bucket
-              FROM metrics JOIN buckets USING (application_name)
-              GROUP BY 1, 2, 3;
-      version: 10
-      columns:
-        - name: application_name
-          type: label
-        - name: seconds
-          type: histogram
-          description: Histogram of idle processes
-    tag: pg_process_idle_seconds
-    collector: idle_procs
-
-# Get number of available extensions for installations.
-  - queries:
-    - query: SELECT COUNT(*) AS extensions
-              FROM pg_available_extensions;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of available extensions for installation.
-    tag: pg_available_extensions
-    collector: available_extensions
-
-# Get number of installed extensions.
-  - queries:
-    - query: SELECT
-                array_agg(extname) AS extensions,
-                count(*)
-              FROM pg_extension;
-      version: 10
-      columns:
-        - name: extensions
-          type: label
-        - type: gauge
-          description: Number of installed extensions.
-    tag: pg_installed_extensions
-    collector: installed_extensions
-
-# Get applied settings
-  - queries:
-    - query: SELECT
-                sourcefile,
-                COUNT(*),
-                (
-                  CASE applied WHEN 't'
-                    THEN 'true'
-                    ELSE 'false'
-                  END
-                ) as applied
-              FROM pg_file_settings
-              WHERE applied = 't'
-              GROUP BY sourcefile, applied;
-      version: 10
-      columns:
-        - name: sourcefile
-          type: label
-        - type: gauge
-          description: Settings that are applied.
-        - name: applied
-          type: label
-    tag: pg_file_settings
-    sort: data
-    collector: file_settings
-
-# Get indexes for schemas.
-  - queries:
-    - query: SELECT
-                schemaname,
-                tablename,
-                COUNT(*)
-              FROM pg_indexes
-              GROUP BY schemaname,tablename;
-      version: 10
-      columns:
-        - name: schemaname
-          type: label
-        - name: tablename
-          type: label
-        - type: gauge
-          description: Indexes for each schemaname for each tablename.
-    tag: pg_indexes
-    sort: data
-    collector: indexes
-
-# Get materialized views
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_matviews
-              WHERE ispopulated = 't'
-              GROUP BY ispopulated;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of applied Materialized views.
-    tag: pg_matviews
-    collector: matviews
-
-# Get number of roles
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_roles;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of roles.
-    tag: pg_role
-    collector: roles
-
-# Get number of rules
-  - queries:
-    - query: SELECT tablename, COUNT(*)
-              FROM pg_rules
-              GROUP BY tablename;
-      version: 10
-      columns:
-        - name: tablename
-          type: label
-        - type: gauge
-          description: Number of rules in table.
-    tag: pg_rule
-    sort: data
-    collector: rules
-
-# Get user auth data
-  - queries:
-    - query: SELECT (
-                CASE
-                  WHEN rolpassword LIKE 'md5%' THEN 'MD5'
-                  WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256'
-                  ELSE 'UNENCRYPTED'
-                END
-              ) AS encryption_type, COUNT(*)
-              FROM pg_authid
-              WHERE rolname != 'postgres'
-              GROUP BY encryption_type;
-      version: 10
-      columns:
-        - name: encryption_type
-          type: label
-        - type: gauge
-          description: Number of users with authentication type.
-    tag: pg_shadow
-    sort: data
-    collector: auth_type
-
-# Get user defined event-triggers
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_event_trigger
-              JOIN pg_authid
-              ON pg_event_trigger.oid = pg_authid.oid
-              WHERE rolname != 'postgres';
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of user defined event triggers.
-    tag: pg_usr_evt_trigger
-    collector: usr_evt_trigger
-
-# Get number of database connections
-  - queries:
-    - query: SELECT datname, count(*)
-              FROM pg_stat_activity
-              WHERE datname IS NOT NULL
-              GROUP BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - type: gauge
-          description: Number of database connections.
-    tag: pg_db_conn
-    sort: data
-    collector: connections
-
-# Get DB connections with SSL
-  - queries:
-    - query: SELECT datname, count(*)
-              FROM pg_stat_ssl
-              JOIN pg_stat_activity
-              ON pg_stat_activity.pid = pg_stat_ssl.pid
-              WHERE ssl = 't' AND datname IS NOT NULL
-              GROUP BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - type: gauge
-          description: Number of DB connections with SSL.
-    tag: pg_db_conn_ssl
-    sort: data
-    collector: connections
-
-# All tables statio
-  - queries:
-    - query: SELECT
-                COUNT(heap_blks_read) AS heap_blks_read,
-                COUNT(heap_blks_hit) AS heap_blks_hit,
-                COUNT(idx_blks_read) as idx_blks_read,
-                COUNT(idx_blks_hit) AS idx_blks_hit,
-                COUNT(toast_blks_read) AS toast_blks_read,
-                COUNT(toast_blks_hit) AS toast_blks_hit,
-                COUNT(tidx_blks_read) AS tidx_blks_read,
-                COUNT(tidx_blks_hit) AS tidx_blks_hit
-              FROM pg_statio_all_tables;
-      version: 10
-      columns:
-        - name: heap_blks_read
-          type: counter
-          description: Number of disk blocks read in postgres db.
-        - name: heap_blks_hit
-          type: counter
-          description: Number of buffer hits read in postgres db.
-        - name: idx_blks_read
-          type: counter
-          description: Number of disk blocks reads from all indexes in postgres db.
-        - name: idx_blks_hit
-          type: counter
-          description: Number of buffer hits read from all indexes in postgres db.
-        - name: toast_blks_read
-          type: counter
-          description: Number of disk blocks reads from postgres db's TOAST tables.
-        - name: toast_blks_hit
-          type: counter
-          description: Number of buffer hits read from postgres db's TOAST tables.
-        - name: tidx_blks_read
-          type: counter
-          description: Number of disk blocks reads from postgres db's TOAST table indexes.
-        - name: tidx_blks_hit
-          type: counter
-          description: Number of buffer hits read from postgres db's TOAST table indexes.
-    tag: pg_statio_all_tables
-    collector: statio_all_tables
-
-# All sequences statio
-  - queries:
-    - query: SELECT
-                COUNT(blks_read) AS blks_read,
-                COUNT(blks_hit) AS blks_hit
-              FROM pg_statio_all_sequences;
-      version: 10
-      columns:
-        - name: blks_read
-          type: counter
-          description: Number of disk blocks read from sequences in postgres db.
-        - name: blks_hit
-          type: counter
-          description: Number of buffer hits read from sequences in postgres db.
-    tag: pg_statio_all_sequences
-    collector: statio_all_sequences
-
-# Stat user functions
-  - queries:
-    - query: SELECT
-                funcname,
-                calls,
-                self_time,
-                total_time
-              FROM pg_stat_user_functions;
-      version: 10
-      columns:
-        - name: funcname
-          type: label
-        - name: calls
-          type: counter
-          description: Number of times function is called.
-        - name: self_time
-          type: counter
-          description: Total time spent in milliseconds on the function itself.
-        - name: total_time
-          type: counter
-          description: Total time spent in milliseconds by the function and any other functions called by it.
-    tag: pg_stat_user_functions
-    sort: data
-    collector: stat_user_functions
-
-# Number of streaming WAL connections per application.
-  - queries:
-    - query: SELECT COUNT(*), application_name
-              FROM pg_stat_replication
-              WHERE state = 'streaming'
-              GROUP BY application_name;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of streaming WAL connections per application.
-        - name: application_name
-          type: label
-    tag: pg_stat_replication
-    sort: data
-    collector: stat_replication
-
-  - queries:
-    - query: SELECT
-                archived_count,
-                (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms,
-                failed_count,
-                (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms
-              FROM pg_stat_archiver;
-      version: 10
-      columns:
-        - type: counter
-          name: archived_count
-          description: Number of successful archived WAL files.
-        - type: counter
-          name: success_time_elapsed_ms
-          description: Milliseconds since successful archived WAL file.
-        - type: counter
-          name: failed_count
-          description: Number of failed archival operation on WAL files.
-        - type: counter
-          name: failure_time_elapsed_ms
-          description: Milliseconds since last failed archival operation on WAL files.
-    tag: pg_stat_archiver
-    sort: data
-    collector: stat_archiver
-
-  - queries:
-    - query: SELECT
-                datname,
-                age(datfrozenxid) as age
-              FROM pg_database;
-      version: 10
-      columns:
-        - type: label
-          name: datname
-          description: Database name.
-        - type: counter
-          name: age
-          description: Age since last vaccum.
-    tag: pg_db_vacuum
-    sort: data
-    collector: db_vacuum
-
-  - queries:
-    - query: SELECT
-                c.oid::regclass as table_name,
-                greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age
-              FROM pg_class c
-              LEFT JOIN pg_class t ON c.reltoastrelid = t.oid
-              WHERE c.relkind IN ('r', 'm');
-      version: 10
-      columns:
-        - type: label
-          name: datname
-          description: View name.
-        - type: counter
-          name: age
-          description: Age since last vaccum.
-    tag: pg_view_vacuum
-    sort: data
-    collector: db_vacuum
-# Blocked vacuum operations
-  - queries:
-    - query: SELECT
-                blocked.pid AS blocked_pid,
-                blocked.datname AS blocked_database,
-                blocked.usename AS blocked_user,
-                blocked.query AS blocked_query,
-                EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds,
-                blocking.pid AS blocking_pid,
-                blocking.datname AS blocking_database,
-                blocking.usename AS blocking_user,
-                blocking.query AS blocking_query,
-                EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds
-              FROM pg_stat_activity blocked
-              JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
-              JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation
-                AND blocked_locks.pid != blocking_locks.pid
-              JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid
-              WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%')
-                AND NOT blocked_locks.granted
-                AND blocking_locks.granted
-              ORDER BY blocked_duration_seconds DESC;
-      version: 10
-      columns:
-        - name: blocked_pid
-          type: label
-        - name: blocked_database
-          type: label
-        - name: blocked_user
-          type: label
-        - name: blocked_query
-          type: label
-        - name: blocked_duration_seconds
-          type: gauge
-          description: Duration in seconds that the vacuum has been blocked
-        - name: blocking_pid
-          type: label
-        - name: blocking_database
-          type: label
-        - name: blocking_user
-          type: label
-        - name: blocking_query
-          type: label
-        - name: blocking_duration_seconds
-          type: gauge
-          description: Duration in seconds that the blocking query has been running
-    tag: pg_blocked_vacuum
-    sort: data
-    collector: blocked_vacuum
-#
-# PostgreSQL 11
-#
-
-# WAL last sent
-  - queries:
-    - query: SELECT
-              CASE
-                WHEN sender_host LIKE '/%' THEN sender_host
-                ELSE sender_host || ':' || sender_port::text
-              END AS sender,
-              (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms
-              FROM pg_stat_wal_receiver;
-      version: 11
-      columns:
-        - name: sender
-          type: label
-        - type: counter
-          description: Time since last message received from WAL sender
-    tag: pg_wal_last_received
-    collector: wal_last_received
-    server: replica
-
-#
-# PostgreSQL 12
-#
-
-# GSS Authenticated DB Connections
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE gss_authenticated = 't' AND datname IS NOT NULL;
-      version: 12
-      columns:
-        - type: gauge
-          description: Number of GSSAPI authenticated DB connections.
-    tag: pg_gss_auth
-    collector: gssapi
-
-# Encrypted DB Connections
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE encrypted = 't' AND datname IS NOT NULL;
-      version: 12
-      columns:
-        - type: gauge
-          description: Number of encrypted DB connections.
-    tag: pg_encrypted_conn
-    collector: encryted_conns
-
-#
-# PostgreSQL 13
-#
-
-# Shared memory histogram
-  - queries:
-    - query: SELECT
-                SUM(sum) AS size_sum,
-                '1' AS size_count,
-                array_agg((bucket - 1) * (50000))::int[] AS size,
-                array_agg(count)::int[] AS size_bucket
-              FROM (
-                  SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size)
-                  FROM pg_shmem_allocations
-                  GROUP BY bucket
-                  ORDER BY bucket
-              ) t;
-      version: 13
-      columns:
-        - name: size
-          type: histogram
-          description: Histogram of shared memory sizes.
-    tag: pg_shmem_allocations
-    collector: shmem_size
-
-# Vacuum progress information
-  - queries:
-    - query: SELECT
-                p.pid,
-                a.datname,
-                a.usename,
-                a.query,
-                p.phase,
-                p.heap_blks_total,
-                p.heap_blks_scanned,
-                p.heap_blks_vacuumed,
-                p.index_vacuum_count,
-                p.max_dead_tuples,
-                p.num_dead_tuples,
-                CASE WHEN p.heap_blks_total > 0
-                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
-                     ELSE 0
-                END AS pct_scan_completed
-              FROM pg_stat_progress_vacuum p
-              JOIN pg_stat_activity a USING (pid)
-              ORDER BY p.pid;
-      version: 13
-      columns:
-        - name: pid
-          type: label
-        - name: datname
-          type: label
-        - name: usename
-          type: label
-        - name: query
-          type: label
-        - name: phase
-          type: label
-        - name: heap_blks_total
-          type: gauge
-          description: Total heap blocks in table
-        - name: heap_blks_scanned
-          type: gauge
-          description: Heap blocks scanned
-        - name: heap_blks_vacuumed
-          type: gauge
-          description: Heap blocks vacuumed
-        - name: index_vacuum_count
-          type: gauge
-          description: Number of index vacuum cycles completed
-        - name: max_dead_tuples
-          type: gauge
-          description: Maximum dead tuples
-        - name: num_dead_tuples
-          type: gauge
-          description: Current dead tuples
-        - name: pct_scan_completed
-          type: gauge
-          description: Vacuum scan progress percentage
-    tag: pg_stat_progress_vacuum
-    sort: data
-    collector: vacuum_progress
-
-# Table-level vacuum and analyze statistics
-  - queries:
-    - query: SELECT
-                schemaname,
-                relname,
-                n_live_tup,
-                n_dead_tup,
-                CASE 
-                  WHEN n_live_tup > 0 
-                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
-                  ELSE 0
-                END AS dead_rows_pct,
-                n_mod_since_analyze,
-                n_ins_since_vacuum,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
-                vacuum_count,
-                autovacuum_count,
-                analyze_count,
-                autoanalyze_count
-              FROM pg_stat_user_tables
-              ORDER BY n_dead_tup DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: n_live_tup
-          type: gauge
-          description: Estimated number of live rows
-        - name: n_dead_tup
-          type: gauge
-          description: Estimated number of dead rows
-        - name: dead_rows_pct
-          type: gauge
-          description: Percentage of dead rows relative to live rows
-        - name: n_mod_since_analyze
-          type: gauge
-          description: Estimated number of rows modified since last analyze
-        - name: n_ins_since_vacuum
-          type: gauge
-          description: Estimated number of rows inserted since last vacuum
-        - name: last_vacuum_seconds
-          type: gauge
-          description: Seconds since last manual vacuum (-1 if never)
-        - name: last_autovacuum_seconds
-          type: gauge
-          description: Seconds since last autovacuum (-1 if never)
-        - name: last_analyze_seconds
-          type: gauge
-          description: Seconds since last manual analyze (-1 if never)
-        - name: last_autoanalyze_seconds
-          type: gauge
-          description: Seconds since last autoanalyze (-1 if never)
-        - name: vacuum_count
-          type: counter
-          description: Number of times this table has been manually vacuumed
-        - name: autovacuum_count
-          type: counter
-          description: Number of times this table has been vacuumed by autovacuum
-        - name: analyze_count
-          type: counter
-          description: Number of times this table has been manually analyzed
-        - name: autoanalyze_count
-          type: counter
-          description: Number of times this table has been analyzed by autoanalyze
-
-    - query: SELECT
-                schemaname,
-                relname,
-                seq_scan,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds,
-                seq_tup_read,
-                idx_scan,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds,
-                idx_tup_fetch,
-                n_tup_ins,
-                n_tup_upd,
-                n_tup_del,
-                n_tup_hot_upd,
-                n_tup_newpage_upd,
-                n_live_tup,
-                n_dead_tup,
-                CASE 
-                  WHEN n_live_tup > 0 
-                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
-                  ELSE 0
-                END AS dead_rows_pct,
-                n_mod_since_analyze,
-                n_ins_since_vacuum,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
-                vacuum_count,
-                autovacuum_count,
-                analyze_count,
-                autoanalyze_count
-              FROM pg_stat_user_tables
-              ORDER BY n_dead_tup DESC;
-      version: 16
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: seq_scan
-          type: counter
-          description: Number of sequential scans initiated on this table
-        - name: last_seq_scan_seconds
-          type: gauge
-          description: Seconds since last sequential scan (-1 if never)
-        - name: seq_tup_read
-          type: counter
-          description: Number of live rows fetched by sequential scans
-        - name: idx_scan
-          type: counter
-          description: Number of index scans initiated on this table
-        - name: last_idx_scan_seconds
-          type: gauge
-          description: Seconds since last index scan (-1 if never)
-        - name: idx_tup_fetch
-          type: counter
-          description: Number of live rows fetched by index scans
-        - name: n_tup_ins
-          type: counter
-          description: Number of rows inserted
-        - name: n_tup_upd
-          type: counter
-          description: Number of rows updated
-        - name: n_tup_del
-          type: counter
-          description: Number of rows deleted
-        - name: n_tup_hot_upd
-          type: counter
-          description: Number of rows HOT updated
-        - name: n_tup_newpage_upd
-          type: counter
-          description: Number of rows updated where successor goes to new heap page
-        - name: n_live_tup
-          type: gauge
-          description: Estimated number of live rows
-        - name: n_dead_tup
-          type: gauge
-          description: Estimated number of dead rows
-        - name: dead_rows_pct
-          type: gauge
-          description: Percentage of dead rows relative to live rows
-        - name: n_mod_since_analyze
-          type: gauge
-          description: Estimated number of rows modified since last analyze
-        - name: n_ins_since_vacuum
-          type: gauge
-          description: Estimated number of rows inserted since last vacuum
-        - name: last_vacuum_seconds
-          type: gauge
-          description: Seconds since last manual vacuum (-1 if never)
-        - name: last_autovacuum_seconds
-          type: gauge
-          description: Seconds since last autovacuum (-1 if never)
-        - name: last_analyze_seconds
-          type: gauge
-          description: Seconds since last manual analyze (-1 if never)
-        - name: last_autoanalyze_seconds
-          type: gauge
-          description: Seconds since last autoanalyze (-1 if never)
-        - name: vacuum_count
-          type: counter
-          description: Number of times this table has been manually vacuumed
-        - name: autovacuum_count
-          type: counter
-          description: Number of times this table has been vacuumed by autovacuum
-        - name: analyze_count
-          type: counter
-          description: Number of times this table has been manually analyzed
-        - name: autoanalyze_count
-          type: counter
-          description: Number of times this table has been analyzed by autoanalyze
-    tag: pg_stat_user_tables_vacuum
-    sort: data
-    collector: stat_user_tables
-    database: all
-
-# Table read/write activity ratios
-  - queries:
-    - query: WITH table_activity AS (
-                SELECT
-                  s.schemaname,
-                  s.relname,
-                  si.heap_blks_read + si.idx_blks_read AS blocks_read,
-                  s.seq_tup_read + s.idx_tup_fetch AS tuples_read,
-                  c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) /
-                    CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write,
-                  s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write
-                FROM pg_stat_user_tables AS s
-                JOIN pg_statio_user_tables AS si ON s.relid = si.relid
-                JOIN pg_class c ON c.oid = s.relid
-                WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0
-                  AND (si.heap_blks_read + si.idx_blks_read) > 0
-              )
-              SELECT
-                schemaname,
-                relname,
-                blocks_read,
-                tuples_read,
-                blocks_write,
-                tuples_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int
-                END AS ratio_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int
-                END AS ratio_read
-              FROM table_activity
-              ORDER BY (blocks_read + blocks_write) DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: blocks_read
-          type: counter
-          description: Total blocks read from disk (heap + index)
-        - name: tuples_read
-          type: counter
-          description: Total number of tuples read (sequential + index scans)
-        - name: blocks_write
-          type: gauge
-          description: Estimated blocks affected by write operations
-        - name: tuples_write
-          type: counter
-          description: Total number of tuples inserted, updated, or deleted
-        - name: ratio_write
-          type: gauge
-          description: Percentage of I/O activity that is writes (0-100)
-        - name: ratio_read
-          type: gauge
-          description: Percentage of I/O activity that is reads (0-100)
-    tag: pg_table_ratio
-    sort: data
-    collector: table_activity_ratio
-    database: all
-
-# Table bloat analysis
-  - queries:
-    - query: SELECT
-                schemaname,
-                tblname,
-                real_size AS table_size,
-                extra_size AS bloat_size,
-                ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct,
-                tblpages,
-                est_tblpages,
-                bs AS block_size
-              FROM (
-                SELECT
-                  schemaname,
-                  tblname,
-                  bs*tblpages AS real_size,
-                  (tblpages-est_tblpages)*bs AS extra_size,
-                  CASE WHEN tblpages > 0
-                    THEN 100 * (tblpages-est_tblpages)/tblpages::numeric
-                    ELSE 0
-                  END AS extra_ratio,
-                  tblpages,
-                  est_tblpages,
-                  bs
-                FROM (
-                  SELECT
-                    n.nspname AS schemaname,
-                    c.relname AS tblname,
-                    c.relpages AS tblpages,
-                    CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages,
-                    current_setting('block_size')::integer AS bs
-                  FROM pg_class c
-                  JOIN pg_namespace n ON n.oid = c.relnamespace
-                  WHERE c.relkind = 'r'
-                  AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
-                  AND n.nspname NOT LIKE 'pg_temp_%'
-                ) AS bloat_calc
-              ) AS bloat_summary
-              WHERE tblpages > 0
-              ORDER BY extra_size DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: tblname
-          type: label
-        - name: table_size
-          type: gauge
-          description: Actual table size in bytes
-        - name: bloat_size
-          type: gauge
-          description: Estimated bloat size in bytes
-        - name: bloat_ratio_pct
-          type: gauge
-          description: Bloat ratio as percentage
-        - name: tblpages
-          type: gauge
-          description: Actual number of pages used by table
-        - name: est_tblpages
-          type: gauge
-          description: Estimated number of pages needed
-        - name: block_size
-          type: gauge
-          description: Database block size in bytes
-    tag: pg_table_bloat
-    sort: data
-    collector: table_bloat
-    database: all
-#
-# PostgreSQL 14
-#
-
-# Memory context information
-  - queries:
-    - query: SELECT
-                COUNT(*) AS contexts,
-                parent,
-                SUM(free_bytes) AS free_bytes,
-                SUM(used_bytes) AS used_bytes,
-                SUM(total_bytes) AS total_bytes
-              FROM pg_backend_memory_contexts
-              WHERE parent!=''
-              GROUP BY parent;
-      version: 14
-      columns:
-        - name: contexts
-          type: gauge
-          description: Number of memory contexts per parent.
-        - name: parent
-          type: label
-        - name: free_bytes
-          type: gauge
-          description: Free bytes per memory context.
-        - name: used_bytes
-          type: gauge
-          description: Used bytes per memory context.
-        - name: total_bytes
-          type: gauge
-          description: Total bytes per memory context.
-    tag: pg_mem_ctx
-    collector: mem_ctx
-
-# Memory context information
-  - queries:
-    - query: SELECT
-                wal_records,
-                wal_fpi,
-                wal_bytes,
-                wal_buffers_full,
-                wal_write,
-                wal_sync,
-                wal_write_time,
-                wal_sync_time
-              FROM pg_stat_wal;
-      version: 14
-      columns:
-        - name: wal_records
-          type: counter
-          description: Number of WAL records generated.
-        - name: wal_fpi
-          type: counter
-          description: Number of WAL full page images generated.
-        - name: wal_bytes
-          type: counter
-          description: Total bytes of generated WAL.
-        - name: wal_buffers_full
-          type: counter
-          description: Number of disk writes due to WAL buffers being full.
-        - name: wal_write
-          type: counter
-          description: Number of times WAL files were written to disk.
-        - name: wal_sync
-          type: counter
-          description: Number of times WAL files were synced to disk.
-        - name: wal_write_time
-          type: counter
-          description: Time taken for WAL files to be written to disk.
-        - name: wal_sync_time
-          type: counter
-          description: Time taken for WAL files to be synced to disk.
-    tag: pg_stat_wal
-    collector: stat_wal
-
-# stat_database_information()
-  - queries:
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends
-              FROM pg_stat_database
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-      version: 10
-
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends,
-                checksum_failures
-              FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-        - name: checksum_failures
-          type: gauge
-          description: pg_stat_database_checksum_failures
-      version: 12
-
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends,
-                checksum_failures,
-                session_time,
-                active_time,
-                idle_in_transaction_time,
-                sessions,
-                sessions_abandoned,
-                sessions_fatal,
-                sessions_killed
-              FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
-      version: 14
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-        - name: checksum_failures
-          type: gauge
-          description: pg_stat_database_checksum_failures
-        - name: session_time
-          type: gauge
-          description: pg_stat_database_session_time
-        - name: active_time
-          type: gauge
-          description: pg_stat_database_active_time
-        - name: idle_in_transaction_time
-          type: gauge
-          description: pg_stat_database_idle_in_transaction_time
-        - name: sessions
-          type: gauge
-          description: pg_stat_database_sessions
-        - name: sessions_abandoned
-          type: gauge
-          description: pg_stat_database_sessions_abandoned
-        - name: sessions_fatal
-          type: gauge
-          description: pg_stat_database_sessions_fatal
-        - name: sessions_killed
-          type: gauge
-          description: pg_stat_database_sessions_killed
-    tag: pg_stat_database
-    collector: stat_db
-
-#
-# PostgreSQL 15
-#
-
-# WAL prefetch last stat reset
-  - queries:
-    - query: SELECT
-                FLOOR(
-                  EXTRACT(
-                    EPOCH FROM (now() - stats_reset)
-                  )
-                )
-              FROM pg_stat_recovery_prefetch;
-      version: 15
-      columns:
-        - type: counter
-          description: Seconds from last WAL prefetch stats reset.
-    tag: pg_wal_prefetch_reset
-    collector: wal_prefetch_reset
-
-#
-# PostgreSQL 16
-#
-
-# GSS API Credentials Delegated to DB Connection
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE credentials_delegated = 't' AND datname IS NOT NULL;
-      columns:
-        - type: gauge
-          description: Number of DB connections with delegated GSSAPI credentials.
-    tag: pg_gssapi_credentials_delegated
-    collector: gssapi_creds_delegated
-
-# pg_stat_io
-  - queries:
-    - query: SELECT
-                backend_type,
-                SUM(COALESCE(reads, 0)) AS reads,
-                SUM(COALESCE(read_time, 0)) AS read_time,
-                SUM(COALESCE(writes, 0)) AS writes,
-                SUM(COALESCE(write_time, 0)) AS write_time,
-                SUM(COALESCE(writebacks, 0)) AS writebacks,
-                SUM(COALESCE(writeback_time, 0)) AS writeback_time,
-                SUM(COALESCE(extends, 0)) AS extends,
-                SUM(COALESCE(extend_time, 0)) AS extend_time,
-                AVG(COALESCE(op_bytes, 0)) AS op_bytes,
-                SUM(COALESCE(hits, 0)) AS hits,
-                SUM(COALESCE(evictions, 0)) AS evictions,
-                SUM(COALESCE(reuses, 0)) AS reuses,
-                SUM(COALESCE(fsyncs, 0)) AS fsyncs,
-                SUM(COALESCE(fsync_time, 0)) AS fsync_time
-              FROM pg_stat_io
-              GROUP BY backend_type;
-      columns:
-        - name: backend_type
-          type: label
-        - name: reads
-          type: counter
-          description: Number of read operations.
-        - name: read_time
-          type: counter
-          description: Total time spent on read operations in milliseconds.
-        - name: writes
-          type: counter
-          description: Number of write operations.
-        - name: write_time
-          type: counter
-          description: Total time spent on write operations in milliseconds.
-        - name: writebacks
-          type: counter
-          description: Number of writeback to permanent storage requests sent to kernel.
-        - name: writeback_time
-          type: counter
-          description: Total time spent on writeback operations in milliseconds.
-        - name: extends
-          type: counter
-          description: Number of relation extend operations.
-        - name: extend_time
-          type: counter
-          description: Total time spent on relation extend operations in milliseconds.
-        - name: op_bytes
-          type: gauge
-          description: Bytes per unit of I/O read, written or extended.
-        - name: hits
-          type: counter
-          description: The number of times a desired block was found in shared buffer.
-        - name: evictions
-          type: counter
-          description: The number of times a block has been written out from shared or local buffer in order to make it available for another use.
-        - name: reuses
-          type: counter
-          description: The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation.
-        - name: fsyncs
-          type: counter
-          description: Number of fsync calls.
-        - name: fsync_time
-          type: counter
-          description: Total time spent on fsync operations in milliseconds.
-    tag: pg_stat_io
-    collector: stat_io
-
-# stat_database_conflicts_information()
-  - queries:
-    - query: SELECT datname,
-                confl_tablespace,
-                confl_lock,
-                confl_snapshot,
-                confl_bufferpin,
-                confl_deadlock
-              FROM pg_stat_database_conflicts
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: confl_tablespace
-          type: counter
-          description: pg_stat_database_conflicts_confl_tablespace
-        - name: confl_lock
-          type: counter
-          description: pg_stat_database_conflicts_confl_lock
-        - name: confl_snapshot
-          type: counter
-          description: pg_stat_database_conflicts_confl_snapshot
-        - name: confl_bufferpin
-          type: counter
-          description: pg_stat_database_conflicts_confl_bufferpin
-        - name: confl_deadlock
-          type: counter
-          description: pg_stat_database_conflicts_confl_deadlock
-      version: 10
-
-    - query: SELECT datname,
-                confl_tablespace,
-                confl_lock,
-                confl_snapshot,
-                confl_bufferpin,
-                confl_deadlock,
-                confl_active_logicalslot
-              FROM pg_stat_database_conflicts
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: confl_tablespace
-          type: counter
-          description: pg_stat_database_conflicts_confl_tablespace
-        - name: confl_lock
-          type: counter
-          description: pg_stat_database_conflicts_confl_lock
-        - name: confl_snapshot
-          type: counter
-          description: pg_stat_database_conflicts_confl_snapshot
-        - name: confl_bufferpin
-          type: counter
-          description: pg_stat_database_conflicts_confl_bufferpin
-        - name: confl_deadlock
-          type: counter
-          description: pg_stat_database_conflicts_confl_dead
-        - name: confl_active_logicalslot
-          type: counter
-          description: pg_stat_database_conflicts_confl_active_logicalslot
-    tag: pg_stat_database_conflicts
-    sort: data
-    collector: stat_conflicts
-
-  - queries:
-    - query: SELECT
-                SUM(idx_scan) AS idx_scans,
-                SUM(idx_tup_read) AS idx_tup_reads,
-                SUM(idx_tup_fetch) AS idx_tup_fetchs,
-                relname
-              FROM pg_stat_all_indexes
-              GROUP BY relname;
-      columns:
-        - type: counter
-          name: idx_scans
-          description: Number of index scans on the table's indexes.
-        - type: counter
-          name: idx_tup_reads
-          description: Number of index entries returned by scans on the table's indexes.
-        - type: counter
-          name: idx_tup_fetchs
-          description: Number of rows fetched by simple index scans on the table's indexes.
-        - type: label
-          name: relname
-      version: 10
-
-    - query: SELECT
-                SUM(idx_scan) AS idx_scans,
-                SUM(idx_tup_read) AS idx_tup_reads,
-                SUM(idx_tup_fetch) AS idx_tup_fetchs,
-                COALESCE(MIN((EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms,
-                relname
-              FROM pg_stat_all_indexes
-              WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%')
-              GROUP BY relname;
-      columns:
-        - type: counter
-          name: idx_scans
-          description: Number of index scans on the table's indexes.
-        - type: counter
-          name: idx_tup_reads
-          description: Number of index entries returned by scans on the table's indexes.
-        - type: counter
-          name: idx_tup_fetchs
-          description: Number of rows fetched by simple index scans on the table's indexes.
-        - type: counter
-          name: time_elapsed_ms
-          description: Milliseconds since last scan of an index in the table.
-        - type: label
-          name: relname
-    tag: pg_stat_all_indexes
-    sort: data
-    collector: stat_all_indexes
-    database: all
+- tag: postgresql_primary
+  collector: primary
+  sort: name
+  server: both
+  queries:
+  - query: SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );
+    version: 10
+    columns:
+    - description: Is the PostgreSQL instance the primary
+      type: gauge
+- tag: pg_database_size
+  collector: db
+  sort: data
+  queries:
+  - query: SELECT datname, pg_database_size(datname) FROM pg_database;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - description: Size of the database
+      type: gauge
+- tag: pg_locks_count
+  collector: locks
+  sort: data
+  queries:
+  - query: SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - name: mode
+      type: label
+    - description: Lock count of a database
+      type: gauge
+- tag: pg_replication_slots
+  collector: replication
+  sort: data
+  queries:
+  - query: SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;
+    version: 10
+    columns:
+    - name: slot_name
+      type: label
+    - name: slot_type
+      type: label
+    - name: database
+      type: label
+    - description: Is the replication active
+      name: active
+      type: gauge
+    - description: Is the replication temporary
+      name: temporary
+      type: gauge
+- tag: pg_stat_bgwriter
+  collector: stat_bgwriter
+  queries:
+  - query: SELECT buffers_alloc, buffers_backend, buffers_backend_fsync, buffers_checkpoint, buffers_clean, checkpoint_sync_time, checkpoint_write_time, checkpoints_req, checkpoints_timed, maxwritten_clean FROM pg_stat_bgwriter;
+    version: 10
+    columns:
+    - description: pg_stat_bgwriter_buffers_alloc
+      name: buffers_alloc
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_backend
+      name: buffers_backend
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_backend_fsync
+      name: buffers_backend_fsync
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_checkpoint
+      name: buffers_checkpoint
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_clean
+      name: buffers_clean
+      type: gauge
+    - description: pg_stat_bgwriter_checkpoint_sync_time
+      name: checkpoint_sync_time
+      type: counter
+    - description: pg_stat_bgwriter_checkpoint_write_time
+      name: checkpoint_write_time
+      type: counter
+    - description: pg_stat_bgwriter_checkpoints_req
+      name: checkpoints_req
+      type: counter
+    - description: pg_stat_bgwriter_checkpoints_timed
+      name: checkpoints_timed
+      type: counter
+    - description: pg_stat_bgwriter_maxwritten_clean
+      name: maxwritten_clean
+      type: counter
+- tag: pg_process_idle_seconds
+  collector: idle_procs
+  queries:
+  - query: WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;
+    version: 10
+    columns:
+    - name: application_name
+      type: label
+    - name: seconds
+      type: histogram
+      description: Histogram of idle processes
+- tag: pg_available_extensions
+  collector: available_extensions
+  queries:
+  - query: SELECT COUNT(*) AS extensions FROM pg_available_extensions;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of available extensions for installation.
+- tag: pg_installed_extensions
+  collector: installed_extensions
+  queries:
+  - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
+    version: 10
+    columns:
+    - name: extensions
+      type: label
+    - type: gauge
+      description: Number of installed extensions.
+- tag: pg_file_settings
+  collector: file_settings
+  sort: data
+  queries:
+  - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
+    version: 10
+    columns:
+    - name: sourcefile
+      type: label
+    - type: gauge
+      description: Settings that are applied.
+    - name: applied
+      type: label
+- tag: pg_indexes
+  collector: indexes
+  sort: data
+  queries:
+  - query: SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;
+    version: 10
+    columns:
+    - name: schemaname
+      type: label
+    - name: tablename
+      type: label
+    - type: gauge
+      description: Indexes for each schemaname for each tablename.
+- tag: pg_matviews
+  collector: matviews
+  queries:
+  - query: SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of applied Materialized views.
+- tag: pg_role
+  collector: roles
+  queries:
+  - query: SELECT COUNT(*) FROM pg_roles;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of roles.
+- tag: pg_rule
+  collector: rules
+  sort: data
+  queries:
+  - query: SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;
+    version: 10
+    columns:
+    - name: tablename
+      type: label
+    - type: gauge
+      description: Number of rules in table.
+- tag: pg_shadow
+  collector: auth_type
+  sort: data
+  queries:
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+    version: 10
+    columns:
+    - name: encryption_type
+      type: label
+    - type: gauge
+      description: Number of users with authentication type.
+- tag: pg_usr_evt_trigger
+  collector: usr_evt_trigger
+  queries:
+  - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of user defined event triggers.
+- tag: pg_db_conn
+  collector: connections
+  sort: data
+  queries:
+  - query: SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - type: gauge
+      description: Number of database connections.
+- tag: pg_db_conn_ssl
+  collector: connections
+  sort: data
+  queries:
+  - query: SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - type: gauge
+      description: Number of DB connections with SSL.
+- tag: pg_statio_all_tables
+  collector: statio_all_tables
+  queries:
+  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+    version: 10
+    columns:
+    - name: heap_blks_read
+      type: counter
+      description: Number of disk blocks read in postgres db.
+    - name: heap_blks_hit
+      type: counter
+      description: Number of buffer hits read in postgres db.
+    - name: idx_blks_read
+      type: counter
+      description: Number of disk blocks reads from all indexes in postgres db.
+    - name: idx_blks_hit
+      type: counter
+      description: Number of buffer hits read from all indexes in postgres db.
+    - name: toast_blks_read
+      type: counter
+      description: Number of disk blocks reads from postgres db's TOAST tables.
+    - name: toast_blks_hit
+      type: counter
+      description: Number of buffer hits read from postgres db's TOAST tables.
+    - name: tidx_blks_read
+      type: counter
+      description: Number of disk blocks reads from postgres db's TOAST table indexes.
+    - name: tidx_blks_hit
+      type: counter
+      description: Number of buffer hits read from postgres db's TOAST table indexes.
+- tag: pg_statio_all_sequences
+  collector: statio_all_sequences
+  queries:
+  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+    version: 10
+    columns:
+    - name: blks_read
+      type: counter
+      description: Number of disk blocks read from sequences in postgres db.
+    - name: blks_hit
+      type: counter
+      description: Number of buffer hits read from sequences in postgres db.
+- tag: pg_stat_user_functions
+  collector: stat_user_functions
+  sort: data
+  queries:
+  - query: SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;
+    version: 10
+    columns:
+    - name: funcname
+      type: label
+    - name: calls
+      type: counter
+      description: Number of times function is called.
+    - name: self_time
+      type: counter
+      description: Total time spent in milliseconds on the function itself.
+    - name: total_time
+      type: counter
+      description: Total time spent in milliseconds by the function and any other functions called by it.
+- tag: pg_stat_replication
+  collector: stat_replication
+  sort: data
+  queries:
+  - query: SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of streaming WAL connections per application.
+    - name: application_name
+      type: label
+- tag: pg_stat_archiver
+  collector: stat_archiver
+  sort: data
+  queries:
+  - query: SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;
+    version: 10
+    columns:
+    - type: counter
+      name: archived_count
+      description: Number of successful archived WAL files.
+    - type: counter
+      name: success_time_elapsed_ms
+      description: Milliseconds since successful archived WAL file.
+    - type: counter
+      name: failed_count
+      description: Number of failed archival operation on WAL files.
+    - type: counter
+      name: failure_time_elapsed_ms
+      description: Milliseconds since last failed archival operation on WAL files.
+- tag: pg_db_vacuum
+  collector: db_vacuum
+  sort: data
+  queries:
+  - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
+    version: 10
+    columns:
+    - type: label
+      name: datname
+      description: Database name.
+    - type: counter
+      name: age
+      description: Age since last vaccum.
+- tag: pg_view_vacuum
+  collector: db_vacuum
+  sort: data
+  queries:
+  - query: SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');
+    version: 10
+    columns:
+    - type: label
+      name: datname
+      description: View name.
+    - type: counter
+      name: age
+      description: Age since last vaccum.
+- tag: pg_blocked_vacuum
+  collector: blocked_vacuum
+  sort: data
+  queries:
+  - query: SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;
+    version: 10
+    columns:
+    - name: blocked_pid
+      type: label
+    - name: blocked_database
+      type: label
+    - name: blocked_user
+      type: label
+    - name: blocked_query
+      type: label
+    - name: blocked_duration_seconds
+      type: gauge
+      description: Duration in seconds that the vacuum has been blocked
+    - name: blocking_pid
+      type: label
+    - name: blocking_database
+      type: label
+    - name: blocking_user
+      type: label
+    - name: blocking_query
+      type: label
+    - name: blocking_duration_seconds
+      type: gauge
+      description: Duration in seconds that the blocking query has been running
+- tag: pg_wal_last_received
+  collector: wal_last_received
+  server: replica
+  queries:
+  - query: SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;
+    version: 11
+    columns:
+    - name: sender
+      type: label
+    - type: counter
+      description: Time since last message received from WAL sender
+- tag: pg_gss_auth
+  collector: gssapi
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;
+    version: 12
+    columns:
+    - type: gauge
+      description: Number of GSSAPI authenticated DB connections.
+- tag: pg_encrypted_conn
+  collector: encryted_conns
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;
+    version: 12
+    columns:
+    - type: gauge
+      description: Number of encrypted DB connections.
+- tag: pg_shmem_allocations
+  collector: shmem_size
+  queries:
+  - query: SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;
+    version: 13
+    columns:
+    - name: size
+      type: histogram
+      description: Histogram of shared memory sizes.
+- tag: pg_stat_progress_vacuum
+  collector: vacuum_progress
+  sort: data
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 13
+    columns:
+    - name: pid
+      type: label
+    - name: datname
+      type: label
+    - name: usename
+      type: label
+    - name: query
+      type: label
+    - name: phase
+      type: label
+    - name: heap_blks_total
+      type: gauge
+      description: Total heap blocks in table
+    - name: heap_blks_scanned
+      type: gauge
+      description: Heap blocks scanned
+    - name: heap_blks_vacuumed
+      type: gauge
+      description: Heap blocks vacuumed
+    - name: index_vacuum_count
+      type: gauge
+      description: Number of index vacuum cycles completed
+    - name: max_dead_tuples
+      type: gauge
+      description: Maximum dead tuples
+    - name: num_dead_tuples
+      type: gauge
+      description: Current dead tuples
+    - name: pct_scan_completed
+      type: gauge
+      description: Vacuum scan progress percentage
+- tag: pg_stat_progress_analyze
+  collector: analyze_progress
+  sort: data
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 13
+    columns:
+    - name: pid
+      type: label
+    - name: datname
+      type: label
+    - name: usename
+      type: label
+    - name: phase
+      type: label
+    - name: sample_blks_total
+      type: gauge
+      description: Total blocks to sample
+    - name: sample_blks_scanned
+      type: gauge
+      description: Blocks sampled so far
+    - name: ext_stats_total
+      type: gauge
+      description: Total extended statistics to compute
+    - name: ext_stats_computed
+      type: gauge
+      description: Extended statistics computed
+    - name: child_tables_total
+      type: gauge
+      description: Total child tables to analyze
+    - name: child_tables_done
+      type: gauge
+      description: Child tables analyzed
+    - name: pct_sample_completed
+      type: gauge
+      description: Percentage of sampling completed
+    - name: pct_child_tables_completed
+      type: gauge
+      description: Percentage of child tables completed
+- tag: pg_stat_user_tables_vacuum
+  collector: stat_user_tables
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, relname, seq_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds, seq_tup_read, idx_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_tup_newpage_upd, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;
+    version: 16
+    columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
+    - name: seq_scan
+      type: counter
+      description: Number of sequential scans initiated on this table
+    - name: last_seq_scan_seconds
+      type: gauge
+      description: Seconds since last sequential scan (-1 if never)
+    - name: seq_tup_read
+      type: counter
+      description: Number of live rows fetched by sequential scans
+    - name: idx_scan
+      type: counter
+      description: Number of index scans initiated on this table
+    - name: last_idx_scan_seconds
+      type: gauge
+      description: Seconds since last index scan (-1 if never)
+    - name: idx_tup_fetch
+      type: counter
+      description: Number of live rows fetched by index scans
+    - name: n_tup_ins
+      type: counter
+      description: Number of rows inserted
+    - name: n_tup_upd
+      type: counter
+      description: Number of rows updated
+    - name: n_tup_del
+      type: counter
+      description: Number of rows deleted
+    - name: n_tup_hot_upd
+      type: counter
+      description: Number of rows HOT updated
+    - name: n_tup_newpage_upd
+      type: counter
+      description: Number of rows updated where successor goes to new heap page
+    - name: n_live_tup
+      type: gauge
+      description: Estimated number of live rows
+    - name: n_dead_tup
+      type: gauge
+      description: Estimated number of dead rows
+    - name: dead_rows_pct
+      type: gauge
+      description: Percentage of dead rows relative to live rows
+    - name: n_mod_since_analyze
+      type: gauge
+      description: Estimated number of rows modified since last analyze
+    - name: n_ins_since_vacuum
+      type: gauge
+      description: Estimated number of rows inserted since last vacuum
+    - name: last_vacuum_seconds
+      type: gauge
+      description: Seconds since last manual vacuum (-1 if never)
+    - name: last_autovacuum_seconds
+      type: gauge
+      description: Seconds since last autovacuum (-1 if never)
+    - name: last_analyze_seconds
+      type: gauge
+      description: Seconds since last manual analyze (-1 if never)
+    - name: last_autoanalyze_seconds
+      type: gauge
+      description: Seconds since last autoanalyze (-1 if never)
+    - name: vacuum_count
+      type: counter
+      description: Number of times this table has been manually vacuumed
+    - name: autovacuum_count
+      type: counter
+      description: Number of times this table has been vacuumed by autovacuum
+    - name: analyze_count
+      type: counter
+      description: Number of times this table has been manually analyzed
+    - name: autoanalyze_count
+      type: counter
+      description: Number of times this table has been analyzed by autoanalyze
+- tag: pg_table_ratio
+  collector: table_activity_ratio
+  sort: data
+  database: all
+  queries:
+  - query: WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
+    - name: blocks_read
+      type: counter
+      description: Total blocks read from disk (heap + index)
+    - name: tuples_read
+      type: counter
+      description: Total number of tuples read (sequential + index scans)
+    - name: blocks_write
+      type: gauge
+      description: Estimated blocks affected by write operations
+    - name: tuples_write
+      type: counter
+      description: Total number of tuples inserted, updated, or deleted
+    - name: ratio_write
+      type: gauge
+      description: Percentage of I/O activity that is writes (0-100)
+    - name: ratio_read
+      type: gauge
+      description: Percentage of I/O activity that is reads (0-100)
+- tag: pg_table_bloat
+  collector: table_bloat
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: tblname
+      type: label
+    - name: table_size
+      type: gauge
+      description: Actual table size in bytes
+    - name: bloat_size
+      type: gauge
+      description: Estimated bloat size in bytes
+    - name: bloat_ratio_pct
+      type: gauge
+      description: Bloat ratio as percentage
+    - name: tblpages
+      type: gauge
+      description: Actual number of pages used by table
+    - name: est_tblpages
+      type: gauge
+      description: Estimated number of pages needed
+    - name: block_size
+      type: gauge
+      description: Database block size in bytes
+- tag: pg_mem_ctx
+  collector: mem_ctx
+  queries:
+  - query: SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;
+    version: 14
+    columns:
+    - name: contexts
+      type: gauge
+      description: Number of memory contexts per parent.
+    - name: parent
+      type: label
+    - name: free_bytes
+      type: gauge
+      description: Free bytes per memory context.
+    - name: used_bytes
+      type: gauge
+      description: Used bytes per memory context.
+    - name: total_bytes
+      type: gauge
+      description: Total bytes per memory context.
+- tag: pg_stat_wal
+  collector: stat_wal
+  queries:
+  - query: SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal;
+    version: 14
+    columns:
+    - name: wal_records
+      type: counter
+      description: Number of WAL records generated.
+    - name: wal_fpi
+      type: counter
+      description: Number of WAL full page images generated.
+    - name: wal_bytes
+      type: counter
+      description: Total bytes of generated WAL.
+    - name: wal_buffers_full
+      type: counter
+      description: Number of disk writes due to WAL buffers being full.
+    - name: wal_write
+      type: counter
+      description: Number of times WAL files were written to disk.
+    - name: wal_sync
+      type: counter
+      description: Number of times WAL files were synced to disk.
+    - name: wal_write_time
+      type: counter
+      description: Time taken for WAL files to be written to disk.
+    - name: wal_sync_time
+      type: counter
+      description: Time taken for WAL files to be synced to disk.
+- tag: pg_stat_database
+  collector: stat_db
+  queries:
+  - query: SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
+    version: 14
+    columns:
+    - name: database
+      type: label
+    - name: blk_read_time
+      type: counter
+      description: pg_stat_database_blk_read_time
+    - name: blk_write_time
+      type: counter
+      description: pg_stat_database_blk_write_time
+    - name: blks_hit
+      type: counter
+      description: pg_stat_database_blks_hit
+    - name: blks_read
+      type: counter
+      description: pg_stat_database_blks_read
+    - name: deadlocks
+      type: counter
+      description: pg_stat_database_deadlocks
+    - name: temp_files
+      type: gauge
+      description: pg_stat_database_temp_files
+    - name: temp_bytes
+      type: gauge
+      description: pg_stat_database_temp_bytes
+    - name: tup_returned
+      type: counter
+      description: pg_stat_database_tup_returned
+    - name: tup_fetched
+      type: counter
+      description: pg_stat_database_tup_fetched
+    - name: tup_inserted
+      type: counter
+      description: pg_stat_database_tup_inserted
+    - name: tup_updated
+      type: counter
+      description: pg_stat_database_tup_updated
+    - name: tup_deleted
+      type: counter
+      description: pg_stat_database_tup_deleted
+    - name: xact_commit
+      type: counter
+      description: pg_stat_database_xact_commit
+    - name: xact_rollback
+      type: counter
+      description: pg_stat_database_xact_rollback
+    - name: conflicts
+      type: counter
+      description: pg_stat_database_conflicts
+    - name: numbackends
+      type: gauge
+      description: pg_stat_database_numbackends
+    - name: checksum_failures
+      type: gauge
+      description: pg_stat_database_checksum_failures
+    - name: session_time
+      type: gauge
+      description: pg_stat_database_session_time
+    - name: active_time
+      type: gauge
+      description: pg_stat_database_active_time
+    - name: idle_in_transaction_time
+      type: gauge
+      description: pg_stat_database_idle_in_transaction_time
+    - name: sessions
+      type: gauge
+      description: pg_stat_database_sessions
+    - name: sessions_abandoned
+      type: gauge
+      description: pg_stat_database_sessions_abandoned
+    - name: sessions_fatal
+      type: gauge
+      description: pg_stat_database_sessions_fatal
+    - name: sessions_killed
+      type: gauge
+      description: pg_stat_database_sessions_killed
+- tag: pg_stat_subscription_stats
+  collector: subscription_stats
+  sort: data
+  queries:
+  - query: SELECT subid, subname, apply_error_count, sync_error_count, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint AS stats_reset_seconds FROM pg_stat_subscription_stats;
+    version: 16
+    columns:
+    - name: subid
+      type: label
+      description: Subscription OID
+    - name: subname
+      type: label
+      description: Subscription name
+    - name: apply_error_count
+      type: counter
+      description: Number of errors during apply
+    - name: sync_error_count
+      type: counter
+      description: Number of errors during initial sync
+    - name: stats_reset_seconds
+      type: counter
+      description: Seconds since statistics were last reset
+- tag: pg_wal_prefetch_reset
+  collector: wal_prefetch_reset
+  queries:
+  - query: SELECT FLOOR( EXTRACT( EPOCH FROM (now() - stats_reset) ) ) FROM pg_stat_recovery_prefetch;
+    version: 15
+    columns:
+    - type: counter
+      description: Seconds from last WAL prefetch stats reset.
+- tag: pg_gssapi_credentials_delegated
+  collector: gssapi_creds_delegated
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE credentials_delegated = 't' AND datname IS NOT NULL;
+    version: 16
+    columns:
+    - type: gauge
+      description: Number of DB connections with delegated GSSAPI credentials.
+- tag: pg_stat_io
+  collector: stat_io
+  queries:
+  - query: SELECT backend_type, SUM(COALESCE(reads, 0)) AS reads, SUM(COALESCE(read_time, 0)) AS read_time, SUM(COALESCE(writes, 0)) AS writes, SUM(COALESCE(write_time, 0)) AS write_time, SUM(COALESCE(writebacks, 0)) AS writebacks, SUM(COALESCE(writeback_time, 0)) AS writeback_time, SUM(COALESCE(extends, 0)) AS extends, SUM(COALESCE(extend_time, 0)) AS extend_time, AVG(COALESCE(op_bytes, 0)) AS op_bytes, SUM(COALESCE(hits, 0)) AS hits, SUM(COALESCE(evictions, 0)) AS evictions, SUM(COALESCE(reuses, 0)) AS reuses, SUM(COALESCE(fsyncs, 0)) AS fsyncs, SUM(COALESCE(fsync_time, 0)) AS fsync_time FROM pg_stat_io GROUP BY backend_type;
+    version: 16
+    columns:
+    - name: backend_type
+      type: label
+    - name: reads
+      type: counter
+      description: Number of read operations.
+    - name: read_time
+      type: counter
+      description: Total time spent on read operations in milliseconds.
+    - name: writes
+      type: counter
+      description: Number of write operations.
+    - name: write_time
+      type: counter
+      description: Total time spent on write operations in milliseconds.
+    - name: writebacks
+      type: counter
+      description: Number of writeback to permanent storage requests sent to kernel.
+    - name: writeback_time
+      type: counter
+      description: Total time spent on writeback operations in milliseconds.
+    - name: extends
+      type: counter
+      description: Number of relation extend operations.
+    - name: extend_time
+      type: counter
+      description: Total time spent on relation extend operations in milliseconds.
+    - name: op_bytes
+      type: gauge
+      description: Bytes per unit of I/O read, written or extended.
+    - name: hits
+      type: counter
+      description: The number of times a desired block was found in shared buffer.
+    - name: evictions
+      type: counter
+      description: The number of times a block has been written out from shared or local buffer in order to make it available for another use.
+    - name: reuses
+      type: counter
+      description: The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation.
+    - name: fsyncs
+      type: counter
+      description: Number of fsync calls.
+    - name: fsync_time
+      type: counter
+      description: Total time spent on fsync operations in milliseconds.
+- tag: pg_stat_database_conflicts
+  collector: stat_conflicts
+  sort: data
+  queries:
+  - query: SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock, confl_active_logicalslot FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;
+    version: 16
+    columns:
+    - name: database
+      type: label
+    - name: confl_tablespace
+      type: counter
+      description: pg_stat_database_conflicts_confl_tablespace
+    - name: confl_lock
+      type: counter
+      description: pg_stat_database_conflicts_confl_lock
+    - name: confl_snapshot
+      type: counter
+      description: pg_stat_database_conflicts_confl_snapshot
+    - name: confl_bufferpin
+      type: counter
+      description: pg_stat_database_conflicts_confl_bufferpin
+    - name: confl_deadlock
+      type: counter
+      description: pg_stat_database_conflicts_confl_dead
+    - name: confl_active_logicalslot
+      type: counter
+      description: pg_stat_database_conflicts_confl_active_logicalslot
+- tag: pg_stat_all_indexes
+  collector: stat_all_indexes
+  sort: data
+  database: all
+  queries:
+  - query: SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, COALESCE(MIN((EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;
+    version: 16
+    columns:
+    - type: counter
+      name: idx_scans
+      description: Number of index scans on the table's indexes.
+    - type: counter
+      name: idx_tup_reads
+      description: Number of index entries returned by scans on the table's indexes.
+    - type: counter
+      name: idx_tup_fetchs
+      description: Number of rows fetched by simple index scans on the table's indexes.
+    - type: counter
+      name: time_elapsed_ms
+      description: Milliseconds since last scan of an index in the table.
+    - type: label
+      name: relname

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -1,1666 +1,919 @@
-# This is the default minimum version for queries, unless specified otherwise
 version: 17
 metrics:
-
-#
-# PostgreSQL 10
-#
-
-# primary_information()
-  - queries:
-    - query: SELECT
-              (
-                CASE pg_is_in_recovery() WHEN 'f'
-                  THEN 't'
-                  ELSE 'f'
-                END
-              );
-      version: 10
-      columns:
-        - description: Is the PostgreSQL instance the primary
-          type: gauge
-    tag: postgresql_primary
-    sort: name
-    collector: primary
-    server: both
-
-# database_information()
-  - queries:
-    - query: SELECT
-                datname,
-                pg_database_size(datname)
-              FROM pg_database;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - description: Size of the database
-          type: gauge
-    tag: pg_database_size
-    sort: data
-    collector: db
-
-# locks_information()
-  - queries:
-    - query: SELECT
-                pg_database.datname as database,
-                tmp.mode,
-                COALESCE(count, 0) as count
-              FROM (
-                VALUES
-                  ('accesssharelock'),
-                  ('rowsharelock'),
-                  ('rowexclusivelock'),
-                  ('shareupdateexclusivelock'),
-                  ('sharelock'),
-                  ('sharerowexclusivelock'),
-                  ('exclusivelock'),
-                  ('accessexclusivelock'),
-                  ('sireadlock')
-              ) AS tmp(mode)
-              CROSS JOIN pg_database
-              LEFT JOIN
-              (
-                SELECT
-                  database,
-                  lower(mode) AS mode,
-                  count(*) AS count
-                FROM pg_locks
-                WHERE database IS NOT NULL
-                GROUP BY database, lower(mode)
-              ) AS tmp2
-              ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database
-              ORDER BY 1, 2;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - name: mode
-          type: label
-        - description: Lock count of a database
-          type: gauge
-    tag: pg_locks_count
-    sort: data
-    collector: locks
-
-# replication_information()
-  - queries:
-    - query: SELECT
-                slot_name,
-                slot_type,
-                database,
-                active,
-                temporary
-              FROM pg_replication_slots;
-      version: 10
-      columns:
-      - name: slot_name
-        type: label
-      - name: slot_type
-        type: label
-      - name: database
-        type: label
-      - description: Is the replication active
-        name: active
-        type: gauge
-      - description: Is the replication temporary
-        name: temporary
-        type: gauge
-    tag: pg_replication_slots
-    sort: data
-    collector: replication
-
-# stat_bgwriter_information()
-  - queries:
-    - query: SELECT
-                buffers_alloc,
-                buffers_clean,
-                maxwritten_clean
-              FROM pg_stat_bgwriter;
-      version: 10
-      columns:
-        - description: pg_stat_bgwriter_buffers_alloc
-          name: buffers_alloc
-          type: gauge
-        - description: pg_stat_bgwriter_buffers_clean
-          name: buffers_clean
-          type: gauge
-        - description: pg_stat_bgwriter_maxwritten_clean
-          name: maxwritten_clean
-          type: counter
-    tag: pg_stat_bgwriter
-    collector: stat_bgwriter
-
-# histogram sample
-  - queries:
-    - query: WITH
-              metrics AS (
-                SELECT
-                  application_name,
-                  SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum,
-                  COUNT(*) AS process_idle_seconds_count
-                FROM pg_stat_activity
-                WHERE state = 'idle'
-                GROUP BY application_name
-              ),
-              buckets AS (
-                SELECT
-                  application_name,
-                  le,
-                  SUM(
-                    CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le
-                      THEN 1
-                      ELSE 0
-                    END
-                  )::bigint AS bucket
-                FROM
-                  pg_stat_activity,
-                  UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le
-                GROUP BY application_name, le
-                ORDER BY application_name, le
-              )
-              SELECT
-                application_name,
-                process_idle_seconds_sum as seconds_sum,
-                process_idle_seconds_count as seconds_count,
-                ARRAY_AGG(le) AS seconds,
-                ARRAY_AGG(bucket) AS seconds_bucket
-              FROM metrics JOIN buckets USING (application_name)
-              GROUP BY 1, 2, 3;
-      version: 10
-      columns:
-        - name: application_name
-          type: label
-        - name: seconds
-          type: histogram
-          description: Histogram of idle processes
-    tag: pg_process_idle_seconds
-    collector: idle_procs
-
-# Get number of available extensions for installations.
-  - queries:
-    - query: SELECT COUNT(*) AS extensions
-              FROM pg_available_extensions;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of available extensions for installation.
-    tag: pg_available_extensions
-    collector: available_extensions
-
-# Get number of installed extensions.
-  - queries:
-    - query: SELECT
-                array_agg(extname) AS extensions,
-                count(*)
-              FROM pg_extension;
-      version: 10
-      columns:
-        - name: extensions
-          type: label
-        - type: gauge
-          description: Number of installed extensions.
-    tag: pg_installed_extensions
-    collector: installed_extensions
-
-# Get applied settings
-  - queries:
-    - query: SELECT
-                sourcefile,
-                COUNT(*),
-                (
-                  CASE applied WHEN 't'
-                    THEN 'true'
-                    ELSE 'false'
-                  END
-                ) as applied
-              FROM pg_file_settings
-              WHERE applied = 't'
-              GROUP BY sourcefile, applied;
-      version: 10
-      columns:
-        - name: sourcefile
-          type: label
-        - type: gauge
-          description: Settings that are applied.
-        - name: applied
-          type: label
-    tag: pg_file_settings
-    sort: data
-    collector: file_settings
-
-# Get indexes for schemas.
-  - queries:
-    - query: SELECT
-                schemaname,
-                tablename,
-                COUNT(*)
-              FROM pg_indexes
-              GROUP BY schemaname,tablename;
-      version: 10
-      columns:
-        - name: schemaname
-          type: label
-        - name: tablename
-          type: label
-        - type: gauge
-          description: Indexes for each schemaname for each tablename.
-    tag: pg_indexes
-    sort: data
-    collector: indexes
-
-# Get materialized views
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_matviews
-              WHERE ispopulated = 't'
-              GROUP BY ispopulated;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of applied Materialized views.
-    tag: pg_matviews
-    collector: matviews
-
-# Get number of roles
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_roles;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of roles.
-    tag: pg_role
-    collector: roles
-
-# Get number of rules
-  - queries:
-    - query: SELECT tablename, COUNT(*)
-              FROM pg_rules
-              GROUP BY tablename;
-      version: 10
-      columns:
-        - name: tablename
-          type: label
-        - type: gauge
-          description: Number of rules in table.
-    tag: pg_rule
-    sort: data
-    collector: rules
-
-# Get user auth data
-  - queries:
-    - query: SELECT (
-                CASE
-                  WHEN rolpassword LIKE 'md5%' THEN 'MD5'
-                  WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256'
-                  ELSE 'UNENCRYPTED'
-                END
-              ) AS encryption_type, COUNT(*)
-              FROM pg_authid
-              WHERE rolname != 'postgres'
-              GROUP BY encryption_type;
-      version: 10
-      columns:
-        - name: encryption_type
-          type: label
-        - type: gauge
-          description: Number of users with authentication type.
-    tag: pg_shadow
-    sort: data
-    collector: auth_type
-
-# Get user defined event-triggers
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_event_trigger
-              JOIN pg_authid
-              ON pg_event_trigger.oid = pg_authid.oid
-              WHERE rolname != 'postgres';
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of user defined event triggers.
-    tag: pg_usr_evt_trigger
-    collector: usr_evt_trigger
-
-# Get number of database connections
-  - queries:
-    - query: SELECT datname, count(*)
-              FROM pg_stat_activity
-              WHERE datname IS NOT NULL
-              GROUP BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - type: gauge
-          description: Number of database connections.
-    tag: pg_db_conn_ssl
-    sort: data
-    collector: connections
-
-# Get DB connections with SSL
-  - queries:
-    - query: SELECT datname, count(*)
-              FROM pg_stat_ssl
-              JOIN pg_stat_activity
-              ON pg_stat_activity.pid = pg_stat_ssl.pid
-              WHERE ssl = 't' AND datname IS NOT NULL
-              GROUP BY datname;
-      version: 10
-      columns:
-        - name: database
-          type: label
-        - type: gauge
-          description: Number of DB connections with SSL.
-    tag: pg_db_conn
-    sort: data
-    collector: connections
-
-# All tables statio
-  - queries:
-    - query: SELECT
-                COUNT(heap_blks_read) AS heap_blks_read,
-                COUNT(heap_blks_hit) AS heap_blks_hit,
-                COUNT(idx_blks_read) as idx_blks_read,
-                COUNT(idx_blks_hit) AS idx_blks_hit,
-                COUNT(toast_blks_read) AS toast_blks_read,
-                COUNT(toast_blks_hit) AS toast_blks_hit,
-                COUNT(tidx_blks_read) AS tidx_blks_read,
-                COUNT(tidx_blks_hit) AS tidx_blks_hit
-              FROM pg_statio_all_tables;
-      version: 10
-      columns:
-        - name: heap_blks_read
-          type: counter
-          description: Number of disk blocks read in postgres db.
-        - name: heap_blks_hit
-          type: counter
-          description: Number of buffer hits read in postgres db.
-        - name: idx_blks_read
-          type: counter
-          description: Number of disk blocks reads from all indexes in postgres db.
-        - name: idx_blks_hit
-          type: counter
-          description: Number of buffer hits read from all indexes in postgres db.
-        - name: toast_blks_read
-          type: counter
-          description: Number of disk blocks reads from postgres db's TOAST tables.
-        - name: toast_blks_hit
-          type: counter
-          description: Number of buffer hits read from postgres db's TOAST tables.
-        - name: tidx_blks_read
-          type: counter
-          description: Number of disk blocks reads from postgres db's TOAST table indexes.
-        - name: tidx_blks_hit
-          type: counter
-          description: Number of buffer hits read from postgres db's TOAST table indexes.
-    tag: pg_statio_all_tables
-    collector: statio_all_tables
-
-# All sequences statio
-  - queries:
-    - query: SELECT
-                COUNT(blks_read) AS blks_read,
-                COUNT(blks_hit) AS blks_hit
-              FROM pg_statio_all_sequences;
-      version: 10
-      columns:
-        - name: blks_read
-          type: counter
-          description: Number of disk blocks read from sequences in postgres db.
-        - name: blks_hit
-          type: counter
-          description: Number of buffer hits read from sequences in postgres db.
-    tag: pg_statio_all_sequences
-    collector: statio_all_sequences
-
-# Stat user functions
-  - queries:
-    - query: SELECT
-                funcname,
-                calls,
-                self_time,
-                total_time
-              FROM pg_stat_user_functions;
-      version: 10
-      columns:
-        - name: funcname
-          type: label
-        - name: calls
-          type: counter
-          description: Number of times function is called.
-        - name: self_time
-          type: counter
-          description: Total time spent in milliseconds on the function itself.
-        - name: total_time
-          type: counter
-          description: Total time spent in milliseconds by the function and any other functions called by it.
-    tag: pg_stat_user_functions
-    sort: data
-    collector: stat_user_functions
-
-# Number of streaming WAL connections per application.
-  - queries:
-    - query: SELECT COUNT(*), application_name
-              FROM pg_stat_replication
-              WHERE state = 'streaming'
-              GROUP BY application_name;
-      version: 10
-      columns:
-        - type: gauge
-          description: Number of streaming WAL connections per application.
-        - name: application_name
-          type: label
-    tag: pg_stat_replication
-    sort: data
-    collector: stat_replication
-
-  - queries:
-    - query: SELECT
-                archived_count,
-                (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms,
-                failed_count,
-                (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms
-              FROM pg_stat_archiver;
-      version: 10
-      columns:
-        - type: counter
-          name: archived_count
-          description: Number of successful archived WAL files.
-        - type: counter
-          name: success_time_elapsed_ms
-          description: Milliseconds since successful archived WAL file.
-        - type: counter
-          name: failed_count
-          description: Number of failed archival operation on WAL files.
-        - type: counter
-          name: failure_time_elapsed_ms
-          description: Milliseconds since last failed archival operation on WAL files.
-    tag: pg_stat_archiver
-    sort: data
-    collector: stat_archiver
-
-  - queries:
-    - query: SELECT
-                datname,
-                age(datfrozenxid) as age
-              FROM pg_database;
-      version: 10
-      columns:
-        - type: label
-          name: datname
-          description: Database name.
-        - type: counter
-          name: age
-          description: Age since last vaccum.
-    tag: pg_db_vacuum
-    sort: data
-    collector: db_vacuum
-
-  - queries:
-    - query: SELECT
-                c.oid::regclass as table_name,
-                greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age
-              FROM pg_class c
-              LEFT JOIN pg_class t ON c.reltoastrelid = t.oid
-              WHERE c.relkind IN ('r', 'm');
-      version: 10
-      columns:
-        - type: label
-          name: datname
-          description: View name.
-        - type: counter
-          name: age
-          description: Age since last vaccum.
-    tag: pg_view_vacuum
-    sort: data
-    collector: db_vacuum
-# Blocked vacuum operations
-  - queries:
-    - query: SELECT
-                blocked.pid AS blocked_pid,
-                blocked.datname AS blocked_database,
-                blocked.usename AS blocked_user,
-                blocked.query AS blocked_query,
-                EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds,
-                blocking.pid AS blocking_pid,
-                blocking.datname AS blocking_database,
-                blocking.usename AS blocking_user,
-                blocking.query AS blocking_query,
-                EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds
-              FROM pg_stat_activity blocked
-              JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
-              JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation
-                AND blocked_locks.pid != blocking_locks.pid
-              JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid
-              WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%')
-                AND NOT blocked_locks.granted
-                AND blocking_locks.granted
-              ORDER BY blocked_duration_seconds DESC;
-      version: 10
-      columns:
-        - name: blocked_pid
-          type: label
-        - name: blocked_database
-          type: label
-        - name: blocked_user
-          type: label
-        - name: blocked_query
-          type: label
-        - name: blocked_duration_seconds
-          type: gauge
-          description: Duration in seconds that the vacuum has been blocked
-        - name: blocking_pid
-          type: label
-        - name: blocking_database
-          type: label
-        - name: blocking_user
-          type: label
-        - name: blocking_query
-          type: label
-        - name: blocking_duration_seconds
-          type: gauge
-          description: Duration in seconds that the blocking query has been running
-    tag: pg_blocked_vacuum
-    sort: data
-    collector: blocked_vacuum
-#
-# PostgreSQL 11
-#
-
-# WAL last sent
-  - queries:
-    - query: SELECT
-              CASE
-                WHEN sender_host LIKE '/%' THEN sender_host
-                ELSE sender_host || ':' || sender_port::text
-              END AS sender,
-              (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms
-              FROM pg_stat_wal_receiver;
-      version: 11
-      columns:
-        - name: sender
-          type: label
-        - type: counter
-          description: Time since last message received from WAL sender
-    tag: pg_wal_last_received
-    collector: wal_last_received
-    server: replica
-
-#
-# PostgreSQL 12
-#
-
-# GSS Authenticated DB Connections
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE gss_authenticated = 't' AND datname IS NOT NULL;
-      version: 12
-      columns:
-        - type: gauge
-          description: Number of GSSAPI authenticated DB connections.
-    tag: pg_gss_auth
-    collector: gssapi
-
-# Encrypted DB Connections
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE encrypted = 't' AND datname IS NOT NULL;
-      version: 12
-      columns:
-        - type: gauge
-          description: Number of encrypted DB connections.
-    tag: pg_encrypted_conn
-    collector: encryted_conns
-
-#
-# PostgreSQL 13
-#
-
-# Shared memory histogram
-  - queries:
-    - query: SELECT
-                SUM(sum) AS size_sum,
-                '1' AS size_count,
-                array_agg((bucket - 1) * (50000))::int[] AS size,
-                array_agg(count)::int[] AS size_bucket
-              FROM (
-                  SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size)
-                  FROM pg_shmem_allocations
-                  GROUP BY bucket
-                  ORDER BY bucket
-              ) t;
-      version: 13
-      columns:
-        - name: size
-          type: histogram
-          description: Histogram of shared memory sizes.
-    tag: pg_shmem_allocations
-    collector: shmem_size
-# Vacuum progress information
-  - queries:
-    - query: SELECT
-                p.pid,
-                a.datname,
-                a.usename,
-                a.query,
-                p.phase,
-                p.heap_blks_total,
-                p.heap_blks_scanned,
-                p.heap_blks_vacuumed,
-                p.index_vacuum_count,
-                p.max_dead_tuples,
-                p.num_dead_tuples,
-                CASE WHEN p.heap_blks_total > 0
-                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
-                     ELSE 0
-                END AS pct_scan_completed
-              FROM pg_stat_progress_vacuum p
-              JOIN pg_stat_activity a USING (pid)
-              ORDER BY p.pid;
-      version: 13
-      columns:
-        - name: pid
-          type: label
-        - name: datname
-          type: label
-        - name: usename
-          type: label
-        - name: query
-          type: label
-        - name: phase
-          type: label
-        - name: heap_blks_total
-          type: gauge
-          description: Total heap blocks in table
-        - name: heap_blks_scanned
-          type: gauge
-          description: Heap blocks scanned
-        - name: heap_blks_vacuumed
-          type: gauge
-          description: Heap blocks vacuumed
-        - name: index_vacuum_count
-          type: gauge
-          description: Number of index vacuum cycles completed
-        - name: max_dead_tuples
-          type: gauge
-          description: Maximum dead tuples
-        - name: num_dead_tuples
-          type: gauge
-          description: Current dead tuples
-        - name: pct_scan_completed
-          type: gauge
-          description: Vacuum scan progress percentage
-
-    - query: SELECT
-                p.pid,
-                a.datname,
-                a.usename,
-                a.query,
-                p.phase,
-                p.heap_blks_total,
-                p.heap_blks_scanned,
-                p.heap_blks_vacuumed,
-                p.index_vacuum_count,
-                p.max_dead_tuple_bytes,
-                p.dead_tuple_bytes,
-                p.num_dead_item_ids,
-                p.indexes_total,
-                p.indexes_processed,
-                CASE WHEN p.heap_blks_total > 0
-                     THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2)
-                     ELSE 0
-                END AS pct_scan_completed,
-                CASE WHEN p.indexes_total > 0
-                     THEN round(100 * p.indexes_processed / p.indexes_total, 2)
-                     ELSE 0
-                END AS pct_index_completed
-              FROM pg_stat_progress_vacuum p
-              JOIN pg_stat_activity a USING (pid)
-              ORDER BY p.pid;
-      version: 17
-      columns:
-        - name: pid
-          type: label
-        - name: datname
-          type: label
-        - name: usename
-          type: label
-        - name: query
-          type: label
-        - name: phase
-          type: label
-        - name: heap_blks_total
-          type: gauge
-          description: Total heap blocks in table
-        - name: heap_blks_scanned
-          type: gauge
-          description: Heap blocks scanned
-        - name: heap_blks_vacuumed
-          type: gauge
-          description: Heap blocks vacuumed
-        - name: index_vacuum_count
-          type: gauge
-          description: Number of index vacuum cycles completed
-        - name: max_dead_tuple_bytes
-          type: gauge
-          description: Maximum dead tuple bytes
-        - name: dead_tuple_bytes
-          type: gauge
-          description: Current dead tuple bytes
-        - name: num_dead_item_ids
-          type: gauge
-          description: Number of dead item identifiers
-        - name: indexes_total
-          type: gauge
-          description: Total number of indexes
-        - name: indexes_processed
-          type: gauge
-          description: Number of indexes processed
-        - name: pct_scan_completed
-          type: gauge
-          description: Vacuum scan progress percentage
-        - name: pct_index_completed
-          type: gauge
-          description: Index processing progress percentage
-    tag: pg_stat_progress_vacuum
-    sort: data
-    collector: vacuum_progress
-# Table-level vacuum and analyze statistics
-  - queries:
-    - query: SELECT
-                schemaname,
-                relname,
-                n_live_tup,
-                n_dead_tup,
-                CASE 
-                  WHEN n_live_tup > 0 
-                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
-                  ELSE 0
-                END AS dead_rows_pct,
-                n_mod_since_analyze,
-                n_ins_since_vacuum,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
-                vacuum_count,
-                autovacuum_count,
-                analyze_count,
-                autoanalyze_count
-              FROM pg_stat_user_tables
-              ORDER BY n_dead_tup DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: n_live_tup
-          type: gauge
-          description: Estimated number of live rows
-        - name: n_dead_tup
-          type: gauge
-          description: Estimated number of dead rows
-        - name: dead_rows_pct
-          type: gauge
-          description: Percentage of dead rows relative to live rows
-        - name: n_mod_since_analyze
-          type: gauge
-          description: Estimated number of rows modified since last analyze
-        - name: n_ins_since_vacuum
-          type: gauge
-          description: Estimated number of rows inserted since last vacuum
-        - name: last_vacuum_seconds
-          type: gauge
-          description: Seconds since last manual vacuum (-1 if never)
-        - name: last_autovacuum_seconds
-          type: gauge
-          description: Seconds since last autovacuum (-1 if never)
-        - name: last_analyze_seconds
-          type: gauge
-          description: Seconds since last manual analyze (-1 if never)
-        - name: last_autoanalyze_seconds
-          type: gauge
-          description: Seconds since last autoanalyze (-1 if never)
-        - name: vacuum_count
-          type: counter
-          description: Number of times this table has been manually vacuumed
-        - name: autovacuum_count
-          type: counter
-          description: Number of times this table has been vacuumed by autovacuum
-        - name: analyze_count
-          type: counter
-          description: Number of times this table has been manually analyzed
-        - name: autoanalyze_count
-          type: counter
-          description: Number of times this table has been analyzed by autoanalyze
-
-    - query: SELECT
-                schemaname,
-                relname,
-                seq_scan,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds,
-                seq_tup_read,
-                idx_scan,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds,
-                idx_tup_fetch,
-                n_tup_ins,
-                n_tup_upd,
-                n_tup_del,
-                n_tup_hot_upd,
-                n_tup_newpage_upd,
-                n_live_tup,
-                n_dead_tup,
-                CASE 
-                  WHEN n_live_tup > 0 
-                  THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2)
-                  ELSE 0
-                END AS dead_rows_pct,
-                n_mod_since_analyze,
-                n_ins_since_vacuum,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds,
-                COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
-                vacuum_count,
-                autovacuum_count,
-                analyze_count,
-                autoanalyze_count
-              FROM pg_stat_user_tables
-              ORDER BY n_dead_tup DESC;
-      version: 16
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: seq_scan
-          type: counter
-          description: Number of sequential scans initiated on this table
-        - name: last_seq_scan_seconds
-          type: gauge
-          description: Seconds since last sequential scan (-1 if never)
-        - name: seq_tup_read
-          type: counter
-          description: Number of live rows fetched by sequential scans
-        - name: idx_scan
-          type: counter
-          description: Number of index scans initiated on this table
-        - name: last_idx_scan_seconds
-          type: gauge
-          description: Seconds since last index scan (-1 if never)
-        - name: idx_tup_fetch
-          type: counter
-          description: Number of live rows fetched by index scans
-        - name: n_tup_ins
-          type: counter
-          description: Number of rows inserted
-        - name: n_tup_upd
-          type: counter
-          description: Number of rows updated
-        - name: n_tup_del
-          type: counter
-          description: Number of rows deleted
-        - name: n_tup_hot_upd
-          type: counter
-          description: Number of rows HOT updated
-        - name: n_tup_newpage_upd
-          type: counter
-          description: Number of rows updated where successor goes to new heap page
-        - name: n_live_tup
-          type: gauge
-          description: Estimated number of live rows
-        - name: n_dead_tup
-          type: gauge
-          description: Estimated number of dead rows
-        - name: dead_rows_pct
-          type: gauge
-          description: Percentage of dead rows relative to live rows
-        - name: n_mod_since_analyze
-          type: gauge
-          description: Estimated number of rows modified since last analyze
-        - name: n_ins_since_vacuum
-          type: gauge
-          description: Estimated number of rows inserted since last vacuum
-        - name: last_vacuum_seconds
-          type: gauge
-          description: Seconds since last manual vacuum (-1 if never)
-        - name: last_autovacuum_seconds
-          type: gauge
-          description: Seconds since last autovacuum (-1 if never)
-        - name: last_analyze_seconds
-          type: gauge
-          description: Seconds since last manual analyze (-1 if never)
-        - name: last_autoanalyze_seconds
-          type: gauge
-          description: Seconds since last autoanalyze (-1 if never)
-        - name: vacuum_count
-          type: counter
-          description: Number of times this table has been manually vacuumed
-        - name: autovacuum_count
-          type: counter
-          description: Number of times this table has been vacuumed by autovacuum
-        - name: analyze_count
-          type: counter
-          description: Number of times this table has been manually analyzed
-        - name: autoanalyze_count
-          type: counter
-          description: Number of times this table has been analyzed by autoanalyze
-    tag: pg_stat_user_tables_vacuum
-    sort: data
-    collector: stat_user_tables
-    database: all
-
-# Table read/write activity ratios
-  - queries:
-    - query: WITH table_activity AS (
-                SELECT
-                  s.schemaname,
-                  s.relname,
-                  si.heap_blks_read + si.idx_blks_read AS blocks_read,
-                  s.seq_tup_read + s.idx_tup_fetch AS tuples_read,
-                  c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) /
-                    CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write,
-                  s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write
-                FROM pg_stat_user_tables AS s
-                JOIN pg_statio_user_tables AS si ON s.relid = si.relid
-                JOIN pg_class c ON c.oid = s.relid
-                WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0
-                  AND (si.heap_blks_read + si.idx_blks_read) > 0
-              )
-              SELECT
-                schemaname,
-                relname,
-                blocks_read,
-                tuples_read,
-                blocks_write,
-                tuples_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int
-                END AS ratio_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int
-                END AS ratio_read
-              FROM table_activity
-              ORDER BY (blocks_read + blocks_write) DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: blocks_read
-          type: counter
-          description: Total blocks read from disk (heap + index)
-        - name: tuples_read
-          type: counter
-          description: Total number of tuples read (sequential + index scans)
-        - name: blocks_write
-          type: gauge
-          description: Estimated blocks affected by write operations
-        - name: tuples_write
-          type: counter
-          description: Total number of tuples inserted, updated, or deleted
-        - name: ratio_write
-          type: gauge
-          description: Percentage of I/O activity that is writes (0-100)
-        - name: ratio_read
-          type: gauge
-          description: Percentage of I/O activity that is reads (0-100)
-    tag: pg_table_ratio
-    sort: data
-    collector: table_activity_ratio
-    database: all
-
-# Table bloat analysis
-  - queries:
-    - query: SELECT
-                schemaname,
-                tblname,
-                real_size AS table_size,
-                extra_size AS bloat_size,
-                ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct,
-                tblpages,
-                est_tblpages,
-                bs AS block_size
-              FROM (
-                SELECT
-                  schemaname,
-                  tblname,
-                  bs*tblpages AS real_size,
-                  (tblpages-est_tblpages)*bs AS extra_size,
-                  CASE WHEN tblpages > 0
-                    THEN 100 * (tblpages-est_tblpages)/tblpages::numeric
-                    ELSE 0
-                  END AS extra_ratio,
-                  tblpages,
-                  est_tblpages,
-                  bs
-                FROM (
-                  SELECT
-                    n.nspname AS schemaname,
-                    c.relname AS tblname,
-                    c.relpages AS tblpages,
-                    CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages,
-                    current_setting('block_size')::integer AS bs
-                  FROM pg_class c
-                  JOIN pg_namespace n ON n.oid = c.relnamespace
-                  WHERE c.relkind = 'r'
-                  AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
-                  AND n.nspname NOT LIKE 'pg_temp_%'
-                ) AS bloat_calc
-              ) AS bloat_summary
-              WHERE tblpages > 0
-              ORDER BY extra_size DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: tblname
-          type: label
-        - name: table_size
-          type: gauge
-          description: Actual table size in bytes
-        - name: bloat_size
-          type: gauge
-          description: Estimated bloat size in bytes
-        - name: bloat_ratio_pct
-          type: gauge
-          description: Bloat ratio as percentage
-        - name: tblpages
-          type: gauge
-          description: Actual number of pages used by table
-        - name: est_tblpages
-          type: gauge
-          description: Estimated number of pages needed
-        - name: block_size
-          type: gauge
-          description: Database block size in bytes
-    tag: pg_table_bloat
-    sort: data
-    collector: table_bloat
-    database: all
-#
-# PostgreSQL 14
-#
-
-# Memory context information
-  - queries:
-    - query: SELECT
-                COUNT(*) AS contexts,
-                parent,
-                SUM(free_bytes) AS free_bytes,
-                SUM(used_bytes) AS used_bytes,
-                SUM(total_bytes) AS total_bytes
-              FROM pg_backend_memory_contexts
-              WHERE parent!=''
-              GROUP BY parent;
-      version: 14
-      columns:
-        - name: contexts
-          type: gauge
-          description: Number of memory contexts per parent.
-        - name: parent
-          type: label
-        - name: free_bytes
-          type: gauge
-          description: Free bytes per memory context.
-        - name: used_bytes
-          type: gauge
-          description: Used bytes per memory context.
-        - name: total_bytes
-          type: gauge
-          description: Total bytes per memory context.
-    tag: pg_mem_ctx
-    collector: mem_ctx
-
-# Memory context information
-  - queries:
-    - query: SELECT
-                wal_records,
-                wal_fpi,
-                wal_bytes,
-                wal_buffers_full,
-                wal_write,
-                wal_sync,
-                wal_write_time,
-                wal_sync_time
-              FROM pg_stat_wal;
-      version: 14
-      columns:
-        - name: wal_records
-          type: counter
-          description: Number of WAL records generated.
-        - name: wal_fpi
-          type: counter
-          description: Number of WAL full page images generated.
-        - name: wal_bytes
-          type: counter
-          description: Total bytes of generated WAL.
-        - name: wal_buffers_full
-          type: counter
-          description: Number of disk writes due to WAL buffers being full.
-        - name: wal_write
-          type: counter
-          description: Number of times WAL files were written to disk.
-        - name: wal_sync
-          type: counter
-          description: Number of times WAL files were synced to disk.
-        - name: wal_write_time
-          type: counter
-          description: Time taken for WAL files to be written to disk.
-        - name: wal_sync_time
-          type: counter
-          description: Time taken for WAL files to be synced to disk.
-    tag: pg_stat_wal
-    collector: stat_wal
-
-# stat_database_information()
-  - queries:
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends
-              FROM pg_stat_database
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-      version: 10
-
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends,
-                checksum_failures
-              FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-        - name: checksum_failures
-          type: gauge
-          description: pg_stat_database_checksum_failures
-      version: 12
-
-    - query: SELECT
-                datname,
-                blk_read_time,
-                blk_write_time,
-                blks_hit,
-                blks_read,
-                deadlocks,
-                temp_files,
-                temp_bytes,
-                tup_returned,
-                tup_fetched,
-                tup_inserted,
-                tup_updated,
-                tup_deleted,
-                xact_commit,
-                xact_rollback,
-                conflicts,
-                numbackends,
-                checksum_failures,
-                session_time,
-                active_time,
-                idle_in_transaction_time,
-                sessions,
-                sessions_abandoned,
-                sessions_fatal,
-                sessions_killed
-              FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
-      version: 14
-      columns:
-        - name: database
-          type: label
-        - name: blk_read_time
-          type: counter
-          description: pg_stat_database_blk_read_time
-        - name: blk_write_time
-          type: counter
-          description: pg_stat_database_blk_write_time
-        - name: blks_hit
-          type: counter
-          description: pg_stat_database_blks_hit
-        - name: blks_read
-          type: counter
-          description: pg_stat_database_blks_read
-        - name: deadlocks
-          type: counter
-          description: pg_stat_database_deadlocks
-        - name: temp_files
-          type: gauge
-          description: pg_stat_database_temp_files
-        - name: temp_bytes
-          type: gauge
-          description: pg_stat_database_temp_bytes
-        - name: tup_returned
-          type: counter
-          description: pg_stat_database_tup_returned
-        - name: tup_fetched
-          type: counter
-          description: pg_stat_database_tup_fetched
-        - name: tup_inserted
-          type: counter
-          description: pg_stat_database_tup_inserted
-        - name: tup_updated
-          type: counter
-          description: pg_stat_database_tup_updated
-        - name: tup_deleted
-          type: counter
-          description: pg_stat_database_tup_deleted
-        - name: xact_commit
-          type: counter
-          description: pg_stat_database_xact_commit
-        - name: xact_rollback
-          type: counter
-          description: pg_stat_database_xact_rollback
-        - name: conflicts
-          type: counter
-          description: pg_stat_database_conflicts
-        - name: numbackends
-          type: gauge
-          description: pg_stat_database_numbackends
-        - name: checksum_failures
-          type: gauge
-          description: pg_stat_database_checksum_failures
-        - name: session_time
-          type: gauge
-          description: pg_stat_database_session_time
-        - name: active_time
-          type: gauge
-          description: pg_stat_database_active_time
-        - name: idle_in_transaction_time
-          type: gauge
-          description: pg_stat_database_idle_in_transaction_time
-        - name: sessions
-          type: gauge
-          description: pg_stat_database_sessions
-        - name: sessions_abandoned
-          type: gauge
-          description: pg_stat_database_sessions_abandoned
-        - name: sessions_fatal
-          type: gauge
-          description: pg_stat_database_sessions_fatal
-        - name: sessions_killed
-          type: gauge
-          description: pg_stat_database_sessions_killed
-    tag: pg_stat_database
-    collector: stat_db
-
-#
-# PostgreSQL 15
-#
-
-# WAL prefetch last stat reset
-  - queries:
-    - query: SELECT
-                FLOOR(
-                  EXTRACT(
-                    EPOCH FROM (now() - stats_reset)
-                  )
-                )
-              FROM pg_stat_recovery_prefetch;
-      version: 15
-      columns:
-        - type: counter
-          description: Seconds from last WAL prefetch stats reset.
-    tag: pg_wal_prefetch_reset
-    collector: wal_prefetch_reset
-
-#
-# PostgreSQL 16
-#
-
-# GSS API Credentials Delegated to DB Connection
-  - queries:
-    - query: SELECT COUNT(*)
-              FROM pg_stat_gssapi
-              JOIN pg_stat_activity
-              ON pg_stat_gssapi.pid = pg_stat_activity.pid
-              WHERE credentials_delegated = 't' AND datname IS NOT NULL;
-      columns:
-        - type: gauge
-          description: Number of DB connections with delegated GSSAPI credentials.
-    tag: pg_gssapi_credentials_delegated
-    collector: gssapi_creds_delegated
-
-# pg_stat_io
-  - queries:
-    - query: SELECT
-                backend_type,
-                SUM(COALESCE(reads, 0)) AS reads,
-                SUM(COALESCE(read_time, 0)) AS read_time,
-                SUM(COALESCE(writes, 0)) AS writes,
-                SUM(COALESCE(write_time, 0)) AS write_time,
-                SUM(COALESCE(writebacks, 0)) AS writebacks,
-                SUM(COALESCE(writeback_time, 0)) AS writeback_time,
-                SUM(COALESCE(extends, 0)) AS extends,
-                SUM(COALESCE(extend_time, 0)) AS extend_time,
-                AVG(COALESCE(op_bytes, 0)) AS op_bytes,
-                SUM(COALESCE(hits, 0)) AS hits,
-                SUM(COALESCE(evictions, 0)) AS evictions,
-                SUM(COALESCE(reuses, 0)) AS reuses,
-                SUM(COALESCE(fsyncs, 0)) AS fsyncs,
-                SUM(COALESCE(fsync_time, 0)) AS fsync_time
-              FROM pg_stat_io
-              GROUP BY backend_type;
-      columns:
-        - name: backend_type
-          type: label
-        - name: reads
-          type: counter
-          description: Number of read operations.
-        - name: read_time
-          type: counter
-          description: Total time spent on read operations in milliseconds.
-        - name: writes
-          type: counter
-          description: Number of write operations.
-        - name: write_time
-          type: counter
-          description: Total time spent on write operations in milliseconds.
-        - name: writebacks
-          type: counter
-          description: Number of writeback to permanent storage requests sent to kernel.
-        - name: writeback_time
-          type: counter
-          description: Total time spent on writeback operations in milliseconds.
-        - name: extends
-          type: counter
-          description: Number of relation extend operations.
-        - name: extend_time
-          type: counter
-          description: Total time spent on relation extend operations in milliseconds.
-        - name: op_bytes
-          type: gauge
-          description: Bytes per unit of I/O read, written or extended.
-        - name: hits
-          type: counter
-          description: The number of times a desired block was found in shared buffer.
-        - name: evictions
-          type: counter
-          description: The number of times a block has been written out from shared or local buffer in order to make it available for another use.
-        - name: reuses
-          type: counter
-          description: The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation.
-        - name: fsyncs
-          type: counter
-          description: Number of fsync calls.
-        - name: fsync_time
-          type: counter
-          description: Total time spent on fsync operations in milliseconds.
-    tag: pg_stat_io
-    collector: stat_io
-
-# stat_database_conflicts_information()
-  - queries:
-    - query: SELECT datname,
-                confl_tablespace,
-                confl_lock,
-                confl_snapshot,
-                confl_bufferpin,
-                confl_deadlock
-              FROM pg_stat_database_conflicts
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: confl_tablespace
-          type: counter
-          description: pg_stat_database_conflicts_confl_tablespace
-        - name: confl_lock
-          type: counter
-          description: pg_stat_database_conflicts_confl_lock
-        - name: confl_snapshot
-          type: counter
-          description: pg_stat_database_conflicts_confl_snapshot
-        - name: confl_bufferpin
-          type: counter
-          description: pg_stat_database_conflicts_confl_bufferpin
-        - name: confl_deadlock
-          type: counter
-          description: pg_stat_database_conflicts_confl_deadlock
-      version: 10
-
-    - query: SELECT datname,
-                confl_tablespace,
-                confl_lock,
-                confl_snapshot,
-                confl_bufferpin,
-                confl_deadlock,
-                confl_active_logicalslot
-              FROM pg_stat_database_conflicts
-              WHERE datname IS NOT NULL
-              ORDER BY datname;
-      columns:
-        - name: database
-          type: label
-        - name: confl_tablespace
-          type: counter
-          description: pg_stat_database_conflicts_confl_tablespace
-        - name: confl_lock
-          type: counter
-          description: pg_stat_database_conflicts_confl_lock
-        - name: confl_snapshot
-          type: counter
-          description: pg_stat_database_conflicts_confl_snapshot
-        - name: confl_bufferpin
-          type: counter
-          description: pg_stat_database_conflicts_confl_bufferpin
-        - name: confl_deadlock
-          type: counter
-          description: pg_stat_database_conflicts_confl_dead
-        - name: confl_active_logicalslot
-          type: counter
-          description: pg_stat_database_conflicts_confl_active_logicalslot
-    tag: pg_stat_database_conflicts
-    sort: data
-    collector: stat_conflicts
-
-  - queries:
-    - query: SELECT
-                SUM(idx_scan) AS idx_scans,
-                SUM(idx_tup_read) AS idx_tup_reads,
-                SUM(idx_tup_fetch) AS idx_tup_fetchs,
-                relname
-              FROM pg_stat_all_indexes
-              GROUP BY relname;
-      columns:
-        - type: counter
-          name: idx_scans
-          description: Number of index scans on the table's indexes.
-        - type: counter
-          name: idx_tup_reads
-          description: Number of index entries returned by scans on the table's indexes.
-        - type: counter
-          name: idx_tup_fetchs
-          description: Number of rows fetched by simple index scans on the table's indexes.
-        - type: label
-          name: relname
-      version: 10
-
-    - query: SELECT
-                SUM(idx_scan) AS idx_scans,
-                SUM(idx_tup_read) AS idx_tup_reads,
-                SUM(idx_tup_fetch) AS idx_tup_fetchs,
-                COALESCE(MIN((EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms,
-                relname
-              FROM pg_stat_all_indexes
-              WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%')
-              GROUP BY relname;
-      columns:
-        - type: counter
-          name: idx_scans
-          description: Number of index scans on the table's indexes.
-        - type: counter
-          name: idx_tup_reads
-          description: Number of index entries returned by scans on the table's indexes.
-        - type: counter
-          name: idx_tup_fetchs
-          description: Number of rows fetched by simple index scans on the table's indexes.
-        - type: counter
-          name: time_elapsed_ms
-          description: Milliseconds since last scan of an index in the table.
-        - type: label
-          name: relname
-    tag: pg_stat_all_indexes
-    sort: data
-    collector: stat_all_indexes
-    database: all
-#
-# PostgreSQL 17
-#
-  - queries:
-    - query: SELECT
-                type,
-                count(*) as count
-               FROM pg_wait_events
-               GROUP BY type
-               ORDER BY count DESC;
-      columns:
-        - name: type
-          type: label
-        - name: count
-          type: gauge
-          description: pg_wait_events_count
-    tag: pg_wait_events
-    sort: data
-    collector: wait_events 
+- tag: postgresql_primary
+  collector: primary
+  sort: name
+  server: both
+  queries:
+  - query: SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );
+    version: 10
+    columns:
+    - description: Is the PostgreSQL instance the primary
+      type: gauge
+- tag: pg_database_size
+  collector: db
+  sort: data
+  queries:
+  - query: SELECT datname, pg_database_size(datname) FROM pg_database;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - description: Size of the database
+      type: gauge
+- tag: pg_locks_count
+  collector: locks
+  sort: data
+  queries:
+  - query: SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - name: mode
+      type: label
+    - description: Lock count of a database
+      type: gauge
+- tag: pg_replication_slots
+  collector: replication
+  sort: data
+  queries:
+  - query: SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;
+    version: 10
+    columns:
+    - name: slot_name
+      type: label
+    - name: slot_type
+      type: label
+    - name: database
+      type: label
+    - description: Is the replication active
+      name: active
+      type: gauge
+    - description: Is the replication temporary
+      name: temporary
+      type: gauge
+- tag: pg_stat_bgwriter
+  collector: stat_bgwriter
+  queries:
+  - query: SELECT buffers_alloc, buffers_clean, maxwritten_clean FROM pg_stat_bgwriter;
+    version: 17
+    columns:
+    - description: pg_stat_bgwriter_buffers_alloc
+      name: buffers_alloc
+      type: gauge
+    - description: pg_stat_bgwriter_buffers_clean
+      name: buffers_clean
+      type: gauge
+    - description: pg_stat_bgwriter_maxwritten_clean
+      name: maxwritten_clean
+      type: counter
+- tag: pg_process_idle_seconds
+  collector: idle_procs
+  queries:
+  - query: WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;
+    version: 10
+    columns:
+    - name: application_name
+      type: label
+    - name: seconds
+      type: histogram
+      description: Histogram of idle processes
+- tag: pg_available_extensions
+  collector: available_extensions
+  queries:
+  - query: SELECT COUNT(*) AS extensions FROM pg_available_extensions;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of available extensions for installation.
+- tag: pg_installed_extensions
+  collector: installed_extensions
+  queries:
+  - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
+    version: 10
+    columns:
+    - name: extensions
+      type: label
+    - type: gauge
+      description: Number of installed extensions.
+- tag: pg_file_settings
+  collector: file_settings
+  sort: data
+  queries:
+  - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
+    version: 10
+    columns:
+    - name: sourcefile
+      type: label
+    - type: gauge
+      description: Settings that are applied.
+    - name: applied
+      type: label
+- tag: pg_indexes
+  collector: indexes
+  sort: data
+  queries:
+  - query: SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;
+    version: 10
+    columns:
+    - name: schemaname
+      type: label
+    - name: tablename
+      type: label
+    - type: gauge
+      description: Indexes for each schemaname for each tablename.
+- tag: pg_matviews
+  collector: matviews
+  queries:
+  - query: SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of applied Materialized views.
+- tag: pg_role
+  collector: roles
+  queries:
+  - query: SELECT COUNT(*) FROM pg_roles;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of roles.
+- tag: pg_rule
+  collector: rules
+  sort: data
+  queries:
+  - query: SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;
+    version: 10
+    columns:
+    - name: tablename
+      type: label
+    - type: gauge
+      description: Number of rules in table.
+- tag: pg_shadow
+  collector: auth_type
+  sort: data
+  queries:
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+    version: 10
+    columns:
+    - name: encryption_type
+      type: label
+    - type: gauge
+      description: Number of users with authentication type.
+- tag: pg_usr_evt_trigger
+  collector: usr_evt_trigger
+  queries:
+  - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of user defined event triggers.
+- tag: pg_db_conn
+  collector: connections
+  sort: data
+  queries:
+  - query: SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - type: gauge
+      description: Number of database connections.
+- tag: pg_db_conn_ssl
+  collector: connections
+  sort: data
+  queries:
+  - query: SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;
+    version: 10
+    columns:
+    - name: database
+      type: label
+    - type: gauge
+      description: Number of DB connections with SSL.
+- tag: pg_statio_all_tables
+  collector: statio_all_tables
+  queries:
+  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+    version: 10
+    columns:
+    - name: heap_blks_read
+      type: counter
+      description: Number of disk blocks read in postgres db.
+    - name: heap_blks_hit
+      type: counter
+      description: Number of buffer hits read in postgres db.
+    - name: idx_blks_read
+      type: counter
+      description: Number of disk blocks reads from all indexes in postgres db.
+    - name: idx_blks_hit
+      type: counter
+      description: Number of buffer hits read from all indexes in postgres db.
+    - name: toast_blks_read
+      type: counter
+      description: Number of disk blocks reads from postgres db's TOAST tables.
+    - name: toast_blks_hit
+      type: counter
+      description: Number of buffer hits read from postgres db's TOAST tables.
+    - name: tidx_blks_read
+      type: counter
+      description: Number of disk blocks reads from postgres db's TOAST table indexes.
+    - name: tidx_blks_hit
+      type: counter
+      description: Number of buffer hits read from postgres db's TOAST table indexes.
+- tag: pg_statio_all_sequences
+  collector: statio_all_sequences
+  queries:
+  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+    version: 10
+    columns:
+    - name: blks_read
+      type: counter
+      description: Number of disk blocks read from sequences in postgres db.
+    - name: blks_hit
+      type: counter
+      description: Number of buffer hits read from sequences in postgres db.
+- tag: pg_stat_user_functions
+  collector: stat_user_functions
+  sort: data
+  queries:
+  - query: SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;
+    version: 10
+    columns:
+    - name: funcname
+      type: label
+    - name: calls
+      type: counter
+      description: Number of times function is called.
+    - name: self_time
+      type: counter
+      description: Total time spent in milliseconds on the function itself.
+    - name: total_time
+      type: counter
+      description: Total time spent in milliseconds by the function and any other functions called by it.
+- tag: pg_stat_replication
+  collector: stat_replication
+  sort: data
+  queries:
+  - query: SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;
+    version: 10
+    columns:
+    - type: gauge
+      description: Number of streaming WAL connections per application.
+    - name: application_name
+      type: label
+- tag: pg_stat_archiver
+  collector: stat_archiver
+  sort: data
+  queries:
+  - query: SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;
+    version: 10
+    columns:
+    - type: counter
+      name: archived_count
+      description: Number of successful archived WAL files.
+    - type: counter
+      name: success_time_elapsed_ms
+      description: Milliseconds since successful archived WAL file.
+    - type: counter
+      name: failed_count
+      description: Number of failed archival operation on WAL files.
+    - type: counter
+      name: failure_time_elapsed_ms
+      description: Milliseconds since last failed archival operation on WAL files.
+- tag: pg_db_vacuum
+  collector: db_vacuum
+  sort: data
+  queries:
+  - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
+    version: 10
+    columns:
+    - type: label
+      name: datname
+      description: Database name.
+    - type: counter
+      name: age
+      description: Age since last vaccum.
+- tag: pg_view_vacuum
+  collector: db_vacuum
+  sort: data
+  queries:
+  - query: SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');
+    version: 10
+    columns:
+    - type: label
+      name: datname
+      description: View name.
+    - type: counter
+      name: age
+      description: Age since last vaccum.
+- tag: pg_blocked_vacuum
+  collector: blocked_vacuum
+  sort: data
+  queries:
+  - query: SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;
+    version: 10
+    columns:
+    - name: blocked_pid
+      type: label
+    - name: blocked_database
+      type: label
+    - name: blocked_user
+      type: label
+    - name: blocked_query
+      type: label
+    - name: blocked_duration_seconds
+      type: gauge
+      description: Duration in seconds that the vacuum has been blocked
+    - name: blocking_pid
+      type: label
+    - name: blocking_database
+      type: label
+    - name: blocking_user
+      type: label
+    - name: blocking_query
+      type: label
+    - name: blocking_duration_seconds
+      type: gauge
+      description: Duration in seconds that the blocking query has been running
+- tag: pg_wal_last_received
+  collector: wal_last_received
+  server: replica
+  queries:
+  - query: SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;
+    version: 11
+    columns:
+    - name: sender
+      type: label
+    - type: counter
+      description: Time since last message received from WAL sender
+- tag: pg_gss_auth
+  collector: gssapi
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;
+    version: 12
+    columns:
+    - type: gauge
+      description: Number of GSSAPI authenticated DB connections.
+- tag: pg_encrypted_conn
+  collector: encryted_conns
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;
+    version: 12
+    columns:
+    - type: gauge
+      description: Number of encrypted DB connections.
+- tag: pg_shmem_allocations
+  collector: shmem_size
+  queries:
+  - query: SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;
+    version: 13
+    columns:
+    - name: size
+      type: histogram
+      description: Histogram of shared memory sizes.
+- tag: pg_stat_progress_vacuum
+  collector: vacuum_progress
+  sort: data
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuple_bytes, p.dead_tuple_bytes, p.num_dead_item_ids, p.indexes_total, p.indexes_processed, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed, CASE WHEN p.indexes_total > 0 THEN round(100 * p.indexes_processed / p.indexes_total, 2) ELSE 0 END AS pct_index_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 17
+    columns:
+    - name: pid
+      type: label
+    - name: datname
+      type: label
+    - name: usename
+      type: label
+    - name: query
+      type: label
+    - name: phase
+      type: label
+    - name: heap_blks_total
+      type: gauge
+      description: Total heap blocks in table
+    - name: heap_blks_scanned
+      type: gauge
+      description: Heap blocks scanned
+    - name: heap_blks_vacuumed
+      type: gauge
+      description: Heap blocks vacuumed
+    - name: index_vacuum_count
+      type: gauge
+      description: Number of index vacuum cycles completed
+    - name: max_dead_tuple_bytes
+      type: gauge
+      description: Maximum dead tuple bytes
+    - name: dead_tuple_bytes
+      type: gauge
+      description: Current dead tuple bytes
+    - name: num_dead_item_ids
+      type: gauge
+      description: Number of dead item identifiers
+    - name: indexes_total
+      type: gauge
+      description: Total number of indexes
+    - name: indexes_processed
+      type: gauge
+      description: Number of indexes processed
+    - name: pct_scan_completed
+      type: gauge
+      description: Vacuum scan progress percentage
+    - name: pct_index_completed
+      type: gauge
+      description: Index processing progress percentage
+- tag: pg_stat_progress_analyze
+  collector: analyze_progress
+  sort: data
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 13
+    columns:
+    - name: pid
+      type: label
+    - name: datname
+      type: label
+    - name: usename
+      type: label
+    - name: phase
+      type: label
+    - name: sample_blks_total
+      type: gauge
+      description: Total blocks to sample
+    - name: sample_blks_scanned
+      type: gauge
+      description: Blocks sampled so far
+    - name: ext_stats_total
+      type: gauge
+      description: Total extended statistics to compute
+    - name: ext_stats_computed
+      type: gauge
+      description: Extended statistics computed
+    - name: child_tables_total
+      type: gauge
+      description: Total child tables to analyze
+    - name: child_tables_done
+      type: gauge
+      description: Child tables analyzed
+    - name: pct_sample_completed
+      type: gauge
+      description: Percentage of sampling completed
+    - name: pct_child_tables_completed
+      type: gauge
+      description: Percentage of child tables completed
+- tag: pg_stat_user_tables_vacuum
+  collector: stat_user_tables
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, relname, seq_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds, seq_tup_read, idx_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_tup_newpage_upd, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;
+    version: 16
+    columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
+    - name: seq_scan
+      type: counter
+      description: Number of sequential scans initiated on this table
+    - name: last_seq_scan_seconds
+      type: gauge
+      description: Seconds since last sequential scan (-1 if never)
+    - name: seq_tup_read
+      type: counter
+      description: Number of live rows fetched by sequential scans
+    - name: idx_scan
+      type: counter
+      description: Number of index scans initiated on this table
+    - name: last_idx_scan_seconds
+      type: gauge
+      description: Seconds since last index scan (-1 if never)
+    - name: idx_tup_fetch
+      type: counter
+      description: Number of live rows fetched by index scans
+    - name: n_tup_ins
+      type: counter
+      description: Number of rows inserted
+    - name: n_tup_upd
+      type: counter
+      description: Number of rows updated
+    - name: n_tup_del
+      type: counter
+      description: Number of rows deleted
+    - name: n_tup_hot_upd
+      type: counter
+      description: Number of rows HOT updated
+    - name: n_tup_newpage_upd
+      type: counter
+      description: Number of rows updated where successor goes to new heap page
+    - name: n_live_tup
+      type: gauge
+      description: Estimated number of live rows
+    - name: n_dead_tup
+      type: gauge
+      description: Estimated number of dead rows
+    - name: dead_rows_pct
+      type: gauge
+      description: Percentage of dead rows relative to live rows
+    - name: n_mod_since_analyze
+      type: gauge
+      description: Estimated number of rows modified since last analyze
+    - name: n_ins_since_vacuum
+      type: gauge
+      description: Estimated number of rows inserted since last vacuum
+    - name: last_vacuum_seconds
+      type: gauge
+      description: Seconds since last manual vacuum (-1 if never)
+    - name: last_autovacuum_seconds
+      type: gauge
+      description: Seconds since last autovacuum (-1 if never)
+    - name: last_analyze_seconds
+      type: gauge
+      description: Seconds since last manual analyze (-1 if never)
+    - name: last_autoanalyze_seconds
+      type: gauge
+      description: Seconds since last autoanalyze (-1 if never)
+    - name: vacuum_count
+      type: counter
+      description: Number of times this table has been manually vacuumed
+    - name: autovacuum_count
+      type: counter
+      description: Number of times this table has been vacuumed by autovacuum
+    - name: analyze_count
+      type: counter
+      description: Number of times this table has been manually analyzed
+    - name: autoanalyze_count
+      type: counter
+      description: Number of times this table has been analyzed by autoanalyze
+- tag: pg_table_ratio
+  collector: table_activity_ratio
+  sort: data
+  database: all
+  queries:
+  - query: WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
+    - name: blocks_read
+      type: counter
+      description: Total blocks read from disk (heap + index)
+    - name: tuples_read
+      type: counter
+      description: Total number of tuples read (sequential + index scans)
+    - name: blocks_write
+      type: gauge
+      description: Estimated blocks affected by write operations
+    - name: tuples_write
+      type: counter
+      description: Total number of tuples inserted, updated, or deleted
+    - name: ratio_write
+      type: gauge
+      description: Percentage of I/O activity that is writes (0-100)
+    - name: ratio_read
+      type: gauge
+      description: Percentage of I/O activity that is reads (0-100)
+- tag: pg_table_bloat
+  collector: table_bloat
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: tblname
+      type: label
+    - name: table_size
+      type: gauge
+      description: Actual table size in bytes
+    - name: bloat_size
+      type: gauge
+      description: Estimated bloat size in bytes
+    - name: bloat_ratio_pct
+      type: gauge
+      description: Bloat ratio as percentage
+    - name: tblpages
+      type: gauge
+      description: Actual number of pages used by table
+    - name: est_tblpages
+      type: gauge
+      description: Estimated number of pages needed
+    - name: block_size
+      type: gauge
+      description: Database block size in bytes
+- tag: pg_mem_ctx
+  collector: mem_ctx
+  queries:
+  - query: SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;
+    version: 14
+    columns:
+    - name: contexts
+      type: gauge
+      description: Number of memory contexts per parent.
+    - name: parent
+      type: label
+    - name: free_bytes
+      type: gauge
+      description: Free bytes per memory context.
+    - name: used_bytes
+      type: gauge
+      description: Used bytes per memory context.
+    - name: total_bytes
+      type: gauge
+      description: Total bytes per memory context.
+- tag: pg_stat_wal
+  collector: stat_wal
+  queries:
+  - query: SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal;
+    version: 14
+    columns:
+    - name: wal_records
+      type: counter
+      description: Number of WAL records generated.
+    - name: wal_fpi
+      type: counter
+      description: Number of WAL full page images generated.
+    - name: wal_bytes
+      type: counter
+      description: Total bytes of generated WAL.
+    - name: wal_buffers_full
+      type: counter
+      description: Number of disk writes due to WAL buffers being full.
+    - name: wal_write
+      type: counter
+      description: Number of times WAL files were written to disk.
+    - name: wal_sync
+      type: counter
+      description: Number of times WAL files were synced to disk.
+    - name: wal_write_time
+      type: counter
+      description: Time taken for WAL files to be written to disk.
+    - name: wal_sync_time
+      type: counter
+      description: Time taken for WAL files to be synced to disk.
+- tag: pg_stat_database
+  collector: stat_db
+  queries:
+  - query: SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
+    version: 14
+    columns:
+    - name: database
+      type: label
+    - name: blk_read_time
+      type: counter
+      description: pg_stat_database_blk_read_time
+    - name: blk_write_time
+      type: counter
+      description: pg_stat_database_blk_write_time
+    - name: blks_hit
+      type: counter
+      description: pg_stat_database_blks_hit
+    - name: blks_read
+      type: counter
+      description: pg_stat_database_blks_read
+    - name: deadlocks
+      type: counter
+      description: pg_stat_database_deadlocks
+    - name: temp_files
+      type: gauge
+      description: pg_stat_database_temp_files
+    - name: temp_bytes
+      type: gauge
+      description: pg_stat_database_temp_bytes
+    - name: tup_returned
+      type: counter
+      description: pg_stat_database_tup_returned
+    - name: tup_fetched
+      type: counter
+      description: pg_stat_database_tup_fetched
+    - name: tup_inserted
+      type: counter
+      description: pg_stat_database_tup_inserted
+    - name: tup_updated
+      type: counter
+      description: pg_stat_database_tup_updated
+    - name: tup_deleted
+      type: counter
+      description: pg_stat_database_tup_deleted
+    - name: xact_commit
+      type: counter
+      description: pg_stat_database_xact_commit
+    - name: xact_rollback
+      type: counter
+      description: pg_stat_database_xact_rollback
+    - name: conflicts
+      type: counter
+      description: pg_stat_database_conflicts
+    - name: numbackends
+      type: gauge
+      description: pg_stat_database_numbackends
+    - name: checksum_failures
+      type: gauge
+      description: pg_stat_database_checksum_failures
+    - name: session_time
+      type: gauge
+      description: pg_stat_database_session_time
+    - name: active_time
+      type: gauge
+      description: pg_stat_database_active_time
+    - name: idle_in_transaction_time
+      type: gauge
+      description: pg_stat_database_idle_in_transaction_time
+    - name: sessions
+      type: gauge
+      description: pg_stat_database_sessions
+    - name: sessions_abandoned
+      type: gauge
+      description: pg_stat_database_sessions_abandoned
+    - name: sessions_fatal
+      type: gauge
+      description: pg_stat_database_sessions_fatal
+    - name: sessions_killed
+      type: gauge
+      description: pg_stat_database_sessions_killed
+- tag: pg_stat_subscription_stats
+  collector: subscription_stats
+  sort: data
+  queries:
+  - query: SELECT subid, subname, apply_error_count, sync_error_count, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint AS stats_reset_seconds FROM pg_stat_subscription_stats;
+    version: 16
+    columns:
+    - name: subid
+      type: label
+      description: Subscription OID
+    - name: subname
+      type: label
+      description: Subscription name
+    - name: apply_error_count
+      type: counter
+      description: Number of errors during apply
+    - name: sync_error_count
+      type: counter
+      description: Number of errors during initial sync
+    - name: stats_reset_seconds
+      type: counter
+      description: Seconds since statistics were last reset
+- tag: pg_wal_prefetch_reset
+  collector: wal_prefetch_reset
+  queries:
+  - query: SELECT FLOOR( EXTRACT( EPOCH FROM (now() - stats_reset) ) ) FROM pg_stat_recovery_prefetch;
+    version: 15
+    columns:
+    - type: counter
+      description: Seconds from last WAL prefetch stats reset.
+- tag: pg_gssapi_credentials_delegated
+  collector: gssapi_creds_delegated
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE credentials_delegated = 't' AND datname IS NOT NULL;
+    version: 16
+    columns:
+    - type: gauge
+      description: Number of DB connections with delegated GSSAPI credentials.
+- tag: pg_stat_io
+  collector: stat_io
+  queries:
+  - query: SELECT backend_type, SUM(COALESCE(reads, 0)) AS reads, SUM(COALESCE(read_time, 0)) AS read_time, SUM(COALESCE(writes, 0)) AS writes, SUM(COALESCE(write_time, 0)) AS write_time, SUM(COALESCE(writebacks, 0)) AS writebacks, SUM(COALESCE(writeback_time, 0)) AS writeback_time, SUM(COALESCE(extends, 0)) AS extends, SUM(COALESCE(extend_time, 0)) AS extend_time, AVG(COALESCE(op_bytes, 0)) AS op_bytes, SUM(COALESCE(hits, 0)) AS hits, SUM(COALESCE(evictions, 0)) AS evictions, SUM(COALESCE(reuses, 0)) AS reuses, SUM(COALESCE(fsyncs, 0)) AS fsyncs, SUM(COALESCE(fsync_time, 0)) AS fsync_time FROM pg_stat_io GROUP BY backend_type;
+    version: 16
+    columns:
+    - name: backend_type
+      type: label
+    - name: reads
+      type: counter
+      description: Number of read operations.
+    - name: read_time
+      type: counter
+      description: Total time spent on read operations in milliseconds.
+    - name: writes
+      type: counter
+      description: Number of write operations.
+    - name: write_time
+      type: counter
+      description: Total time spent on write operations in milliseconds.
+    - name: writebacks
+      type: counter
+      description: Number of writeback to permanent storage requests sent to kernel.
+    - name: writeback_time
+      type: counter
+      description: Total time spent on writeback operations in milliseconds.
+    - name: extends
+      type: counter
+      description: Number of relation extend operations.
+    - name: extend_time
+      type: counter
+      description: Total time spent on relation extend operations in milliseconds.
+    - name: op_bytes
+      type: gauge
+      description: Bytes per unit of I/O read, written or extended.
+    - name: hits
+      type: counter
+      description: The number of times a desired block was found in shared buffer.
+    - name: evictions
+      type: counter
+      description: The number of times a block has been written out from shared or local buffer in order to make it available for another use.
+    - name: reuses
+      type: counter
+      description: The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation.
+    - name: fsyncs
+      type: counter
+      description: Number of fsync calls.
+    - name: fsync_time
+      type: counter
+      description: Total time spent on fsync operations in milliseconds.
+- tag: pg_stat_database_conflicts
+  collector: stat_conflicts
+  sort: data
+  queries:
+  - query: SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock, confl_active_logicalslot FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;
+    version: 16
+    columns:
+    - name: database
+      type: label
+    - name: confl_tablespace
+      type: counter
+      description: pg_stat_database_conflicts_confl_tablespace
+    - name: confl_lock
+      type: counter
+      description: pg_stat_database_conflicts_confl_lock
+    - name: confl_snapshot
+      type: counter
+      description: pg_stat_database_conflicts_confl_snapshot
+    - name: confl_bufferpin
+      type: counter
+      description: pg_stat_database_conflicts_confl_bufferpin
+    - name: confl_deadlock
+      type: counter
+      description: pg_stat_database_conflicts_confl_dead
+    - name: confl_active_logicalslot
+      type: counter
+      description: pg_stat_database_conflicts_confl_active_logicalslot
+- tag: pg_stat_all_indexes
+  collector: stat_all_indexes
+  sort: data
+  database: all
+  queries:
+  - query: SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, COALESCE(MIN((EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;
+    version: 16
+    columns:
+    - type: counter
+      name: idx_scans
+      description: Number of index scans on the table's indexes.
+    - type: counter
+      name: idx_tup_reads
+      description: Number of index entries returned by scans on the table's indexes.
+    - type: counter
+      name: idx_tup_fetchs
+      description: Number of rows fetched by simple index scans on the table's indexes.
+    - type: counter
+      name: time_elapsed_ms
+      description: Milliseconds since last scan of an index in the table.
+    - type: label
+      name: relname
+- tag: pg_stat_checkpointer
+  collector: stat_checkpointer
+  queries:
+  - query: SELECT num_timed, num_requested, restartpoints_timed, restartpoints_req, restartpoints_done, write_time, sync_time, buffers_written, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint AS stats_reset_seconds FROM pg_stat_checkpointer;
+    version: 17
+    columns:
+    - name: num_timed
+      type: counter
+      description: Number of scheduled checkpoints performed
+    - name: num_requested
+      type: counter
+      description: Number of requested checkpoints performed
+    - name: restartpoints_timed
+      type: counter
+      description: Number of scheduled restartpoints on replica
+    - name: restartpoints_req
+      type: counter
+      description: Number of requested restartpoints on replica
+    - name: restartpoints_done
+      type: counter
+      description: Number of restartpoints completed on replica
+    - name: write_time
+      type: counter
+      description: Total time spent writing buffers during checkpoints (ms)
+    - name: sync_time
+      type: counter
+      description: Total time spent syncing buffers during checkpoints (ms)
+    - name: buffers_written
+      type: counter
+      description: Number of buffers written during checkpoints
+    - name: stats_reset_seconds
+      type: counter
+      description: Seconds since statistics were last reset
+- tag: pg_wait_events
+  collector: wait_events
+  sort: data
+  queries:
+  - query: SELECT type, count(*) as count FROM pg_wait_events GROUP BY type ORDER BY count DESC;
+    version: 17
+    columns:
+    - name: type
+      type: label
+    - name: count
+      type: gauge
+      description: pg_wait_events_count

--- a/contrib/yaml/postgresql-18.yaml
+++ b/contrib/yaml/postgresql-18.yaml
@@ -1,16 +1,19 @@
 version: 18
 metrics:
-- queries:
+- tag: postgresql_primary
+  collector: primary
+  sort: name
+  server: both
+  queries:
   - query: SELECT ( CASE pg_is_in_recovery() WHEN 'f' THEN 't' ELSE 'f' END );
     version: 10
     columns:
     - description: Is the PostgreSQL instance the primary
       type: gauge
-  tag: postgresql_primary
-  sort: name
-  collector: primary
-  server: both
-- queries:
+- tag: pg_database_size
+  collector: db
+  sort: data
+  queries:
   - query: SELECT datname, pg_database_size(datname) FROM pg_database;
     version: 10
     columns:
@@ -18,15 +21,11 @@ metrics:
       type: label
     - description: Size of the database
       type: gauge
-  tag: pg_database_size
+- tag: pg_locks_count
+  collector: locks
   sort: data
-  collector: db
-- queries:
-  - query: SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'),
-      ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'),
-      ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode)
-      AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode
-      = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;
+  queries:
+  - query: SELECT pg_database.datname as database, tmp.mode, COALESCE(count, 0) as count FROM ( VALUES ('accesssharelock'), ('rowsharelock'), ('rowexclusivelock'), ('shareupdateexclusivelock'), ('sharelock'), ('sharerowexclusivelock'), ('exclusivelock'), ('accessexclusivelock'), ('sireadlock') ) AS tmp(mode) CROSS JOIN pg_database LEFT JOIN ( SELECT database, lower(mode) AS mode, count(*) AS count FROM pg_locks WHERE database IS NOT NULL GROUP BY database, lower(mode) ) AS tmp2 ON tmp.mode = tmp2.mode AND pg_database.oid = tmp2.database ORDER BY 1, 2;
     version: 10
     columns:
     - name: database
@@ -35,12 +34,12 @@ metrics:
       type: label
     - description: Lock count of a database
       type: gauge
-  tag: pg_locks_count
+- tag: pg_replication_slots
+  collector: replication
   sort: data
-  collector: locks
-- queries:
-  - query: SELECT slot_name, slot_type, database, active, temporary FROM pg_replication_slots;
-    version: 10
+  queries:
+  - query: SELECT slot_name, slot_type, database, active, temporary, two_phase, two_phase_at, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - inactive_since))::bigint AS inactive_since_seconds, conflicting, invalidation_reason, failover, synced FROM pg_replication_slots;
+    version: 18
     columns:
     - name: slot_name
       type: label
@@ -48,18 +47,38 @@ metrics:
       type: label
     - name: database
       type: label
-    - description: Is the replication active
-      name: active
+    - name: active
       type: gauge
-    - description: Is the replication temporary
-      name: temporary
+      description: Is the replication active
+    - name: temporary
       type: gauge
-  tag: pg_replication_slots
-  sort: data
-  collector: replication
-- queries:
+      description: Is the replication temporary
+    - name: two_phase
+      type: gauge
+      description: Is two-phase commit enabled for this slot
+    - name: two_phase_at
+      type: label
+      description: LSN at which two-phase state was enabled
+    - name: inactive_since_seconds
+      type: gauge
+      description: Seconds since slot became inactive (-1 if active or NULL)
+    - name: conflicting
+      type: gauge
+      description: Is this slot conflicting with other slots
+    - name: invalidation_reason
+      type: label
+      description: Reason slot was invalidated
+    - name: failover
+      type: gauge
+      description: Is failover enabled for this slot
+    - name: synced
+      type: gauge
+      description: Is this slot synced from primary
+- tag: pg_stat_bgwriter
+  collector: stat_bgwriter
+  queries:
   - query: SELECT buffers_alloc, buffers_clean, maxwritten_clean FROM pg_stat_bgwriter;
-    version: 10
+    version: 17
     columns:
     - description: pg_stat_bgwriter_buffers_alloc
       name: buffers_alloc
@@ -70,16 +89,10 @@ metrics:
     - description: pg_stat_bgwriter_maxwritten_clean
       name: maxwritten_clean
       type: counter
-  tag: pg_stat_bgwriter
-  collector: stat_bgwriter
-- queries:
-  - query: WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float
-      AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP
-      BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP
-      - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60,
-      90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum
-      as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket
-      FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;
+- tag: pg_process_idle_seconds
+  collector: idle_procs
+  queries:
+  - query: WITH metrics AS ( SELECT application_name, SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum, COUNT(*) AS process_idle_seconds_count FROM pg_stat_activity WHERE state = 'idle' GROUP BY application_name ), buckets AS ( SELECT application_name, le, SUM( CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le THEN 1 ELSE 0 END )::bigint AS bucket FROM pg_stat_activity, UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le GROUP BY application_name, le ORDER BY application_name, le ) SELECT application_name, process_idle_seconds_sum as seconds_sum, process_idle_seconds_count as seconds_count, ARRAY_AGG(le) AS seconds, ARRAY_AGG(bucket) AS seconds_bucket FROM metrics JOIN buckets USING (application_name) GROUP BY 1, 2, 3;
     version: 10
     columns:
     - name: application_name
@@ -87,17 +100,17 @@ metrics:
     - name: seconds
       type: histogram
       description: Histogram of idle processes
-  tag: pg_process_idle_seconds
-  collector: idle_procs
-- queries:
+- tag: pg_available_extensions
+  collector: available_extensions
+  queries:
   - query: SELECT COUNT(*) AS extensions FROM pg_available_extensions;
     version: 10
     columns:
     - type: gauge
       description: Number of available extensions for installation.
-  tag: pg_available_extensions
-  collector: available_extensions
-- queries:
+- tag: pg_installed_extensions
+  collector: installed_extensions
+  queries:
   - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
     version: 10
     columns:
@@ -105,11 +118,11 @@ metrics:
       type: label
     - type: gauge
       description: Number of installed extensions.
-  tag: pg_installed_extensions
-  collector: installed_extensions
-- queries:
-  - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings
-      WHERE applied = 't' GROUP BY sourcefile, applied;
+- tag: pg_file_settings
+  collector: file_settings
+  sort: data
+  queries:
+  - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
     version: 10
     columns:
     - name: sourcefile
@@ -118,10 +131,10 @@ metrics:
       description: Settings that are applied.
     - name: applied
       type: label
-  tag: pg_file_settings
+- tag: pg_indexes
+  collector: indexes
   sort: data
-  collector: file_settings
-- queries:
+  queries:
   - query: SELECT schemaname, tablename, COUNT(*) FROM pg_indexes GROUP BY schemaname,tablename;
     version: 10
     columns:
@@ -131,26 +144,26 @@ metrics:
       type: label
     - type: gauge
       description: Indexes for each schemaname for each tablename.
-  tag: pg_indexes
-  sort: data
-  collector: indexes
-- queries:
+- tag: pg_matviews
+  collector: matviews
+  queries:
   - query: SELECT COUNT(*) FROM pg_matviews WHERE ispopulated = 't' GROUP BY ispopulated;
     version: 10
     columns:
     - type: gauge
       description: Number of applied Materialized views.
-  tag: pg_matviews
-  collector: matviews
-- queries:
+- tag: pg_role
+  collector: roles
+  queries:
   - query: SELECT COUNT(*) FROM pg_roles;
     version: 10
     columns:
     - type: gauge
       description: Number of roles.
-  tag: pg_role
-  collector: roles
-- queries:
+- tag: pg_rule
+  collector: rules
+  sort: data
+  queries:
   - query: SELECT tablename, COUNT(*) FROM pg_rules GROUP BY tablename;
     version: 10
     columns:
@@ -158,30 +171,29 @@ metrics:
       type: label
     - type: gauge
       description: Number of rules in table.
-  tag: pg_rule
+- tag: pg_shadow
+  collector: auth_type
   sort: data
-  collector: rules
-- queries:
-  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256'
-      ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+  queries:
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
     columns:
     - name: encryption_type
       type: label
     - type: gauge
       description: Number of users with authentication type.
-  tag: pg_shadow
-  sort: data
-  collector: auth_type
-- queries:
+- tag: pg_usr_evt_trigger
+  collector: usr_evt_trigger
+  queries:
   - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
     version: 10
     columns:
     - type: gauge
       description: Number of user defined event triggers.
-  tag: pg_usr_evt_trigger
-  collector: usr_evt_trigger
-- queries:
+- tag: pg_db_conn
+  collector: connections
+  sort: data
+  queries:
   - query: SELECT datname, count(*) FROM pg_stat_activity WHERE datname IS NOT NULL GROUP BY datname;
     version: 10
     columns:
@@ -189,25 +201,21 @@ metrics:
       type: label
     - type: gauge
       description: Number of database connections.
-  tag: pg_db_conn_ssl
-  sort: data
+- tag: pg_db_conn_ssl
   collector: connections
-- queries:
-  - query: SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE
-      ssl = 't' AND datname IS NOT NULL GROUP BY datname;
+  sort: data
+  queries:
+  - query: SELECT datname, count(*) FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_activity.pid = pg_stat_ssl.pid WHERE ssl = 't' AND datname IS NOT NULL GROUP BY datname;
     version: 10
     columns:
     - name: database
       type: label
     - type: gauge
       description: Number of DB connections with SSL.
-  tag: pg_db_conn
-  sort: data
-  collector: connections
-- queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as
-      idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit)
-      AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+- tag: pg_statio_all_tables
+  collector: statio_all_tables
+  queries:
+  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
     - name: heap_blks_read
@@ -234,9 +242,9 @@ metrics:
     - name: tidx_blks_hit
       type: counter
       description: Number of buffer hits read from postgres db's TOAST table indexes.
-  tag: pg_statio_all_tables
-  collector: statio_all_tables
-- queries:
+- tag: pg_statio_all_sequences
+  collector: statio_all_sequences
+  queries:
   - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
@@ -246,9 +254,10 @@ metrics:
     - name: blks_hit
       type: counter
       description: Number of buffer hits read from sequences in postgres db.
-  tag: pg_statio_all_sequences
-  collector: statio_all_sequences
-- queries:
+- tag: pg_stat_user_functions
+  collector: stat_user_functions
+  sort: data
+  queries:
   - query: SELECT funcname, calls, self_time, total_time FROM pg_stat_user_functions;
     version: 10
     columns:
@@ -263,10 +272,10 @@ metrics:
     - name: total_time
       type: counter
       description: Total time spent in milliseconds by the function and any other functions called by it.
-  tag: pg_stat_user_functions
+- tag: pg_stat_replication
+  collector: stat_replication
   sort: data
-  collector: stat_user_functions
-- queries:
+  queries:
   - query: SELECT COUNT(*), application_name FROM pg_stat_replication WHERE state = 'streaming' GROUP BY application_name;
     version: 10
     columns:
@@ -274,13 +283,11 @@ metrics:
       description: Number of streaming WAL connections per application.
     - name: application_name
       type: label
-  tag: pg_stat_replication
+- tag: pg_stat_archiver
+  collector: stat_archiver
   sort: data
-  collector: stat_replication
-- queries:
-  - query: SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms,
-      failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms
-      FROM pg_stat_archiver;
+  queries:
+  - query: SELECT archived_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_archived_time)) * 1000)::bigint AS success_time_elapsed_ms, failed_count, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_failed_time)) * 1000)::bigint AS failure_time_elapsed_ms FROM pg_stat_archiver;
     version: 10
     columns:
     - type: counter
@@ -295,10 +302,10 @@ metrics:
     - type: counter
       name: failure_time_elapsed_ms
       description: Milliseconds since last failed archival operation on WAL files.
-  tag: pg_stat_archiver
+- tag: pg_db_vacuum
+  collector: db_vacuum
   sort: data
-  collector: stat_archiver
-- queries:
+  queries:
   - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
     version: 10
     columns:
@@ -308,12 +315,11 @@ metrics:
     - type: counter
       name: age
       description: Age since last vaccum.
-  tag: pg_db_vacuum
-  sort: data
+- tag: pg_view_vacuum
   collector: db_vacuum
-- queries:
-  - query: SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c
-      LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');
+  sort: data
+  queries:
+  - query: SELECT c.oid::regclass as table_name, greatest(age(c.relfrozenxid),age(t.relfrozenxid)) as age FROM pg_class c LEFT JOIN pg_class t ON c.reltoastrelid = t.oid WHERE c.relkind IN ('r', 'm');
     version: 10
     columns:
     - type: label
@@ -322,18 +328,11 @@ metrics:
     - type: counter
       name: age
       description: Age since last vaccum.
-  tag: pg_view_vacuum
+- tag: pg_blocked_vacuum
+  collector: blocked_vacuum
   sort: data
-  collector: db_vacuum
-- queries:
-  - query: SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query
-      AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid
-      AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query,
-      EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked
-      JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation
-      = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid
-      = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted
-      AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;
+  queries:
+  - query: SELECT blocked.pid AS blocked_pid, blocked.datname AS blocked_database, blocked.usename AS blocked_user, blocked.query AS blocked_query, EXTRACT(EPOCH FROM age(now(), blocked.query_start))::bigint AS blocked_duration_seconds, blocking.pid AS blocking_pid, blocking.datname AS blocking_database, blocking.usename AS blocking_user, blocking.query AS blocking_query, EXTRACT(EPOCH FROM age(now(), blocking.query_start))::bigint AS blocking_duration_seconds FROM pg_stat_activity blocked JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid JOIN pg_locks blocking_locks ON blocked_locks.relation = blocking_locks.relation AND blocked_locks.pid != blocking_locks.pid JOIN pg_stat_activity blocking ON blocking.pid = blocking_locks.pid WHERE (blocked.query ILIKE '%VACUUM%' OR blocked.query ILIKE '%AUTOVACUUM%') AND NOT blocked_locks.granted AND blocking_locks.granted ORDER BY blocked_duration_seconds DESC;
     version: 10
     columns:
     - name: blocked_pid
@@ -358,94 +357,73 @@ metrics:
     - name: blocking_duration_seconds
       type: gauge
       description: Duration in seconds that the blocking query has been running
-  tag: pg_blocked_vacuum
-  sort: data
-  collector: blocked_vacuum
-- queries:
-  - query: SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender,
-      (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;
+- tag: pg_wal_last_received
+  collector: wal_last_received
+  server: replica
+  queries:
+  - query: SELECT CASE WHEN sender_host LIKE '/%' THEN sender_host ELSE sender_host || ':' || sender_port::text END AS sender, (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_msg_send_time)) * 1000)::bigint AS time_elapsed_ms FROM pg_stat_wal_receiver;
     version: 11
     columns:
     - name: sender
       type: label
     - type: counter
       description: Time since last message received from WAL sender
-  tag: pg_wal_last_received
-  collector: wal_last_received
-  server: replica
-- queries:
-  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated
-      = 't' AND datname IS NOT NULL;
+- tag: pg_gss_auth
+  collector: gssapi
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE gss_authenticated = 't' AND datname IS NOT NULL;
     version: 12
     columns:
     - type: gauge
       description: Number of GSSAPI authenticated DB connections.
-  tag: pg_gss_auth
-  collector: gssapi
-- queries:
-  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted
-      = 't' AND datname IS NOT NULL;
+- tag: pg_encrypted_conn
+  collector: encryted_conns
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE encrypted = 't' AND datname IS NOT NULL;
     version: 12
     columns:
     - type: gauge
       description: Number of encrypted DB connections.
-  tag: pg_encrypted_conn
-  collector: encryted_conns
-- queries:
-  - query: SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[]
-      AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size)
-      FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;
+- tag: pg_shmem_allocations
+  collector: shmem_size
+  queries:
+  - query: SELECT SUM(sum) AS size_sum, '1' AS size_count, array_agg((bucket - 1) * (50000))::int[] AS size, array_agg(count)::int[] AS size_bucket FROM ( SELECT width_bucket(allocated_size, 0, 5000000, 100) AS bucket, COUNT(*), SUM(allocated_size) FROM pg_shmem_allocations GROUP BY bucket ORDER BY bucket ) t;
     version: 13
     columns:
     - name: size
       type: histogram
       description: Histogram of shared memory sizes.
-  tag: pg_shmem_allocations
-  collector: shmem_size
-- queries:
-  - query: SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed,
-      p.index_vacuum_count, p.max_dead_tuples, p.num_dead_tuples, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned
-      / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING
-      (pid) ORDER BY p.pid;
-    version: 13
+- tag: pg_shmem_allocations_numa
+  collector: shmem_numa
+  sort: data
+  queries:
+  - query: SELECT numa_node, COUNT(*) AS allocations, SUM(size) AS total_bytes, AVG(size) AS avg_bytes, MAX(size) AS max_bytes, MIN(size) AS min_bytes FROM pg_shmem_allocations_numa GROUP BY numa_node ORDER BY numa_node;
+    version: 18
     columns:
-    - name: pid
+    - name: numa_node
       type: label
-    - name: datname
-      type: label
-    - name: usename
-      type: label
-    - name: query
-      type: label
-    - name: phase
-      type: label
-    - name: heap_blks_total
+      description: NUMA node number
+    - name: allocations
       type: gauge
-      description: Total heap blocks in table
-    - name: heap_blks_scanned
+      description: Number of shared memory allocations on this NUMA node
+    - name: total_bytes
       type: gauge
-      description: Heap blocks scanned
-    - name: heap_blks_vacuumed
+      description: Total bytes allocated on this NUMA node
+    - name: avg_bytes
       type: gauge
-      description: Heap blocks vacuumed
-    - name: index_vacuum_count
+      description: Average allocation size on this NUMA node
+    - name: max_bytes
       type: gauge
-      description: Number of index vacuum cycles completed
-    - name: max_dead_tuples
+      description: Maximum allocation size on this NUMA node
+    - name: min_bytes
       type: gauge
-      description: Maximum dead tuples
-    - name: num_dead_tuples
-      type: gauge
-      description: Current dead tuples
-    - name: pct_scan_completed
-      type: gauge
-      description: Vacuum scan progress percentage
-  - query: SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed,
-      p.index_vacuum_count, p.max_dead_tuple_bytes, p.dead_tuple_bytes, p.num_dead_item_ids, p.indexes_total, p.indexes_processed,
-      CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed,
-      CASE WHEN p.indexes_total > 0 THEN round(100 * p.indexes_processed / p.indexes_total, 2) ELSE 0 END AS pct_index_completed
-      FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
-    version: 17
+      description: Minimum allocation size on this NUMA node
+- tag: pg_stat_progress_vacuum
+  collector: vacuum_progress
+  sort: data
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, a.query, p.phase, p.heap_blks_total, p.heap_blks_scanned, p.heap_blks_vacuumed, p.index_vacuum_count, p.max_dead_tuple_bytes, p.dead_tuple_bytes, p.num_dead_item_ids, p.indexes_total, p.indexes_processed, p.delay_time, CASE WHEN p.heap_blks_total > 0 THEN round(100 * p.heap_blks_scanned / p.heap_blks_total, 2) ELSE 0 END AS pct_scan_completed, CASE WHEN p.indexes_total > 0 THEN round(100 * p.indexes_processed / p.indexes_total, 2) ELSE 0 END AS pct_index_completed FROM pg_stat_progress_vacuum p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 18
     columns:
     - name: pid
       type: label
@@ -484,77 +462,64 @@ metrics:
     - name: indexes_processed
       type: gauge
       description: Number of indexes processed
+    - name: delay_time
+      type: gauge
+      description: Total time spent in vacuum delay/throttling (milliseconds)
     - name: pct_scan_completed
       type: gauge
       description: Vacuum scan progress percentage
     - name: pct_index_completed
       type: gauge
       description: Index processing progress percentage
-  tag: pg_stat_progress_vacuum
+- tag: pg_stat_progress_analyze
+  collector: analyze_progress
   sort: data
-  collector: vacuum_progress
-- queries:
-  - query: SELECT schemaname, relname, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric /
-      n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH
-      FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP
-      - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint,
-      -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds,
-      vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;
-    version: 13
+  queries:
+  - query: SELECT p.pid, a.datname, a.usename, p.phase, p.sample_blks_total, p.sample_blks_scanned, p.ext_stats_total, p.ext_stats_computed, p.child_tables_total, p.child_tables_done, p.delay_time, CASE WHEN p.sample_blks_total > 0 THEN ROUND(100 * p.sample_blks_scanned / p.sample_blks_total, 2) ELSE 0 END AS pct_sample_completed, CASE WHEN p.child_tables_total > 0 THEN ROUND(100 * p.child_tables_done / p.child_tables_total, 2) ELSE 0 END AS pct_child_tables_completed FROM pg_stat_progress_analyze p JOIN pg_stat_activity a USING (pid) ORDER BY p.pid;
+    version: 18
     columns:
-    - name: schemaname
+    - name: pid
       type: label
-    - name: relname
+    - name: datname
       type: label
-    - name: n_live_tup
+    - name: usename
+      type: label
+    - name: phase
+      type: label
+    - name: sample_blks_total
       type: gauge
-      description: Estimated number of live rows
-    - name: n_dead_tup
+      description: Total blocks to sample
+    - name: sample_blks_scanned
       type: gauge
-      description: Estimated number of dead rows
-    - name: dead_rows_pct
+      description: Blocks sampled so far
+    - name: ext_stats_total
       type: gauge
-      description: Percentage of dead rows relative to live rows
-    - name: n_mod_since_analyze
+      description: Total extended statistics to compute
+    - name: ext_stats_computed
       type: gauge
-      description: Estimated number of rows modified since last analyze
-    - name: n_ins_since_vacuum
+      description: Extended statistics computed
+    - name: child_tables_total
       type: gauge
-      description: Estimated number of rows inserted since last vacuum
-    - name: last_vacuum_seconds
+      description: Total child tables to analyze
+    - name: child_tables_done
       type: gauge
-      description: Seconds since last manual vacuum (-1 if never)
-    - name: last_autovacuum_seconds
+      description: Child tables analyzed
+    - name: delay_time
       type: gauge
-      description: Seconds since last autovacuum (-1 if never)
-    - name: last_analyze_seconds
+      description: Total time spent in analyze delay/throttling (milliseconds)
+    - name: pct_sample_completed
       type: gauge
-      description: Seconds since last manual analyze (-1 if never)
-    - name: last_autoanalyze_seconds
+      description: Percentage of sampling completed
+    - name: pct_child_tables_completed
       type: gauge
-      description: Seconds since last autoanalyze (-1 if never)
-    - name: vacuum_count
-      type: counter
-      description: Number of times this table has been manually vacuumed
-    - name: autovacuum_count
-      type: counter
-      description: Number of times this table has been vacuumed by autovacuum
-    - name: analyze_count
-      type: counter
-      description: Number of times this table has been manually analyzed
-    - name: autoanalyze_count
-      type: counter
-      description: Number of times this table has been analyzed by autoanalyze
-  - query: SELECT schemaname, relname, seq_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint,
-      -1) AS last_seq_scan_seconds, seq_tup_read, idx_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint,
-      -1) AS last_idx_scan_seconds, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_tup_newpage_upd, n_live_tup,
-      n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS
-      dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint,
-      -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds,
-      COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH
-      FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count,
-      analyze_count, autoanalyze_count FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;
-    version: 16
+      description: Percentage of child tables completed
+- tag: pg_stat_user_tables_vacuum
+  collector: stat_user_tables
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, relname, seq_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_seq_scan))::bigint, -1) AS last_seq_scan_seconds, seq_tup_read, idx_scan, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan))::bigint, -1) AS last_idx_scan_seconds, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_tup_newpage_upd, n_live_tup, n_dead_tup, CASE WHEN n_live_tup > 0 THEN ROUND((n_dead_tup::numeric / n_live_tup::numeric) * 100, 2) ELSE 0 END AS dead_rows_pct, n_mod_since_analyze, n_ins_since_vacuum, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_vacuum))::bigint, -1) AS last_vacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autovacuum))::bigint, -1) AS last_autovacuum_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_analyze))::bigint, -1) AS last_analyze_seconds, COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_autoanalyze))::bigint, -1) AS last_autoanalyze_seconds, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count, total_vacuum_time, total_autovacuum_time, total_analyze_time, total_autoanalyze_time FROM pg_stat_user_tables ORDER BY n_dead_tup DESC;
+    version: 18
     columns:
     - name: schemaname
       type: label
@@ -632,85 +597,54 @@ metrics:
     - name: autoanalyze_count
       type: counter
       description: Number of times this table has been analyzed by autoanalyze
-  tag: pg_stat_user_tables_vacuum
+    - name: total_vacuum_time
+      type: counter
+      description: Total time spent vacuuming this table, in milliseconds
+    - name: total_autovacuum_time
+      type: counter
+      description: Total time spent auto-vacuuming this table, in milliseconds
+    - name: total_analyze_time
+      type: counter
+      description: Total time spent analyzing this table, in milliseconds
+    - name: total_autoanalyze_time
+      type: counter
+      description: Total time spent auto-analyzing this table, in milliseconds
+- tag: pg_table_ratio
+  collector: table_activity_ratio
   sort: data
-  collector: stat_user_tables
   database: all
-
-# Table read/write activity ratios
-  - queries:
-    - query: WITH table_activity AS (
-                SELECT
-                  s.schemaname,
-                  s.relname,
-                  si.heap_blks_read + si.idx_blks_read AS blocks_read,
-                  s.seq_tup_read + s.idx_tup_fetch AS tuples_read,
-                  c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) /
-                    CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write,
-                  s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write
-                FROM pg_stat_user_tables AS s
-                JOIN pg_statio_user_tables AS si ON s.relid = si.relid
-                JOIN pg_class c ON c.oid = s.relid
-                WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0
-                  AND (si.heap_blks_read + si.idx_blks_read) > 0
-              )
-              SELECT
-                schemaname,
-                relname,
-                blocks_read,
-                tuples_read,
-                blocks_write,
-                tuples_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int
-                END AS ratio_write,
-                CASE
-                  WHEN (blocks_read + blocks_write) = 0 THEN 0
-                  ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int
-                END AS ratio_read
-              FROM table_activity
-              ORDER BY (blocks_read + blocks_write) DESC;
-      version: 13
-      columns:
-        - name: schemaname
-          type: label
-        - name: relname
-          type: label
-        - name: blocks_read
-          type: counter
-          description: Total blocks read from disk (heap + index)
-        - name: tuples_read
-          type: counter
-          description: Total number of tuples read (sequential + index scans)
-        - name: blocks_write
-          type: gauge
-          description: Estimated blocks affected by write operations
-        - name: tuples_write
-          type: counter
-          description: Total number of tuples inserted, updated, or deleted
-        - name: ratio_write
-          type: gauge
-          description: Percentage of I/O activity that is writes (0-100)
-        - name: ratio_read
-          type: gauge
-          description: Percentage of I/O activity that is reads (0-100)
-    tag: pg_table_ratio
-    sort: data
-    collector: table_activity_ratio
-    database: all
-
-
-
-- queries:
-  - query: SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS
-      bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size,
-      (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric
-      ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages
-      AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer
-      AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema',
-      'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER
-      BY extra_size DESC;
+  queries:
+  - query: WITH table_activity AS ( SELECT s.schemaname, s.relname, si.heap_blks_read + si.idx_blks_read AS blocks_read, s.seq_tup_read + s.idx_tup_fetch AS tuples_read, c.relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / CASE WHEN c.reltuples = 0 THEN 1 ELSE c.reltuples END AS blocks_write, s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS tuples_write FROM pg_stat_user_tables AS s JOIN pg_statio_user_tables AS si ON s.relid = si.relid JOIN pg_class c ON c.oid = s.relid WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0 AND (si.heap_blks_read + si.idx_blks_read) > 0 ) SELECT schemaname, relname, blocks_read, tuples_read, blocks_write, tuples_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_write / (blocks_read + blocks_write))::int END AS ratio_write, CASE WHEN (blocks_read + blocks_write) = 0 THEN 0 ELSE ROUND(100.0 * blocks_read / (blocks_read + blocks_write))::int END AS ratio_read FROM table_activity ORDER BY (blocks_read + blocks_write) DESC;
+    version: 13
+    columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
+    - name: blocks_read
+      type: counter
+      description: Total blocks read from disk (heap + index)
+    - name: tuples_read
+      type: counter
+      description: Total number of tuples read (sequential + index scans)
+    - name: blocks_write
+      type: gauge
+      description: Estimated blocks affected by write operations
+    - name: tuples_write
+      type: counter
+      description: Total number of tuples inserted, updated, or deleted
+    - name: ratio_write
+      type: gauge
+      description: Percentage of I/O activity that is writes (0-100)
+    - name: ratio_read
+      type: gauge
+      description: Percentage of I/O activity that is reads (0-100)
+- tag: pg_table_bloat
+  collector: table_bloat
+  sort: data
+  database: all
+  queries:
+  - query: SELECT schemaname, tblname, real_size AS table_size, extra_size AS bloat_size, ROUND(extra_ratio::numeric, 2) AS bloat_ratio_pct, tblpages, est_tblpages, bs AS block_size FROM ( SELECT schemaname, tblname, bs*tblpages AS real_size, (tblpages-est_tblpages)*bs AS extra_size, CASE WHEN tblpages > 0 THEN 100 * (tblpages-est_tblpages)/tblpages::numeric ELSE 0 END AS extra_ratio, tblpages, est_tblpages, bs FROM ( SELECT n.nspname AS schemaname, c.relname AS tblname, c.relpages AS tblpages, CEIL(c.reltuples/((current_setting('block_size')::integer-24)/100)) AS est_tblpages, current_setting('block_size')::integer AS bs FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND n.nspname NOT LIKE 'pg_temp_%' ) AS bloat_calc ) AS bloat_summary WHERE tblpages > 0 ORDER BY extra_size DESC;
     version: 13
     columns:
     - name: schemaname
@@ -735,32 +669,10 @@ metrics:
     - name: block_size
       type: gauge
       description: Database block size in bytes
-  tag: pg_table_bloat
-  sort: data
-  collector: table_bloat
-  database: all
-- queries:
-  - query: SELECT COUNT(*) AS contexts, parent, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes)
-      AS total_bytes FROM pg_backend_memory_contexts WHERE parent!='' GROUP BY parent;
-    version: 14
-    columns:
-    - name: contexts
-      type: gauge
-      description: Number of memory contexts per parent.
-    - name: parent
-      type: label
-    - name: free_bytes
-      type: gauge
-      description: Free bytes per memory context.
-    - name: used_bytes
-      type: gauge
-      description: Used bytes per memory context.
-    - name: total_bytes
-      type: gauge
-      description: Total bytes per memory context.
-  # 'type' column replaces 'name' in pg_backend_memory_contexts
-  - query: "SELECT\n  COUNT(*) AS contexts,\n  type,\n  SUM(free_bytes) AS free_bytes,\n  SUM(used_bytes) AS used_bytes,\n\
-      \  SUM(total_bytes) AS total_bytes\nFROM pg_backend_memory_contexts\nWHERE type!=''\nGROUP BY type;"
+- tag: pg_mem_ctx
+  collector: mem_ctx
+  queries:
+  - query: SELECT COUNT(*) AS contexts, type, SUM(free_bytes) AS free_bytes, SUM(used_bytes) AS used_bytes, SUM(total_bytes) AS total_bytes FROM pg_backend_memory_contexts WHERE type!='' GROUP BY type;
     version: 18
     columns:
     - name: contexts
@@ -778,42 +690,10 @@ metrics:
     - name: total_bytes
       type: gauge
       description: Total bytes per memory context type.
-  tag: pg_mem_ctx
-  collector: mem_ctx
-- queries:
-  - query: SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM
-      pg_stat_wal;
-    version: 14
-    columns:
-    - name: wal_records
-      type: counter
-      description: Number of WAL records generated.
-    - name: wal_fpi
-      type: counter
-      description: Number of WAL full page images generated.
-    - name: wal_bytes
-      type: counter
-      description: Total bytes of generated WAL.
-    - name: wal_buffers_full
-      type: counter
-      description: Number of disk writes due to WAL buffers being full.
-    - name: wal_write
-      type: counter
-      description: Number of times WAL files were written to disk.
-    - name: wal_sync
-      type: counter
-      description: Number of times WAL files were synced to disk.
-    - name: wal_write_time
-      type: counter
-      description: Time taken for WAL files to be written to disk.
-    - name: wal_sync_time
-      type: counter
-      description: Time taken for WAL files to be synced to disk.
-  # wal_write, wal_sync, wal_write_time, wal_sync_time moved to pg_stat_io, recovered via CTE
-  - query: "WITH wal_io AS (\n  SELECT\n    sum(writes) as wal_write,\n    sum(fsyncs) as wal_sync,\n    sum(write_time) as\
-      \ wal_write_time,\n    sum(fsync_time) as wal_sync_time\n  FROM pg_stat_io\n  WHERE object = 'wal'\n)\nSELECT\n  wal_records,\n\
-      \  wal_fpi,\n  wal_bytes,\n  wal_buffers_full,\n  wal_write,\n  wal_sync,\n  wal_write_time,\n  wal_sync_time\nFROM\
-      \ pg_stat_wal, wal_io;"
+- tag: pg_stat_wal
+  collector: stat_wal
+  queries:
+  - query: WITH wal_io AS ( SELECT sum(writes) as wal_write, sum(fsyncs) as wal_sync, sum(write_time) as wal_write_time, sum(fsync_time) as wal_sync_time FROM pg_stat_io WHERE object = 'wal' ) SELECT wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync, wal_write_time, wal_sync_time FROM pg_stat_wal, wal_io;
     version: 18
     columns:
     - name: wal_records
@@ -840,127 +720,11 @@ metrics:
     - name: wal_sync_time
       type: counter
       description: Time taken for WAL files to be synced to disk in milliseconds (from pg_stat_io).
-  tag: pg_stat_wal
-  collector: stat_wal
-- queries:
-  - query: SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned,
-      tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends FROM pg_stat_database
-      WHERE datname IS NOT NULL ORDER BY datname;
-    columns:
-    - name: database
-      type: label
-    - name: blk_read_time
-      type: counter
-      description: pg_stat_database_blk_read_time
-    - name: blk_write_time
-      type: counter
-      description: pg_stat_database_blk_write_time
-    - name: blks_hit
-      type: counter
-      description: pg_stat_database_blks_hit
-    - name: blks_read
-      type: counter
-      description: pg_stat_database_blks_read
-    - name: deadlocks
-      type: counter
-      description: pg_stat_database_deadlocks
-    - name: temp_files
-      type: gauge
-      description: pg_stat_database_temp_files
-    - name: temp_bytes
-      type: gauge
-      description: pg_stat_database_temp_bytes
-    - name: tup_returned
-      type: counter
-      description: pg_stat_database_tup_returned
-    - name: tup_fetched
-      type: counter
-      description: pg_stat_database_tup_fetched
-    - name: tup_inserted
-      type: counter
-      description: pg_stat_database_tup_inserted
-    - name: tup_updated
-      type: counter
-      description: pg_stat_database_tup_updated
-    - name: tup_deleted
-      type: counter
-      description: pg_stat_database_tup_deleted
-    - name: xact_commit
-      type: counter
-      description: pg_stat_database_xact_commit
-    - name: xact_rollback
-      type: counter
-      description: pg_stat_database_xact_rollback
-    - name: conflicts
-      type: counter
-      description: pg_stat_database_conflicts
-    - name: numbackends
-      type: gauge
-      description: pg_stat_database_numbackends
-    version: 10
-  - query: SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned,
-      tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures
-      FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
-    columns:
-    - name: database
-      type: label
-    - name: blk_read_time
-      type: counter
-      description: pg_stat_database_blk_read_time
-    - name: blk_write_time
-      type: counter
-      description: pg_stat_database_blk_write_time
-    - name: blks_hit
-      type: counter
-      description: pg_stat_database_blks_hit
-    - name: blks_read
-      type: counter
-      description: pg_stat_database_blks_read
-    - name: deadlocks
-      type: counter
-      description: pg_stat_database_deadlocks
-    - name: temp_files
-      type: gauge
-      description: pg_stat_database_temp_files
-    - name: temp_bytes
-      type: gauge
-      description: pg_stat_database_temp_bytes
-    - name: tup_returned
-      type: counter
-      description: pg_stat_database_tup_returned
-    - name: tup_fetched
-      type: counter
-      description: pg_stat_database_tup_fetched
-    - name: tup_inserted
-      type: counter
-      description: pg_stat_database_tup_inserted
-    - name: tup_updated
-      type: counter
-      description: pg_stat_database_tup_updated
-    - name: tup_deleted
-      type: counter
-      description: pg_stat_database_tup_deleted
-    - name: xact_commit
-      type: counter
-      description: pg_stat_database_xact_commit
-    - name: xact_rollback
-      type: counter
-      description: pg_stat_database_xact_rollback
-    - name: conflicts
-      type: counter
-      description: pg_stat_database_conflicts
-    - name: numbackends
-      type: gauge
-      description: pg_stat_database_numbackends
-    - name: checksum_failures
-      type: gauge
-      description: pg_stat_database_checksum_failures
-    version: 12
-  - query: SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned,
-      tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures,
-      session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed FROM
-      pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
-    version: 14
+- tag: pg_stat_database
+  collector: stat_db
+  queries:
+  - query: SELECT datname, blk_read_time, blk_write_time, blks_hit, blks_read, deadlocks, temp_files, temp_bytes, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, xact_commit, xact_rollback, conflicts, numbackends, checksum_failures, session_time, active_time, idle_in_transaction_time, sessions, sessions_abandoned, sessions_fatal, sessions_killed, parallel_workers_to_launch, parallel_workers_launched FROM pg_stat_database WHERE datname IS NOT NULL ORDER BY datname;
+    version: 18
     columns:
     - name: database
       type: label
@@ -1036,85 +800,75 @@ metrics:
     - name: sessions_killed
       type: gauge
       description: pg_stat_database_sessions_killed
-  tag: pg_stat_database
-  collector: stat_db
-- queries:
+    - name: parallel_workers_to_launch
+      type: gauge
+      description: Number of parallel workers PostgreSQL attempted to launch
+    - name: parallel_workers_launched
+      type: gauge
+      description: Number of parallel workers successfully launched
+- tag: pg_stat_subscription_stats
+  collector: subscription_stats
+  sort: data
+  queries:
+  - query: SELECT subid, subname, apply_error_count, sync_error_count, confl_insert_exists, confl_update_origin_differs, confl_update_exists, confl_update_missing, confl_delete_origin_differs, confl_delete_missing, confl_multiple_unique_conflicts, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint AS stats_reset_seconds FROM pg_stat_subscription_stats;
+    version: 18
+    columns:
+    - name: subid
+      type: label
+      description: Subscription OID
+    - name: subname
+      type: label
+      description: Subscription name
+    - name: apply_error_count
+      type: counter
+      description: Number of errors during apply
+    - name: sync_error_count
+      type: counter
+      description: Number of errors during initial sync
+    - name: confl_insert_exists
+      type: counter
+      description: Number of conflicts where INSERT tried to insert existing row
+    - name: confl_update_origin_differs
+      type: counter
+      description: Number of conflicts where UPDATE had different origin
+    - name: confl_update_exists
+      type: counter
+      description: Number of conflicts where UPDATE target already exists
+    - name: confl_update_missing
+      type: counter
+      description: Number of conflicts where UPDATE target is missing
+    - name: confl_delete_origin_differs
+      type: counter
+      description: Number of conflicts where DELETE had different origin
+    - name: confl_delete_missing
+      type: counter
+      description: Number of conflicts where DELETE target is missing
+    - name: confl_multiple_unique_conflicts
+      type: counter
+      description: Number of conflicts with multiple unique constraint violations
+    - name: stats_reset_seconds
+      type: counter
+      description: Seconds since statistics were last reset
+- tag: pg_wal_prefetch_reset
+  collector: wal_prefetch_reset
+  queries:
   - query: SELECT FLOOR( EXTRACT( EPOCH FROM (now() - stats_reset) ) ) FROM pg_stat_recovery_prefetch;
     version: 15
     columns:
     - type: counter
       description: Seconds from last WAL prefetch stats reset.
-  tag: pg_wal_prefetch_reset
-  collector: wal_prefetch_reset
-- queries:
-  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE credentials_delegated
-      = 't' AND datname IS NOT NULL;
+- tag: pg_gssapi_credentials_delegated
+  collector: gssapi_creds_delegated
+  queries:
+  - query: SELECT COUNT(*) FROM pg_stat_gssapi JOIN pg_stat_activity ON pg_stat_gssapi.pid = pg_stat_activity.pid WHERE credentials_delegated = 't' AND datname IS NOT NULL;
+    version: 16
     columns:
     - type: gauge
       description: Number of DB connections with delegated GSSAPI credentials.
-  tag: pg_gssapi_credentials_delegated
-  collector: gssapi_creds_delegated
-- queries:
-  - query: SELECT backend_type, SUM(COALESCE(reads, 0)) AS reads, SUM(COALESCE(read_time, 0)) AS read_time, SUM(COALESCE(writes,
-      0)) AS writes, SUM(COALESCE(write_time, 0)) AS write_time, SUM(COALESCE(writebacks, 0)) AS writebacks, SUM(COALESCE(writeback_time,
-      0)) AS writeback_time, SUM(COALESCE(extends, 0)) AS extends, SUM(COALESCE(extend_time, 0)) AS extend_time, AVG(COALESCE(op_bytes,
-      0)) AS op_bytes, SUM(COALESCE(hits, 0)) AS hits, SUM(COALESCE(evictions, 0)) AS evictions, SUM(COALESCE(reuses, 0))
-      AS reuses, SUM(COALESCE(fsyncs, 0)) AS fsyncs, SUM(COALESCE(fsync_time, 0)) AS fsync_time FROM pg_stat_io GROUP BY backend_type;
-    columns:
-    - name: backend_type
-      type: label
-    - name: reads
-      type: counter
-      description: Number of read operations.
-    - name: read_time
-      type: counter
-      description: Total time spent on read operations in milliseconds.
-    - name: writes
-      type: counter
-      description: Number of write operations.
-    - name: write_time
-      type: counter
-      description: Total time spent on write operations in milliseconds.
-    - name: writebacks
-      type: counter
-      description: Number of writeback to permanent storage requests sent to kernel.
-    - name: writeback_time
-      type: counter
-      description: Total time spent on writeback operations in milliseconds.
-    - name: extends
-      type: counter
-      description: Number of relation extend operations.
-    - name: extend_time
-      type: counter
-      description: Total time spent on relation extend operations in milliseconds.
-    - name: op_bytes
-      type: gauge
-      description: Bytes per unit of I/O read, written or extended.
-    - name: hits
-      type: counter
-      description: The number of times a desired block was found in shared buffer.
-    - name: evictions
-      type: counter
-      description: The number of times a block has been written out from shared or local buffer in order to make it available
-        for another use.
-    - name: reuses
-      type: counter
-      description: The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused
-        as part of an I/O operation.
-    - name: fsyncs
-      type: counter
-      description: Number of fsync calls.
-    - name: fsync_time
-      type: counter
-      description: Total time spent on fsync operations in milliseconds.
-  # op_bytes replaced with granular read_bytes, write_bytes, extend_bytes columns
-  - query: "SELECT\n  backend_type,\n  SUM(COALESCE(reads, 0)) AS reads,\n  SUM(COALESCE(read_bytes, 0)) AS read_bytes,\n\
-      \  SUM(COALESCE(read_time, 0)) AS read_time,\n  SUM(COALESCE(writes, 0)) AS writes,\n  SUM(COALESCE(write_bytes, 0))\
-      \ AS write_bytes,\n  SUM(COALESCE(write_time, 0)) AS write_time,\n  SUM(COALESCE(writebacks, 0)) AS writebacks,\n  SUM(COALESCE(writeback_time,\
-      \ 0)) AS writeback_time,\n  SUM(COALESCE(extends, 0)) AS extends,\n  SUM(COALESCE(extend_bytes, 0)) AS extend_bytes,\n\
-      \  SUM(COALESCE(extend_time, 0)) AS extend_time,\n  SUM(COALESCE(hits, 0)) AS hits,\n  SUM(COALESCE(evictions, 0)) AS\
-      \ evictions,\n  SUM(COALESCE(reuses, 0)) AS reuses,\n  SUM(COALESCE(fsyncs, 0)) AS fsyncs,\n  SUM(COALESCE(fsync_time,\
-      \ 0)) AS fsync_time\nFROM pg_stat_io\nGROUP BY backend_type;"
+- tag: pg_stat_io
+  collector: stat_io
+  queries:
+  - query: SELECT backend_type, SUM(COALESCE(reads, 0)) AS reads, SUM(COALESCE(read_bytes, 0)) AS read_bytes, SUM(COALESCE(read_time, 0)) AS read_time, SUM(COALESCE(writes, 0)) AS writes, SUM(COALESCE(write_bytes, 0)) AS write_bytes, SUM(COALESCE(write_time, 0)) AS write_time, SUM(COALESCE(writebacks, 0)) AS writebacks, SUM(COALESCE(writeback_time, 0)) AS writeback_time, SUM(COALESCE(extends, 0)) AS extends, SUM(COALESCE(extend_bytes, 0)) AS extend_bytes, SUM(COALESCE(extend_time, 0)) AS extend_time, SUM(COALESCE(hits, 0)) AS hits, SUM(COALESCE(evictions, 0)) AS evictions, SUM(COALESCE(reuses, 0)) AS reuses, SUM(COALESCE(fsyncs, 0)) AS fsyncs, SUM(COALESCE(fsync_time, 0)) AS fsync_time FROM pg_stat_io GROUP BY backend_type;
     version: 18
     columns:
     - name: backend_type
@@ -1157,44 +911,22 @@ metrics:
       description: The number of times a desired block was found in shared buffer.
     - name: evictions
       type: counter
-      description: The number of times a block has been written out from shared or local buffer in order to make it available
-        for another use.
+      description: The number of times a block has been written out from shared or local buffer in order to make it available for another use.
     - name: reuses
       type: counter
-      description: The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused
-        as part of an I/O operation.
+      description: The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation.
     - name: fsyncs
       type: counter
       description: Number of fsync calls.
     - name: fsync_time
       type: counter
       description: Total time spent on fsync operations in milliseconds.
-  tag: pg_stat_io
-  collector: stat_io
-- queries:
-  - query: SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock FROM pg_stat_database_conflicts
-      WHERE datname IS NOT NULL ORDER BY datname;
-    columns:
-    - name: database
-      type: label
-    - name: confl_tablespace
-      type: counter
-      description: pg_stat_database_conflicts_confl_tablespace
-    - name: confl_lock
-      type: counter
-      description: pg_stat_database_conflicts_confl_lock
-    - name: confl_snapshot
-      type: counter
-      description: pg_stat_database_conflicts_confl_snapshot
-    - name: confl_bufferpin
-      type: counter
-      description: pg_stat_database_conflicts_confl_bufferpin
-    - name: confl_deadlock
-      type: counter
-      description: pg_stat_database_conflicts_confl_deadlock
-    version: 10
-  - query: SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock, confl_active_logicalslot
-      FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;
+- tag: pg_stat_database_conflicts
+  collector: stat_conflicts
+  sort: data
+  queries:
+  - query: SELECT datname, confl_tablespace, confl_lock, confl_snapshot, confl_bufferpin, confl_deadlock, confl_active_logicalslot FROM pg_stat_database_conflicts WHERE datname IS NOT NULL ORDER BY datname;
+    version: 16
     columns:
     - name: database
       type: label
@@ -1216,28 +948,13 @@ metrics:
     - name: confl_active_logicalslot
       type: counter
       description: pg_stat_database_conflicts_confl_active_logicalslot
-  tag: pg_stat_database_conflicts
+- tag: pg_stat_all_indexes
+  collector: stat_all_indexes
   sort: data
-  collector: stat_conflicts
-- queries:
-  - query: SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, relname
-      FROM pg_stat_all_indexes GROUP BY relname;
-    columns:
-    - type: counter
-      name: idx_scans
-      description: Number of index scans on the table's indexes.
-    - type: counter
-      name: idx_tup_reads
-      description: Number of index entries returned by scans on the table's indexes.
-    - type: counter
-      name: idx_tup_fetchs
-      description: Number of rows fetched by simple index scans on the table's indexes.
-    - type: label
-      name: relname
-    version: 10
-  - query: SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, COALESCE(MIN((EXTRACT(EPOCH
-      FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms, relname FROM pg_stat_all_indexes
-      WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;
+  database: all
+  queries:
+  - query: SELECT SUM(idx_scan) AS idx_scans, SUM(idx_tup_read) AS idx_tup_reads, SUM(idx_tup_fetch) AS idx_tup_fetchs, COALESCE(MIN((EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - last_idx_scan)) * 1000)::bigint), 0) AS time_elapsed_ms, relname FROM pg_stat_all_indexes WHERE (current_database() = 'postgres' OR schemaname NOT LIKE 'pg_%') GROUP BY relname;
+    version: 16
     columns:
     - type: counter
       name: idx_scans
@@ -1253,26 +970,10 @@ metrics:
       description: Milliseconds since last scan of an index in the table.
     - type: label
       name: relname
-  tag: pg_stat_all_indexes
-  sort: data
-  collector: stat_all_indexes
-  database: all
-- queries:
-  - query: SELECT type, count(*) as count FROM pg_wait_events GROUP BY type ORDER BY count DESC;
-    columns:
-    - name: type
-      type: label
-    - name: count
-      type: gauge
-      description: pg_wait_events_count
-  tag: pg_wait_events
-  sort: data
-  collector: wait_events
-- queries:
-  # New view for checkpoint statistics
-  - query: "SELECT\n  num_timed,\n  num_requested,\n  num_done,\n  restartpoints_timed,\n  restartpoints_req,\n  restartpoints_done,\n\
-      \  write_time,\n  sync_time,\n  buffers_written,\n  slru_written,\n  EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint\
-      \ AS stats_reset_seconds\nFROM pg_stat_checkpointer;"
+- tag: pg_stat_checkpointer
+  collector: stat_checkpointer
+  queries:
+  - query: SELECT num_timed, num_requested, num_done, restartpoints_timed, restartpoints_req, restartpoints_done, write_time, sync_time, buffers_written, slru_written, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stats_reset))::bigint AS stats_reset_seconds FROM pg_stat_checkpointer;
     version: 18
     columns:
     - name: num_timed
@@ -1308,13 +1009,11 @@ metrics:
     - name: stats_reset_seconds
       type: counter
       description: Seconds since statistics were last reset
-  tag: pg_stat_checkpointer
-  collector: stat_checkpointer
-- queries:
-  # Newly introduced async I/O statistics
-  - query: "SELECT\n  state,\n  operation,\n  COUNT(*) AS total_operations,\n  SUM(length) AS total_bytes,\n  AVG(length)\
-      \ AS avg_bytes_per_op,\n  COUNT(*) FILTER (WHERE f_sync) AS sync_operations,\n  COUNT(*) FILTER (WHERE f_buffered) AS\
-      \ buffered_operations\nFROM pg_aios\nGROUP BY state, operation;"
+- tag: pg_aios
+  collector: aios
+  sort: data
+  queries:
+  - query: SELECT state, operation, COUNT(*) AS total_operations, SUM(length) AS total_bytes, AVG(length) AS avg_bytes_per_op, COUNT(*) FILTER (WHERE f_sync) AS sync_operations, COUNT(*) FILTER (WHERE f_buffered) AS buffered_operations FROM pg_aios GROUP BY state, operation;
     version: 18
     columns:
     - name: state
@@ -1338,33 +1037,15 @@ metrics:
     - name: buffered_operations
       type: gauge
       description: Number of buffered operations
-  tag: pg_aios
+- tag: pg_wait_events
+  collector: wait_events
   sort: data
-  collector: aios
-- queries:
-  # Added NUMA-aware shared memory allocation tracking
-  - query: "SELECT\n  numa_node,\n  COUNT(*) AS allocations,\n  SUM(size) AS total_bytes,\n  AVG(size) AS avg_bytes,\n  MAX(size)\
-      \ AS max_bytes,\n  MIN(size) AS min_bytes\nFROM pg_shmem_allocations_numa\nGROUP BY numa_node\nORDER BY numa_node;"
-    version: 18
+  queries:
+  - query: SELECT type, count(*) as count FROM pg_wait_events GROUP BY type ORDER BY count DESC;
+    version: 17
     columns:
-    - name: numa_node
+    - name: type
       type: label
-      description: NUMA node number
-    - name: allocations
+    - name: count
       type: gauge
-      description: Number of shared memory allocations on this NUMA node
-    - name: total_bytes
-      type: gauge
-      description: Total bytes allocated on this NUMA node
-    - name: avg_bytes
-      type: gauge
-      description: Average allocation size on this NUMA node
-    - name: max_bytes
-      type: gauge
-      description: Maximum allocation size on this NUMA node
-    - name: min_bytes
-      type: gauge
-      description: Minimum allocation size on this NUMA node
-  tag: pg_shmem_allocations_numa
-  sort: data
-  collector: shmem_numa
+      description: pg_wait_events_count

--- a/doc/DEVELOPERS.md
+++ b/doc/DEVELOPERS.md
@@ -378,6 +378,23 @@ git checkout -b mywork main
 
 Remember to verify the compile and execution of the code
 
+### Editing Queries and Metrics
+
+When modifying queries or metrics in `src/include/internal.h`:
+
+1. Make your changes to `src/include/internal.h`
+2. Regenerate the contrib files:
+   ```bash
+   make generate-contrib
+   ```
+   Or from the repo root:
+   ```bash
+   python3 scripts/generate_contrib.py --internal-h src/include/internal.h
+   ```
+3. Commit both `src/include/internal.h` and the regenerated `contrib/yaml/*.yaml` and `contrib/json/*.json` files together
+
+The generator parses `internal.h` (the single source of truth), validates schemas, and outputs YAML and JSON for PostgreSQL 13–18. Manual edits to contrib files will be detected and rejected by the CI drift check.
+
 ### AUTHORS
 
 Remember to add your name to

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -25,6 +25,7 @@ Ahmed Osama Fathy <ahmedosamaft@gmail.com>
 Vanes Angelo <k124k3n@gmail.com>
 Sara Nabih <nabihsara8@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
+Somye Mahajan <mahajan.somye@gmail.com>
 ```
 
 ## Contributing

--- a/scripts/generate_contrib.py
+++ b/scripts/generate_contrib.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+Generate versioned PostgreSQL metric YAML and JSON files from src/include/internal.h.
+
+This script reads the INTERNAL_YAML macro from the C header file, applies a
+selection algorithm to pick the correct query variant per PostgreSQL version,
+and outputs versioned files to contrib/yaml and contrib/json directories.
+
+Usage:
+    generate_contrib.py --internal-h <path> [--yaml-only | --json-only] [--check] [--verbose]
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    import yaml 
+except ImportError as exc: 
+    raise SystemExit(
+        "PyYAML is required. Install with: python3 -m pip install pyyaml"
+    ) from exc
+
+
+def setup_logging(verbose: bool = False) -> logging.Logger:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format='%(levelname)s: %(message)s'
+    )
+    return logging.getLogger(__name__)
+
+
+SUPPORTED_VERSIONS: List[int] = [13, 14, 15, 16, 17, 18]
+
+
+def extract_internal_yaml(internal_h_path: Path) -> str:
+    with open(internal_h_path, 'r') as f:
+        lines = f.readlines()
+    
+    # Find the start of #define INTERNAL_YAML
+    macro_start = None
+    for i, line in enumerate(lines):
+        if '#define INTERNAL_YAML' in line:
+            macro_start = i
+            break
+    
+    if macro_start is None:
+        raise ValueError("Could not find INTERNAL_YAML macro in internal.h")
+    
+    # Collect all lines of the macro (including line continuations)
+    macro_lines = []
+    i = macro_start
+    while i < len(lines):
+        line = lines[i]
+        if line.rstrip().endswith('\\'):
+            macro_lines.append(line.rstrip()[:-1])  # Remove \ and trailing whitespace
+        else:
+            macro_lines.append(line.rstrip())
+            break
+        i += 1
+    
+    # Join all lines
+    full_macro = ''.join(macro_lines)
+    
+    # Remove the #define INTERNAL_YAML "" prefix
+    import re
+    define_match = re.match(r'#define\s+INTERNAL_YAML\s+""', full_macro)
+    if not define_match:
+        raise ValueError("Unexpected INTERNAL_YAML macro format")
+    
+    content = full_macro[define_match.end():]
+    
+    # Manually extract quoted strings and properly handle escapes
+    yaml_parts = []
+    in_string = False
+    current_string = []
+    i = 0
+    while i < len(content):
+        c = content[i]
+        
+        if not in_string:
+            if c == '"':
+                in_string = True
+                i += 1
+                continue
+            else:
+                i += 1
+                continue
+        
+        if c == '\\' and i + 1 < len(content):
+            # Escape sequence
+            next_char = content[i + 1]
+            if next_char == 'n':
+                current_string.append('\n')
+                i += 2
+            elif next_char == 't':
+                current_string.append('\t')
+                i += 2
+            elif next_char == 'r':
+                current_string.append('\r')
+                i += 2
+            elif next_char == '\\':
+                current_string.append('\\')
+                i += 2
+            elif next_char == '"':
+                current_string.append('"')
+                i += 2
+            else:
+                # Unknown escape, keep as-is
+                current_string.append(c)
+                i += 1
+        elif c == '"':
+            # End of string
+            in_string = False
+            yaml_parts.append(''.join(current_string))
+            current_string = []
+            i += 1
+        else:
+            current_string.append(c)
+            i += 1
+    
+    if not yaml_parts:
+        raise ValueError("Could not extract YAML strings from INTERNAL_YAML macro")
+    
+    yaml_str = ''.join(yaml_parts)
+    return yaml_str
+
+
+def parse_internal_yaml(yaml_str: str) -> Dict[str, Any]:
+    data = yaml.safe_load(yaml_str)
+    validate_schema(data)
+    return data
+
+
+def validate_schema(data: Dict[str, Any]) -> None:
+    if not isinstance(data, dict):
+        raise ValueError("YAML root must be a dict")
+    
+    if 'version' not in data:
+        raise ValueError("YAML missing required 'version' field")
+    
+    if 'metrics' not in data:
+        raise ValueError("YAML missing required 'metrics' field")
+    
+    if not isinstance(data['metrics'], list):
+        raise ValueError("'metrics' must be a list")
+    
+    seen_tags = set()
+    valid_column_types = {'gauge', 'counter', 'label', 'histogram'}
+    
+    for i, metric in enumerate(data['metrics']):
+        if not isinstance(metric, dict):
+            raise ValueError(f"Metric {i} must be a dict")
+        
+        # Check required fields
+        if 'tag' not in metric:
+            raise ValueError(f"Metric {i} missing required 'tag' field")
+        
+        tag = metric['tag']
+        if not isinstance(tag, str):
+            raise ValueError(f"Metric {i} 'tag' must be a string, got {type(tag)}")
+        
+        if tag in seen_tags:
+            raise ValueError(f"Metric {i}: duplicate tag '{tag}'")
+        seen_tags.add(tag)
+        
+        if 'queries' not in metric:
+            raise ValueError(f"Metric {i} ({tag}) missing required 'queries' field")
+        
+        if not isinstance(metric['queries'], list):
+            raise ValueError(f"Metric {i} ({tag}) 'queries' must be a list")
+        
+        if not metric['queries']:
+            raise ValueError(f"Metric {i} ({tag}) has empty 'queries' list")
+        
+        # Validate each query variant
+        versions_seen = set()
+        for j, query in enumerate(metric['queries']):
+            if not isinstance(query, dict):
+                raise ValueError(f"Metric {i} ({tag}) query {j} must be a dict")
+            
+            if 'version' not in query:
+                raise ValueError(f"Metric {i} ({tag}) query {j} missing 'version'")
+            
+            if 'query' not in query:
+                raise ValueError(f"Metric {i} ({tag}) query {j} missing 'query'")
+            
+            if 'columns' not in query:
+                raise ValueError(f"Metric {i} ({tag}) query {j} missing 'columns'")
+            
+            version = query['version']
+            if version in versions_seen:
+                raise ValueError(f"Metric {i} ({tag}): duplicate version {version}")
+            versions_seen.add(version)
+            
+            # Validate columns
+            columns = query['columns']
+            if not isinstance(columns, list):
+                raise ValueError(f"Metric {i} ({tag}) query {j} 'columns' must be a list")
+            
+            for k, col in enumerate(columns):
+                if not isinstance(col, dict):
+                    raise ValueError(f"Metric {i} ({tag}) query {j} column {k} must be a dict")
+                
+                if 'type' not in col:
+                    raise ValueError(f"Metric {i} ({tag}) query {j} column {k} missing 'type'")
+                
+                col_type = col['type']
+                if col_type not in valid_column_types:
+                    raise ValueError(
+                        f"Metric {i} ({tag}) query {j} column {k}: "
+                        f"invalid type '{col_type}' (valid: {valid_column_types})"
+                    )
+
+
+def select_query_variant(metric: Dict[str, Any], target_version: int) -> Optional[Dict[str, Any]]:
+    queries = metric.get('queries', [])
+    if not queries:
+        return None
+    
+    # Sort by version descending to find highest matching version first
+    sorted_queries = sorted(queries, key=lambda q: q.get('version', 0), reverse=True)
+    
+    for query_variant in sorted_queries:
+        variant_version = query_variant.get('version', 0)
+        if variant_version <= target_version:
+            return query_variant
+    
+    return None
+
+
+def build_metric_for_version(
+    metric: Dict[str, Any],
+    target_version: int,
+    logger: logging.Logger
+) -> Optional[Dict[str, Any]]:
+    tag = metric.get('tag')
+    if not tag:
+        logger.warning("Metric missing 'tag' field, skipping")
+        return None
+    
+    selected_query = select_query_variant(metric, target_version)
+    if not selected_query:
+        logger.debug(f"No query variant found for {tag} on PG {target_version}")
+        return None
+    
+    # Build output metric: top-level fields + selected query
+    output_metric = {
+        'tag': tag,
+        'collector': metric.get('collector', tag),
+    }
+    
+    # Add optional top-level fields if present
+    for field in ['sort', 'server', 'database']:
+        if field in metric:
+            output_metric[field] = metric[field]
+    
+    # Add the selected query and its columns
+    output_metric['queries'] = [
+        {
+            'query': selected_query['query'],
+            'version': selected_query['version'],
+            'columns': selected_query.get('columns', []),
+        }
+    ]
+    
+    return output_metric
+
+
+def generate_for_version(
+    data: Dict[str, Any],
+    target_version: int,
+    logger: logging.Logger
+) -> Dict[str, Any]:
+    output = {
+        'version': target_version,
+        'metrics': []
+    }
+    
+    metrics = data.get('metrics', [])
+    logger.info(f"Processing {len(metrics)} metrics for PostgreSQL {target_version}")
+    
+    for metric in metrics:
+        built_metric = build_metric_for_version(metric, target_version, logger)
+        if built_metric:
+            output['metrics'].append(built_metric)
+    
+    logger.info(f"Generated {len(output['metrics'])} metrics for PostgreSQL {target_version}")
+    return output
+
+
+def write_yaml_file(output_data: Dict[str, Any], output_path: Path, logger: logging.Logger) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, 'w') as f:
+        yaml.dump(
+            output_data,
+            f,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+            indent=2,
+            width=4096,
+        )
+    logger.info(f"Wrote {output_path}")
+
+
+def write_json_file(output_data: Dict[str, Any], output_path: Path, logger: logging.Logger) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    with open(output_path, 'w') as f:
+        json.dump(output_data, f, indent=2)
+        f.write('\n')
+    
+    logger.info(f"Wrote {output_path}")
+
+
+def check_file_diff(generated_path: Path, existing_path: Path, logger: logging.Logger) -> bool:
+    if not existing_path.exists():
+        logger.warning(f"Existing file not found: {existing_path}")
+        return True
+    
+    with open(generated_path, 'r') as f:
+        generated = f.read()
+    
+    with open(existing_path, 'r') as f:
+        existing = f.read()
+    
+    if generated != existing:
+        logger.warning(f"Diff detected: {existing_path}")
+        return True
+    
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        '--internal-h',
+        required=True,
+        type=Path,
+        help='Path to src/include/internal.h'
+    )
+    parser.add_argument(
+        '--yaml-only',
+        action='store_true',
+        help='Generate only YAML files'
+    )
+    parser.add_argument(
+        '--json-only',
+        action='store_true',
+        help='Generate only JSON files'
+    )
+    parser.add_argument(
+        '--check',
+        action='store_true',
+        help='Check mode: compare generated files with existing; exit non-zero if diffs found'
+    )
+    parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help='Verbose logging'
+    )
+    
+    args = parser.parse_args()
+    logger = setup_logging(args.verbose)
+    
+    # Validate arguments
+    if args.yaml_only and args.json_only:
+        logger.error("Cannot use both --yaml-only and --json-only")
+        sys.exit(1)
+    
+    # Determine output directory
+    repo_root = args.internal_h.parent.parent.parent
+    contrib_yaml_dir = repo_root / 'contrib' / 'yaml'
+    contrib_json_dir = repo_root / 'contrib' / 'json'
+    
+    logger.info(f"Repository root: {repo_root}")
+    logger.info(f"YAML output: {contrib_yaml_dir}")
+    logger.info(f"JSON output: {contrib_json_dir}")
+    
+    try:
+        # Extract and parse INTERNAL_YAML
+        logger.info(f"Reading {args.internal_h}")
+        yaml_str = extract_internal_yaml(args.internal_h)
+        data = parse_internal_yaml(yaml_str)
+        
+        # If check mode, write to temp location first
+        if args.check:
+            import tempfile
+            temp_dir = Path(tempfile.mkdtemp(prefix='pgexporter_gen_'))
+            output_yaml_dir = temp_dir / 'yaml'
+            output_json_dir = temp_dir / 'json'
+            output_yaml_dir.mkdir(parents=True, exist_ok=True)
+            output_json_dir.mkdir(parents=True, exist_ok=True)
+        else:
+            output_yaml_dir = contrib_yaml_dir
+            output_json_dir = contrib_json_dir
+        
+        # Generate for each version
+        has_diffs = False
+        diff_paths: List[Path] = []
+        
+        for version in SUPPORTED_VERSIONS:
+            output_data = generate_for_version(data, version, logger)
+            
+            # Write YAML
+            if not args.json_only:
+                yaml_path = output_yaml_dir / f'postgresql-{version}.yaml'
+                write_yaml_file(output_data, yaml_path, logger)
+                
+                if args.check:
+                    existing_yaml = contrib_yaml_dir / f'postgresql-{version}.yaml'
+                    if check_file_diff(yaml_path, existing_yaml, logger):
+                        has_diffs = True
+                        diff_paths.append(existing_yaml)
+            
+            # Write JSON
+            if not args.yaml_only:
+                json_path = output_json_dir / f'postgresql-{version}.json'
+                write_json_file(output_data, json_path, logger)
+                
+                if args.check:
+                    existing_json = contrib_json_dir / f'postgresql-{version}.json'
+                    if check_file_diff(json_path, existing_json, logger):
+                        has_diffs = True
+                        diff_paths.append(existing_json)
+        
+        if args.check and has_diffs:
+            logger.error("Drift detected: generated files differ from existing")
+            for p in diff_paths:
+                logger.error(f"Diff file: {p}")
+            sys.exit(1)
+        
+        logger.info("Done")
+        sys.exit(0)
+    
+    except Exception as e:
+        logger.error(f"{type(e).__name__}: {e}")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Resolves #361 

## Changes
- Added a python script `scripts/generate_contrib.py` which parses `internal.h` and generates yaml and json files for versions 13-18
- Selects the highest query version <= target PostgreSQL version
- PyYAML based parsing with validations for required fields
- Added `generate-contrib` custom target in cmake
- Added a CI job which checks for drifts - preventing manual edits or out-of-sync commits

## Dev Workflow
Edit `internal.h` -> run `make generate-contrib` -> commit 