### PR TITLE
Fix missing libatomic in RPM Dockerfile

### DIFF
--- a/contrib/docker/rpm/Dockerfile
+++ b/contrib/docker/rpm/Dockerfile
@@ -4,7 +4,7 @@ FROM almalinux:$OS_VERSION-minimal
 
 RUN microdnf upgrade -y
 RUN microdnf install -y git gcc cmake make rpm-build rpm-devel rpmlint diffutils patch rpmdevtools chrpath
-RUN microdnf install --enablerepo=crb -y check-devel zlib-devel bzip2-devel lz4-devel libev-devel openssl-devel python3-docutils doxygen libyaml-devel lz4 systemd-devel
+RUN microdnf install --enablerepo=crb -y check-devel zlib-devel bzip2-devel lz4-devel libev-devel libatomic openssl-devel python3-docutils doxygen libyaml-devel lz4 systemd-devel
 RUN microdnf clean all && rm -rf /var/cache/yum
 WORKDIR /root
 RUN rpmdev-setuptree


### PR DESCRIPTION
While using the RPM Dockerfile to build a RPM, I came across the following error, which is easy to fix:

```
CMake Error at CMakeLists.txt:180 (message):
  libatomic needed


-- Configuring incomplete, errors occurred!
```