### PR TITLE
Fix pg_statio metrics

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Sara Nabih <nabihsara8@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Somye Mahajan <mahajan.somye@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
+Benjamin Li <bli@linsang.com>

--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -406,7 +406,7 @@
       "collector": "statio_all_tables",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
             {
@@ -458,7 +458,7 @@
       "collector": "statio_all_sequences",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -406,7 +406,7 @@
       "collector": "statio_all_tables",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
             {
@@ -458,7 +458,7 @@
       "collector": "statio_all_sequences",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -406,7 +406,7 @@
       "collector": "statio_all_tables",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
             {
@@ -458,7 +458,7 @@
       "collector": "statio_all_sequences",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -406,7 +406,7 @@
       "collector": "statio_all_tables",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
             {
@@ -458,7 +458,7 @@
       "collector": "statio_all_sequences",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -371,7 +371,7 @@
       "collector": "statio_all_tables",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
             {
@@ -423,7 +423,7 @@
       "collector": "statio_all_sequences",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-18.json
+++ b/contrib/json/postgresql-18.json
@@ -406,7 +406,7 @@
       "collector": "statio_all_tables",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
             {
@@ -458,7 +458,7 @@
       "collector": "statio_all_sequences",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
             {

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -215,7 +215,7 @@ metrics:
 - tag: pg_statio_all_tables
   collector: statio_all_tables
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
     - name: heap_blks_read
@@ -245,7 +245,7 @@ metrics:
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
     - name: blks_read

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -215,7 +215,7 @@ metrics:
 - tag: pg_statio_all_tables
   collector: statio_all_tables
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
     - name: heap_blks_read
@@ -245,7 +245,7 @@ metrics:
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
     - name: blks_read

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -215,7 +215,7 @@ metrics:
 - tag: pg_statio_all_tables
   collector: statio_all_tables
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
     - name: heap_blks_read
@@ -245,7 +245,7 @@ metrics:
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
     - name: blks_read

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -215,7 +215,7 @@ metrics:
 - tag: pg_statio_all_tables
   collector: statio_all_tables
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
     - name: heap_blks_read
@@ -245,7 +245,7 @@ metrics:
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
     - name: blks_read

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -194,7 +194,7 @@ metrics:
 - tag: pg_statio_all_tables
   collector: statio_all_tables
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
     - name: heap_blks_read
@@ -224,7 +224,7 @@ metrics:
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
     - name: blks_read

--- a/contrib/yaml/postgresql-18.yaml
+++ b/contrib/yaml/postgresql-18.yaml
@@ -215,7 +215,7 @@ metrics:
 - tag: pg_statio_all_tables
   collector: statio_all_tables
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT SUM(heap_blks_read) AS heap_blks_read, SUM(heap_blks_hit) AS heap_blks_hit, SUM(idx_blks_read) as idx_blks_read, SUM(idx_blks_hit) AS idx_blks_hit, SUM(toast_blks_read) AS toast_blks_read, SUM(toast_blks_hit) AS toast_blks_hit, SUM(tidx_blks_read) AS tidx_blks_read, SUM(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
     - name: heap_blks_read
@@ -245,7 +245,7 @@ metrics:
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT SUM(blks_read) AS blks_read, SUM(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
     - name: blks_read

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -491,14 +491,14 @@ extern "C" {
                       "# All tables statio\n"                                                                                                                                           \
                       "  - queries:\n"                                                                                                                                                  \
                       "    - query: SELECT\n"                                                                                                                                           \
-                      "                COUNT(heap_blks_read) AS heap_blks_read,\n"                                                                                                      \
-                      "                COUNT(heap_blks_hit) AS heap_blks_hit,\n"                                                                                                        \
-                      "                COUNT(idx_blks_read) as idx_blks_read,\n"                                                                                                        \
-                      "                COUNT(idx_blks_hit) AS idx_blks_hit,\n"                                                                                                          \
-                      "                COUNT(toast_blks_read) AS toast_blks_read,\n"                                                                                                    \
-                      "                COUNT(toast_blks_hit) AS toast_blks_hit,\n"                                                                                                      \
-                      "                COUNT(tidx_blks_read) AS tidx_blks_read,\n"                                                                                                      \
-                      "                COUNT(tidx_blks_hit) AS tidx_blks_hit\n"                                                                                                         \
+                      "                SUM(heap_blks_read) AS heap_blks_read,\n"                                                                                                        \
+                      "                SUM(heap_blks_hit) AS heap_blks_hit,\n"                                                                                                          \
+                      "                SUM(idx_blks_read) as idx_blks_read,\n"                                                                                                          \
+                      "                SUM(idx_blks_hit) AS idx_blks_hit,\n"                                                                                                            \
+                      "                SUM(toast_blks_read) AS toast_blks_read,\n"                                                                                                      \
+                      "                SUM(toast_blks_hit) AS toast_blks_hit,\n"                                                                                                        \
+                      "                SUM(tidx_blks_read) AS tidx_blks_read,\n"                                                                                                        \
+                      "                SUM(tidx_blks_hit) AS tidx_blks_hit\n"                                                                                                           \
                       "              FROM pg_statio_all_tables;\n"                                                                                                                      \
                       "      version: 10\n"                                                                                                                                             \
                       "      columns:\n"                                                                                                                                                \
@@ -532,8 +532,8 @@ extern "C" {
                       "# All sequences statio\n"                                                                                                                                        \
                       "  - queries:\n"                                                                                                                                                  \
                       "    - query: SELECT\n"                                                                                                                                           \
-                      "                COUNT(blks_read) AS blks_read,\n"                                                                                                                \
-                      "                COUNT(blks_hit) AS blks_hit\n"                                                                                                                   \
+                      "                SUM(blks_read) AS blks_read,\n"                                                                                                                  \
+                      "                SUM(blks_hit) AS blks_hit\n"                                                                                                                     \
                       "              FROM pg_statio_all_sequences;\n"                                                                                                                   \
                       "      version: 10\n"                                                                                                                                             \
                       "      columns:\n"                                                                                                                                                \


### PR DESCRIPTION
Previous query was effectively counting tables, instead of combining the data across each table. This change SUMs the data from pg_statio_all_tables and pg_statio_all_sequences, instead of counting rows from those tables.

This is a minimal fix for issue #377 