### PR TITLE
Make pg_statio metrics more useful

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Somye Mahajan <mahajan.somye@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
 Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
+Benjamin Li <bli@linsang.com>
 Amr Shams (NightBird) <amr.shams2015.a@gmail.com>
 Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>

--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -407,11 +407,20 @@
     {
       "tag": "pg_statio_all_tables",
       "collector": "statio_all_tables",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "heap_blks_read",
               "type": "counter",
@@ -459,11 +468,20 @@
     {
       "tag": "pg_statio_all_sequences",
       "collector": "statio_all_sequences",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "blks_read",
               "type": "counter",

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -407,11 +407,20 @@
     {
       "tag": "pg_statio_all_tables",
       "collector": "statio_all_tables",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "heap_blks_read",
               "type": "counter",
@@ -459,11 +468,20 @@
     {
       "tag": "pg_statio_all_sequences",
       "collector": "statio_all_sequences",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "blks_read",
               "type": "counter",

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -407,11 +407,20 @@
     {
       "tag": "pg_statio_all_tables",
       "collector": "statio_all_tables",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "heap_blks_read",
               "type": "counter",
@@ -459,11 +468,20 @@
     {
       "tag": "pg_statio_all_sequences",
       "collector": "statio_all_sequences",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "blks_read",
               "type": "counter",

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -407,11 +407,20 @@
     {
       "tag": "pg_statio_all_tables",
       "collector": "statio_all_tables",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "heap_blks_read",
               "type": "counter",
@@ -459,11 +468,20 @@
     {
       "tag": "pg_statio_all_sequences",
       "collector": "statio_all_sequences",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "blks_read",
               "type": "counter",

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -372,11 +372,20 @@
     {
       "tag": "pg_statio_all_tables",
       "collector": "statio_all_tables",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "heap_blks_read",
               "type": "counter",
@@ -424,11 +433,20 @@
     {
       "tag": "pg_statio_all_sequences",
       "collector": "statio_all_sequences",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "blks_read",
               "type": "counter",

--- a/contrib/json/postgresql-18.json
+++ b/contrib/json/postgresql-18.json
@@ -407,11 +407,20 @@
     {
       "tag": "pg_statio_all_tables",
       "collector": "statio_all_tables",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;",
+          "query": "SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "heap_blks_read",
               "type": "counter",
@@ -459,11 +468,20 @@
     {
       "tag": "pg_statio_all_sequences",
       "collector": "statio_all_sequences",
+      "database": "all",
       "queries": [
         {
-          "query": "SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;",
+          "query": "SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;",
           "version": 10,
           "columns": [
+            {
+              "name": "schemaname",
+              "type": "label"
+            },
+            {
+              "name": "relname",
+              "type": "label"
+            },
             {
               "name": "blks_read",
               "type": "counter",

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -217,10 +217,15 @@ metrics:
       description: Number of DB connections with SSL.
 - tag: pg_statio_all_tables
   collector: statio_all_tables
+  database: all
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: heap_blks_read
       type: counter
       description: Number of disk blocks read in postgres db.
@@ -247,10 +252,15 @@ metrics:
       description: Number of buffer hits read from postgres db's TOAST table indexes.
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
+  database: all
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: blks_read
       type: counter
       description: Number of disk blocks read from sequences in postgres db.

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -217,10 +217,15 @@ metrics:
       description: Number of DB connections with SSL.
 - tag: pg_statio_all_tables
   collector: statio_all_tables
+  database: all
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: heap_blks_read
       type: counter
       description: Number of disk blocks read in postgres db.
@@ -247,10 +252,15 @@ metrics:
       description: Number of buffer hits read from postgres db's TOAST table indexes.
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
+  database: all
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: blks_read
       type: counter
       description: Number of disk blocks read from sequences in postgres db.

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -217,10 +217,15 @@ metrics:
       description: Number of DB connections with SSL.
 - tag: pg_statio_all_tables
   collector: statio_all_tables
+  database: all
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: heap_blks_read
       type: counter
       description: Number of disk blocks read in postgres db.
@@ -247,10 +252,15 @@ metrics:
       description: Number of buffer hits read from postgres db's TOAST table indexes.
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
+  database: all
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: blks_read
       type: counter
       description: Number of disk blocks read from sequences in postgres db.

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -217,10 +217,15 @@ metrics:
       description: Number of DB connections with SSL.
 - tag: pg_statio_all_tables
   collector: statio_all_tables
+  database: all
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: heap_blks_read
       type: counter
       description: Number of disk blocks read in postgres db.
@@ -247,10 +252,15 @@ metrics:
       description: Number of buffer hits read from postgres db's TOAST table indexes.
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
+  database: all
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: blks_read
       type: counter
       description: Number of disk blocks read from sequences in postgres db.

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -196,10 +196,15 @@ metrics:
       description: Number of DB connections with SSL.
 - tag: pg_statio_all_tables
   collector: statio_all_tables
+  database: all
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: heap_blks_read
       type: counter
       description: Number of disk blocks read in postgres db.
@@ -226,10 +231,15 @@ metrics:
       description: Number of buffer hits read from postgres db's TOAST table indexes.
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
+  database: all
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: blks_read
       type: counter
       description: Number of disk blocks read from sequences in postgres db.

--- a/contrib/yaml/postgresql-18.yaml
+++ b/contrib/yaml/postgresql-18.yaml
@@ -217,10 +217,15 @@ metrics:
       description: Number of DB connections with SSL.
 - tag: pg_statio_all_tables
   collector: statio_all_tables
+  database: all
   queries:
-  - query: SELECT COUNT(heap_blks_read) AS heap_blks_read, COUNT(heap_blks_hit) AS heap_blks_hit, COUNT(idx_blks_read) as idx_blks_read, COUNT(idx_blks_hit) AS idx_blks_hit, COUNT(toast_blks_read) AS toast_blks_read, COUNT(toast_blks_hit) AS toast_blks_hit, COUNT(tidx_blks_read) AS tidx_blks_read, COUNT(tidx_blks_hit) AS tidx_blks_hit FROM pg_statio_all_tables;
+  - query: SELECT schemaname, relname, heap_blks_read AS heap_blks_read, heap_blks_hit AS heap_blks_hit, idx_blks_read as idx_blks_read, idx_blks_hit AS idx_blks_hit, toast_blks_read AS toast_blks_read, toast_blks_hit AS toast_blks_hit, tidx_blks_read AS tidx_blks_read, tidx_blks_hit AS tidx_blks_hit FROM pg_statio_all_tables;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: heap_blks_read
       type: counter
       description: Number of disk blocks read in postgres db.
@@ -247,10 +252,15 @@ metrics:
       description: Number of buffer hits read from postgres db's TOAST table indexes.
 - tag: pg_statio_all_sequences
   collector: statio_all_sequences
+  database: all
   queries:
-  - query: SELECT COUNT(blks_read) AS blks_read, COUNT(blks_hit) AS blks_hit FROM pg_statio_all_sequences;
+  - query: SELECT schemaname, relname, blks_read AS blks_read, blks_hit AS blks_hit FROM pg_statio_all_sequences;
     version: 10
     columns:
+    - name: schemaname
+      type: label
+    - name: relname
+      type: label
     - name: blks_read
       type: counter
       description: Number of disk blocks read from sequences in postgres db.

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -494,17 +494,23 @@ extern "C" {
                       "# All tables statio\n"                                                                                                                                           \
                       "  - queries:\n"                                                                                                                                                  \
                       "    - query: SELECT\n"                                                                                                                                           \
-                      "                COUNT(heap_blks_read) AS heap_blks_read,\n"                                                                                                      \
-                      "                COUNT(heap_blks_hit) AS heap_blks_hit,\n"                                                                                                        \
-                      "                COUNT(idx_blks_read) as idx_blks_read,\n"                                                                                                        \
-                      "                COUNT(idx_blks_hit) AS idx_blks_hit,\n"                                                                                                          \
-                      "                COUNT(toast_blks_read) AS toast_blks_read,\n"                                                                                                    \
-                      "                COUNT(toast_blks_hit) AS toast_blks_hit,\n"                                                                                                      \
-                      "                COUNT(tidx_blks_read) AS tidx_blks_read,\n"                                                                                                      \
-                      "                COUNT(tidx_blks_hit) AS tidx_blks_hit\n"                                                                                                         \
+                      "                schemaname,\n"                                                                                                                                   \
+                      "                relname,\n"                                                                                                                                      \
+                      "                heap_blks_read AS heap_blks_read,\n"                                                                                                             \
+                      "                heap_blks_hit AS heap_blks_hit,\n"                                                                                                               \
+                      "                idx_blks_read as idx_blks_read,\n"                                                                                                               \
+                      "                idx_blks_hit AS idx_blks_hit,\n"                                                                                                                 \
+                      "                toast_blks_read AS toast_blks_read,\n"                                                                                                           \
+                      "                toast_blks_hit AS toast_blks_hit,\n"                                                                                                             \
+                      "                tidx_blks_read AS tidx_blks_read,\n"                                                                                                             \
+                      "                tidx_blks_hit AS tidx_blks_hit\n"                                                                                                                \
                       "              FROM pg_statio_all_tables;\n"                                                                                                                      \
                       "      version: 10\n"                                                                                                                                             \
                       "      columns:\n"                                                                                                                                                \
+                      "        - name: schemaname\n"                                                                                                                                    \
+                      "          type: label\n"                                                                                                                                         \
+                      "        - name: relname\n"                                                                                                                                       \
+                      "          type: label\n"                                                                                                                                         \
                       "        - name: heap_blks_read\n"                                                                                                                                \
                       "          type: counter\n"                                                                                                                                       \
                       "          description: Number of disk blocks read in postgres db.\n"                                                                                             \
@@ -531,15 +537,22 @@ extern "C" {
                       "          description: Number of buffer hits read from postgres db's TOAST table indexes.\n"                                                                     \
                       "    tag: pg_statio_all_tables\n"                                                                                                                                 \
                       "    collector: statio_all_tables\n"                                                                                                                              \
+                      "    database: all\n"                                                                                                                                             \
                       "\n"                                                                                                                                                              \
                       "# All sequences statio\n"                                                                                                                                        \
                       "  - queries:\n"                                                                                                                                                  \
                       "    - query: SELECT\n"                                                                                                                                           \
-                      "                COUNT(blks_read) AS blks_read,\n"                                                                                                                \
-                      "                COUNT(blks_hit) AS blks_hit\n"                                                                                                                   \
+                      "                schemaname,\n"                                                                                                                                   \
+                      "                relname,\n"                                                                                                                                      \
+                      "                blks_read AS blks_read,\n"                                                                                                                       \
+                      "                blks_hit AS blks_hit\n"                                                                                                                          \
                       "              FROM pg_statio_all_sequences;\n"                                                                                                                   \
                       "      version: 10\n"                                                                                                                                             \
                       "      columns:\n"                                                                                                                                                \
+                      "        - name: schemaname\n"                                                                                                                                    \
+                      "          type: label\n"                                                                                                                                         \
+                      "        - name: relname\n"                                                                                                                                       \
+                      "          type: label\n"                                                                                                                                         \
                       "        - name: blks_read\n"                                                                                                                                     \
                       "          type: counter\n"                                                                                                                                       \
                       "          description: Number of disk blocks read from sequences in postgres db.\n"                                                                              \
@@ -548,6 +561,7 @@ extern "C" {
                       "          description: Number of buffer hits read from sequences in postgres db.\n"                                                                              \
                       "    tag: pg_statio_all_sequences\n"                                                                                                                              \
                       "    collector: statio_all_sequences\n"                                                                                                                           \
+                      "    database: all\n"                                                                                                                                             \
                       "\n"                                                                                                                                                              \
                       "# Stat user functions\n"                                                                                                                                         \
                       "  - queries:\n"                                                                                                                                                  \


### PR DESCRIPTION
 * Fix queries to report actual stats by relname instead of counting relations.
 * Run statio queries on all databases since they relate to the actual tables and not just the system as a whole.

This will effectively fix the issue I raised in #377.