### PR TITLE
[#371] Add optional flag for queries

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Sara Nabih <nabihsara8@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Somye Mahajan <mahajan.somye@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
+Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>

--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -223,6 +223,7 @@
       "tag": "pg_file_settings",
       "collector": "file_settings",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -326,6 +327,7 @@
       "tag": "pg_shadow",
       "collector": "auth_type",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -346,6 +348,7 @@
     {
       "tag": "pg_usr_evt_trigger",
       "collector": "usr_evt_trigger",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -223,6 +223,7 @@
       "tag": "pg_file_settings",
       "collector": "file_settings",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -326,6 +327,7 @@
       "tag": "pg_shadow",
       "collector": "auth_type",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -346,6 +348,7 @@
     {
       "tag": "pg_usr_evt_trigger",
       "collector": "usr_evt_trigger",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -223,6 +223,7 @@
       "tag": "pg_file_settings",
       "collector": "file_settings",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -326,6 +327,7 @@
       "tag": "pg_shadow",
       "collector": "auth_type",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -346,6 +348,7 @@
     {
       "tag": "pg_usr_evt_trigger",
       "collector": "usr_evt_trigger",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -223,6 +223,7 @@
       "tag": "pg_file_settings",
       "collector": "file_settings",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -326,6 +327,7 @@
       "tag": "pg_shadow",
       "collector": "auth_type",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -346,6 +348,7 @@
     {
       "tag": "pg_usr_evt_trigger",
       "collector": "usr_evt_trigger",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -188,6 +188,7 @@
       "tag": "pg_file_settings",
       "collector": "file_settings",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -291,6 +292,7 @@
       "tag": "pg_shadow",
       "collector": "auth_type",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -311,6 +313,7 @@
     {
       "tag": "pg_usr_evt_trigger",
       "collector": "usr_evt_trigger",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",

--- a/contrib/json/postgresql-18.json
+++ b/contrib/json/postgresql-18.json
@@ -223,6 +223,7 @@
       "tag": "pg_file_settings",
       "collector": "file_settings",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;",
@@ -326,6 +327,7 @@
       "tag": "pg_shadow",
       "collector": "auth_type",
       "sort": "data",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
@@ -346,6 +348,7 @@
     {
       "tag": "pg_usr_evt_trigger",
       "collector": "usr_evt_trigger",
+      "optional": true,
       "queries": [
         {
           "query": "SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';",

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -121,6 +121,7 @@ metrics:
 - tag: pg_file_settings
   collector: file_settings
   sort: data
+  optional: true
   queries:
   - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
     version: 10
@@ -174,6 +175,7 @@ metrics:
 - tag: pg_shadow
   collector: auth_type
   sort: data
+  optional: true
   queries:
   - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
@@ -184,6 +186,7 @@ metrics:
       description: Number of users with authentication type.
 - tag: pg_usr_evt_trigger
   collector: usr_evt_trigger
+  optional: true
   queries:
   - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
     version: 10

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -121,6 +121,7 @@ metrics:
 - tag: pg_file_settings
   collector: file_settings
   sort: data
+  optional: true
   queries:
   - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
     version: 10
@@ -174,6 +175,7 @@ metrics:
 - tag: pg_shadow
   collector: auth_type
   sort: data
+  optional: true
   queries:
   - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
@@ -184,6 +186,7 @@ metrics:
       description: Number of users with authentication type.
 - tag: pg_usr_evt_trigger
   collector: usr_evt_trigger
+  optional: true
   queries:
   - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
     version: 10

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -121,6 +121,7 @@ metrics:
 - tag: pg_file_settings
   collector: file_settings
   sort: data
+  optional: true
   queries:
   - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
     version: 10
@@ -174,6 +175,7 @@ metrics:
 - tag: pg_shadow
   collector: auth_type
   sort: data
+  optional: true
   queries:
   - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
@@ -184,6 +186,7 @@ metrics:
       description: Number of users with authentication type.
 - tag: pg_usr_evt_trigger
   collector: usr_evt_trigger
+  optional: true
   queries:
   - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
     version: 10

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -121,6 +121,7 @@ metrics:
 - tag: pg_file_settings
   collector: file_settings
   sort: data
+  optional: true
   queries:
   - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
     version: 10
@@ -174,6 +175,7 @@ metrics:
 - tag: pg_shadow
   collector: auth_type
   sort: data
+  optional: true
   queries:
   - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
@@ -184,6 +186,7 @@ metrics:
       description: Number of users with authentication type.
 - tag: pg_usr_evt_trigger
   collector: usr_evt_trigger
+  optional: true
   queries:
   - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
     version: 10

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -100,6 +100,7 @@ metrics:
 - tag: pg_file_settings
   collector: file_settings
   sort: data
+  optional: true
   queries:
   - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
     version: 10
@@ -153,6 +154,7 @@ metrics:
 - tag: pg_shadow
   collector: auth_type
   sort: data
+  optional: true
   queries:
   - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
@@ -163,6 +165,7 @@ metrics:
       description: Number of users with authentication type.
 - tag: pg_usr_evt_trigger
   collector: usr_evt_trigger
+  optional: true
   queries:
   - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
     version: 10

--- a/contrib/yaml/postgresql-18.yaml
+++ b/contrib/yaml/postgresql-18.yaml
@@ -121,6 +121,7 @@ metrics:
 - tag: pg_file_settings
   collector: file_settings
   sort: data
+  optional: true
   queries:
   - query: SELECT sourcefile, COUNT(*), ( CASE applied WHEN 't' THEN 'true' ELSE 'false' END ) as applied FROM pg_file_settings WHERE applied = 't' GROUP BY sourcefile, applied;
     version: 10
@@ -174,6 +175,7 @@ metrics:
 - tag: pg_shadow
   collector: auth_type
   sort: data
+  optional: true
   queries:
   - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
@@ -184,6 +186,7 @@ metrics:
       description: Number of users with authentication type.
 - tag: pg_usr_evt_trigger
   collector: usr_evt_trigger
+  optional: true
   queries:
   - query: SELECT COUNT(*) FROM pg_event_trigger JOIN pg_authid ON pg_event_trigger.oid = pg_authid.oid WHERE rolname != 'postgres';
     version: 10

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -27,6 +27,7 @@ Sara Nabih <nabihsara8@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Somye Mahajan <mahajan.somye@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
+Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
 ```
 
 ## Contributing

--- a/scripts/generate_contrib.py
+++ b/scripts/generate_contrib.py
@@ -255,7 +255,7 @@ def build_metric_for_version(
     }
     
     # Add optional top-level fields if present
-    for field in ['sort', 'server', 'database']:
+    for field in ['sort', 'server', 'database', 'optional']:
         if field in metric:
             output_metric[field] = metric[field]
     

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -356,6 +356,7 @@ extern "C" {
                       "        - name: applied\n"                                                                                                                                       \
                       "          type: label\n"                                                                                                                                         \
                       "    tag: pg_file_settings\n"                                                                                                                                     \
+                      "    optional: true\n"                                                                                                                                            \
                       "    sort: data\n"                                                                                                                                                \
                       "    collector: file_settings\n"                                                                                                                                  \
                       "\n"                                                                                                                                                              \
@@ -437,6 +438,7 @@ extern "C" {
                       "        - type: gauge\n"                                                                                                                                         \
                       "          description: Number of users with authentication type.\n"                                                                                              \
                       "    tag: pg_shadow\n"                                                                                                                                            \
+                      "    optional: true\n"                                                                                                                                            \
                       "    sort: data\n"                                                                                                                                                \
                       "    collector: auth_type\n"                                                                                                                                      \
                       "\n"                                                                                                                                                              \
@@ -452,6 +454,7 @@ extern "C" {
                       "        - type: gauge\n"                                                                                                                                         \
                       "          description: Number of user defined event triggers.\n"                                                                                                 \
                       "    tag: pg_usr_evt_trigger\n"                                                                                                                                   \
+                      "    optional: true\n"                                                                                                                                            \
                       "    collector: usr_evt_trigger\n"                                                                                                                                \
                       "\n"                                                                                                                                                              \
                       "# Get number of database connections\n"                                                                                                                          \

--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -332,6 +332,7 @@ struct prometheus
    int sort_type;                        /**< Sorting type of multi queries 0--SORT_NAME 1--SORT_DATA0 */
    int server_query_type;                /**< Query type 0--SERVER_QUERY_BOTH 1--SERVER_QUERY_PRIMARY 2--SERVER_QUERY_REPLICA */
    bool exec_on_all_dbs;                 /**< Execute on all databases */
+   bool optional;                        /**< If true, suppress warning on query failure */
    char collector[MAX_COLLECTOR_LENGTH]; /**< Collector Tag for query */
    struct pg_query_alts* pg_root;        /**< Root of the Query Alternatives' AVL Tree for PostgreSQL core queries*/
    struct ext_query_alts* ext_root;      /**< Root of the Query Alternatives' AVL Tree for PostgreSQL extension queries*/

--- a/src/libpgexporter/json_configuration.c
+++ b/src/libpgexporter/json_configuration.c
@@ -73,6 +73,7 @@ typedef struct json_metric
    char* collector;
    char* server;
    bool exec_on_all_dbs;
+   bool optional;
 } __attribute__((aligned(64))) json_metric_t;
 
 // Config's Structure
@@ -605,6 +606,23 @@ parse_metrics(struct json* metrics_array, json_config_t* config)
          current_metric->exec_on_all_dbs = false;
       }
 
+      if (pgexporter_json_contains_key(metric, "optional"))
+      {
+         char* optional = (char*)pgexporter_json_get(metric, "optional");
+         if (!strcmp("true", optional))
+         {
+            current_metric->optional = true;
+         }
+         else
+         {
+            current_metric->optional = false;
+         }
+      }
+      else
+      {
+         current_metric->optional = false; // default
+      }
+
       if (pgexporter_json_contains_key(metric, "queries"))
       {
          struct json* queries = (struct json*)pgexporter_json_get(metric, "queries");
@@ -832,6 +850,7 @@ semantics_json(struct prometheus* prometheus, int prometheus_idx, json_config_t*
 
       // Execute on all databases
       prom->exec_on_all_dbs = json_config->metrics[i].exec_on_all_dbs;
+      prom->optional = json_config->metrics[i].optional;
 
       // Queries
       for (int j = 0; j < json_config->metrics[i].n_queries; j++)

--- a/src/libpgexporter/prometheus.c
+++ b/src/libpgexporter/prometheus.c
@@ -1615,7 +1615,14 @@ custom_metrics(SSL* client_ssl, int client_fd)
 
             if (temp->error != 0)
             {
-               pgexporter_log_warn("Failed to execute custom query for server %s, database %s, tag %s", config->servers[server].name, database, prom->tag);
+               if (prom->optional)
+               {
+                  pgexporter_log_debug("Failed to execute custom query for server %s, database %s, tag %s", config->servers[server].name, database, prom->tag);
+               }
+               else
+               {
+                  pgexporter_log_warn("Failed to execute custom query for server %s, database %s, tag %s", config->servers[server].name, database, prom->tag);
+               }
             }
 
             pgexporter_snprintf(temp->database, DB_NAME_LENGTH, "%s", database);


### PR DESCRIPTION
Fix: #371 

Create an optional flag for a query (default is false) for:
- pg_file_settings
- pg_shadow
- pg_usr_evt_trigger

## Before
<img width="1166" height="143" alt="Screenshot from 2026-02-02 00-19-15" src="https://github.com/user-attachments/assets/d4c519cf-f12d-41a2-8b44-fd0761dc3f77" />

## After
<img width="1166" height="143" alt="Screenshot from 2026-02-02 00-19-45" src="https://github.com/user-attachments/assets/3ac041e7-f547-4f9c-b78a-70946ba66edb" />
