### PR TITLE
[#369] Added global postgresql query timeout

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Ahmed Osama Fathy <ahmedosamaft@gmail.com>
 Vanes Angelo <k124k3n@gmail.com>
 Sara Nabih <nabihsara8@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
+Somye Mahajan <mahajan.somye@gmail.com>

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -28,6 +28,7 @@ See a [sample](./etc/pgexporter.conf) configuration for running `pgexporter` on 
 | metrics_path | | String | No | Path to customized metrics (either a YAML file or a directory with YAML files). Can interpolate environment variables (e.g., `$HOME`) |
 | metrics_cache_max_age | 0 | String | No | The number of seconds to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Can be a string with a suffix, like `2m` to indicate 2 minutes |
 | metrics_cache_max_size | 256k | String | No | The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart. This parameter determines the size of memory allocated for the cache even if `metrics_cache_max_age` or `metrics` are disabled. Its value, however, is taken into account only if `metrics_cache_max_age` is set to a non-zero value. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes).|
+| metrics_query_timeout | 0 | Int | No | The timeout in milliseconds for metric SQL queries. If set to 0, no timeout is applied. Minimum value is 50ms when set |
 | bridge | | Int | No | The bridge port |
 | bridge_endpoints | | String | No | A comma-separated list of bridge endpoints specified by host:port |
 | bridge_cache_max_age | `5m` | String | No | The number of seconds to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Can be a string with a suffix, like `2m` to indicate 2 minutes |

--- a/doc/man/pgexporter.conf.5.rst
+++ b/doc/man/pgexporter.conf.5.rst
@@ -52,6 +52,11 @@ metrics_cache_max_size
   M or MB (megabytes), G or GB (gigabytes).
   Default is 256k
 
+metrics_query_timeout
+  The timeout in milliseconds for metric SQL queries.
+  If set to 0, no timeout is applied. Minimum value is 50ms when set
+  Default is 0
+
 bridge
   The bridge port
 

--- a/doc/manual/en/04-configuration.md
+++ b/doc/manual/en/04-configuration.md
@@ -28,6 +28,7 @@ See a [sample][sample] configuration for running [**pgexporter**][pgexporter] on
 | metrics_path | | String | No | Path to customized metrics (either a YAML file or a directory with YAML files) |
 | metrics_cache_max_age | 0 | String | No | The number of seconds to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Can be a string with a suffix, like `2m` to indicate 2 minutes |
 | metrics_cache_max_size | 256k | String | No | The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart. This parameter determines the size of memory allocated for the cache even if `metrics_cache_max_age` or `metrics` are disabled. Its value, however, is taken into account only if `metrics_cache_max_age` is set to a non-zero value. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes).|
+| metrics_query_timeout | 0 | Int | No | The timeout in milliseconds for metric SQL queries. If set to 0, no timeout is applied. Minimum value is 50ms when set |
 | bridge | | Int | No | The bridge port |
 | bridge_endpoints | | String | No | A comma-separated list of bridge endpoints specified by host:port |
 | bridge_cache_max_age | `5m` | String | No | The number of seconds to keep in cache a Prometheus (bridge) response. If set to zero, the caching will be disabled. Can be a string with a suffix, like `2m` to indicate 2 minutes |

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -25,6 +25,7 @@ Ahmed Osama Fathy <ahmedosamaft@gmail.com>
 Vanes Angelo <k124k3n@gmail.com>
 Sara Nabih <nabihsara8@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
+Somye Mahajan <mahajan.somye@gmail.com>
 ```
 
 ## Contributing

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -68,6 +68,7 @@ extern "C" {
 #define CONFIGURATION_ARGUMENT_METRICS_CERT_FILE          "metrics_cert_file"
 #define CONFIGURATION_ARGUMENT_METRICS_KEY_FILE           "metrics_key_file"
 #define CONFIGURATION_ARGUMENT_METRICS_CA_FILE            "metrics_ca_file"
+#define CONFIGURATION_ARGUMENT_METRICS_QUERY_TIMEOUT      "metrics_query_timeout"
 #define CONFIGURATION_ARGUMENT_LIBEV                      "libev"
 #define CONFIGURATION_ARGUMENT_KEEP_ALIVE                 "keep_alive"
 #define CONFIGURATION_ARGUMENT_NODELAY                    "nodelay"

--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -370,6 +370,7 @@ struct configuration
    int metrics;                   /**< The metrics port */
    int metrics_cache_max_age;     /**< Number of seconds to cache the Prometheus response */
    size_t metrics_cache_max_size; /**< Number of bytes max to cache the Prometheus response */
+   int metrics_query_timeout;     /**< Timeout in milliseconds for metric queries */
    int management;                /**< The management port */
 
    int bridge;                        /**< The bridge port */

--- a/src/include/queries.h
+++ b/src/include/queries.h
@@ -114,6 +114,15 @@ int
 pgexporter_query_execute(int server, char* sql, char* tag, struct query** query);
 
 /**
+ * Execute a command that doesn't return result sets
+ * @param server The server
+ * @param sql The SQL command to execute
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_execute_command(int server, char* sql);
+
+/**
  * Query PostgreSQL version
  * @param server The server
  * @param query The resulting query

--- a/src/libpgexporter/prometheus.c
+++ b/src/libpgexporter/prometheus.c
@@ -896,6 +896,10 @@ version_information(SSL* client_ssl, int client_fd)
          {
             all = pgexporter_merge_queries(all, query, SORT_NAME);
          }
+         else
+         {
+            pgexporter_log_error("Failed to query version for server %s", config->servers[server].name);
+         }
          query = NULL;
       }
    }
@@ -969,6 +973,10 @@ uptime_information(SSL* client_ssl, int client_fd)
          {
             all = pgexporter_merge_queries(all, query, SORT_NAME);
          }
+         else
+         {
+            pgexporter_log_error("Failed to query uptime for server %s", config->servers[server].name);
+         }
          query = NULL;
       }
    }
@@ -1035,6 +1043,10 @@ primary_information(SSL* client_ssl, int client_fd)
          if (ret == 0)
          {
             all = pgexporter_merge_queries(all, query, SORT_NAME);
+         }
+         else
+         {
+            pgexporter_log_error("Failed to query primary for server %s", config->servers[server].name);
          }
          query = NULL;
       }
@@ -1205,6 +1217,10 @@ settings_information(SSL* client_ssl, int client_fd)
          if (ret == 0)
          {
             all = pgexporter_merge_queries(all, query, SORT_DATA0);
+         }
+         else
+         {
+            pgexporter_log_error("Failed to query settings for server %s", config->servers[server].name);
          }
          query = NULL;
       }
@@ -1377,6 +1393,11 @@ extension_metrics(SSL* client_ssl, int client_fd)
             {
                ext_temp->error = pgexporter_custom_query(server, query_alt->node.query, prom->tag, query_alt->node.n_columns, names, &ext_temp->query);
                ext_temp->sort_type = prom->sort_type;
+            }
+
+            if (ext_temp->error != 0)
+            {
+               pgexporter_log_error("Failed to execute extension query for server %s, extension %s, tag %s", config->servers[server].name, ext_info->name, prom->tag);
             }
 
             free(names);
@@ -1578,6 +1599,11 @@ custom_metrics(SSL* client_ssl, int client_fd)
             {
                temp->error = pgexporter_custom_query(server, query_alt->node.query, prom->tag, query_alt->node.n_columns, names, &temp->query);
                temp->sort_type = prom->sort_type;
+            }
+
+            if (temp->error != 0)
+            {
+               pgexporter_log_error("Failed to execute custom query for server %s, database %s, tag %s", config->servers[server].name, database, prom->tag);
             }
 
             pgexporter_snprintf(temp->database, DB_NAME_LENGTH, "%s", database);


### PR DESCRIPTION
### Changes
- Introduced a new `metrics_query_timeout`,  allowing users to set a global timeout (in milliseconds) for all metric SQL queries.
- Implemented logic in the connection setup and database switch routines to automatically set the PostgreSQL `statement_timeout` for all metric connections, enforcing the configured timeout.
- Added minimum value check of 50ms to prevent too low timeouts.
- Added a new function `pgexporter_execute_command` to execute the queries that dont return dataset.


### Testing
- Tested this functionality by setting a too low timeout (bypassing the 50ms constraint) and the `settings` information was skipped due to the timeout
- Tested by adding a custom metrics which sleeps for 3 seconds and the timeout caused it to skip that request.