### PR TITLE
[#194] implement time based configuration generalization

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -26,12 +26,12 @@ See a [sample](./etc/pgexporter.conf) configuration for running `pgexporter` on 
 | unix_socket_dir | | String | Yes | The Unix Domain Socket location. Can interpolate environment variables (e.g., `$HOME`) |
 | metrics | | Int | Yes | The metrics port |
 | metrics_path | | String | No | Path to customized metrics (either a YAML file or a directory with YAML files). Can interpolate environment variables (e.g., `$HOME`) |
-| metrics_cache_max_age | 0 | String | No | The number of seconds to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Can be a string with a suffix, like `2m` to indicate 2 minutes |
+| metrics_cache_max_age | 0 | String | No | The duration to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Supports suffixes: 'ms' (milliseconds), 's' (seconds, default), 'm' (minutes), 'h' (hours), 'd' (days), 'w' (weeks). |
 | metrics_cache_max_size | 256k | String | No | The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart. This parameter determines the size of memory allocated for the cache even if `metrics_cache_max_age` or `metrics` are disabled. Its value, however, is taken into account only if `metrics_cache_max_age` is set to a non-zero value. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes).|
-| metrics_query_timeout | 0 | Int | No | The timeout in milliseconds for metric SQL queries. If set to 0, no timeout is applied. Minimum value is 50ms when set |
+| metrics_query_timeout | 0 | String | No | The timeout for metric SQL queries. If set to 0, no timeout is applied. Minimum value is 50ms when set. Supports suffixes: 'ms' (milliseconds, default), 's' (seconds), 'm' (minutes), 'h' (hours), 'd' (days), 'w' (weeks). |
 | bridge | | Int | No | The bridge port |
 | bridge_endpoints | | String | No | A comma-separated list of bridge endpoints specified by host:port |
-| bridge_cache_max_age | `5m` | String | No | The number of seconds to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Can be a string with a suffix, like `2m` to indicate 2 minutes |
+| bridge_cache_max_age | `5m` | String | No | The duration to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Supports suffixes: 'ms' (milliseconds), 's' (seconds, default), 'm' (minutes), 'h' (hours), 'd' (days), 'w' (weeks). |
 | bridge_cache_max_size | `10M` | String | No | The maximum amount of data to keep in cache when serving bridge responses. Changes require restart. If set to zero, the caching will be disabled. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes).|
 | bridge_json | | Int | No | The bridge JSON port |
 | bridge_json_cache_max_size | `10M` | String | No | The maximum amount of data to keep in cache when serving bridge JSON responses. Changes require restart. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes).|
@@ -40,11 +40,12 @@ See a [sample](./etc/pgexporter.conf) configuration for running `pgexporter` on 
 | log_type | console | String | No | The logging type (console, file, syslog) |
 | log_level | info | String | No | The logging level, any of the (case insensitive) strings `FATAL`, `ERROR`, `WARN`, `INFO` and `DEBUG` (that can be more specific as `DEBUG1` thru `DEBUG5`). Debug level greater than 5 will be set to `DEBUG5`. Not recognized values will make the log_level be `INFO` |
 | log_path | pgexporter.log | String | No | The log file location. Can be a strftime(3) compatible string. Can interpolate environment variables (e.g., `$HOME`) |
-| log_rotation_age | 0 | String | No | The age that will trigger a log file rotation. If expressed as a positive number, is managed as seconds. Supports suffixes: 'S' (seconds, the default), 'M' (minutes), 'H' (hours), 'D' (days), 'W' (weeks). A value of `0` disables. |
+| log_rotation_age | 0 | String | No | The age that will trigger a log file rotation. If expressed as a positive number, is managed as seconds. Supports suffixes: 'ms' (milliseconds), 's' (seconds, default), 'm' (minutes), 'h' (hours), 'd' (days), 'w' (weeks). A value of `0` disables. |
 | log_rotation_size | 0 | String | No | The size of the log file that will trigger a log rotation. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes). A value of `0` (with or without suffix) disables. |
 | log_line_prefix | %Y-%m-%d %H:%M:%S | String | No | A strftime(3) compatible string to use as prefix for every log line. Must be quoted if contains spaces. |
 | log_mode | append | String | No | Append to or create the log file (append, create) |
-| blocking_timeout | 30 | Int | No | The number of seconds the process will be blocking for a connection (disable = 0) |
+| blocking_timeout | 30s | String | No | The duration the process will be blocking for a connection (disable = 0). Supports suffixes: 'ms' (milliseconds), 's' (seconds, default), 'm' (minutes), 'h' (hours), 'd' (days), 'w' (weeks). |
+| authentication_timeout | 5s | String | No | The duration allowed for authentication. Supports suffixes: 'ms' (milliseconds), 's' (seconds, default), 'm' (minutes), 'h' (hours), 'd' (days), 'w' (weeks). |
 | tls | `off` | Bool | No | Enable Transport Layer Security (TLS) |
 | tls_cert_file | | String | No | Certificate file for TLS. This file must be owned by either the user running pgexporter or root. Can interpolate environment variables (e.g., `$HOME`) |
 | tls_key_file | | String | No | Private key file for TLS. This file must be owned by either the user running pgexporter or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. Can interpolate environment variables (e.g., `$HOME`) |

--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -162,6 +162,23 @@ extern "C" {
            __typeof__ (b) _b = (b);  \
            _a < _b ? _a : _b; })
 
+/**
+ * Duration type stored internally as milliseconds.
+ */
+typedef struct pgexporter_time
+{
+   int64_t ms; /**< Internal storage in milliseconds */
+} pgexporter_time_t;
+
+#define PGEXPORTER_TIME_MS(v)    ((pgexporter_time_t){.ms = (int64_t)(v)})
+#define PGEXPORTER_TIME_SEC(v)   ((pgexporter_time_t){.ms = (int64_t)(v) * 1000LL})
+#define PGEXPORTER_TIME_MIN(v)   ((pgexporter_time_t){.ms = (int64_t)(v) * 60000LL})
+#define PGEXPORTER_TIME_HOUR(v)  ((pgexporter_time_t){.ms = (int64_t)(v) * 3600000LL})
+#define PGEXPORTER_TIME_DAY(v)   ((pgexporter_time_t){.ms = (int64_t)(v) * 86400000LL})
+
+#define PGEXPORTER_TIME_DISABLED ((pgexporter_time_t){.ms = 0})
+#define PGEXPORTER_TIME_INFINITE ((pgexporter_time_t){.ms = -1})
+
 /*
  * Common piece of code to perform a sleeping.
  *
@@ -367,29 +384,29 @@ struct configuration
    char admins_path[MAX_PATH];        /**< The admins path */
    char extensions_path[MAX_PATH];    /**< The extensions path, containing metric files */
 
-   char host[MISC_LENGTH];        /**< The host */
-   int metrics;                   /**< The metrics port */
-   int metrics_cache_max_age;     /**< Number of seconds to cache the Prometheus response */
-   size_t metrics_cache_max_size; /**< Number of bytes max to cache the Prometheus response */
-   int metrics_query_timeout;     /**< Timeout in milliseconds for metric queries */
-   int management;                /**< The management port */
+   char host[MISC_LENGTH];                  /**< The host */
+   int metrics;                             /**< The metrics port */
+   pgexporter_time_t metrics_cache_max_age; /**< Cache duration for Prometheus response */
+   size_t metrics_cache_max_size;           /**< Number of bytes max to cache the Prometheus response */
+   pgexporter_time_t metrics_query_timeout; /**< Timeout for metric queries */
+   int management;                          /**< The management port */
 
-   int bridge;                        /**< The bridge port */
-   int bridge_cache_max_age;          /**< Number of seconds to cache the bridge response */
-   size_t bridge_cache_max_size;      /**< Number of bytes max to cache the bridge response */
-   int bridge_json;                   /**< The bridge port */
-   size_t bridge_json_cache_max_size; /**< Number of bytes max to cache the bridge response */
+   int bridge;                             /**< The bridge port */
+   pgexporter_time_t bridge_cache_max_age; /**< Cache duration for bridge response */
+   size_t bridge_cache_max_size;           /**< Number of bytes max to cache the bridge response */
+   int bridge_json;                        /**< The bridge port */
+   size_t bridge_json_cache_max_size;      /**< Number of bytes max to cache the bridge response */
 
    bool cache; /**< Cache connection */
 
-   int log_type;                      /**< The logging type */
-   int log_level;                     /**< The logging level */
-   char log_path[MISC_LENGTH];        /**< The logging path */
-   int log_mode;                      /**< The logging mode */
-   size_t log_rotation_size;          /**< bytes to force log rotation */
-   int log_rotation_age;              /**< minutes for log rotation */
-   char log_line_prefix[MISC_LENGTH]; /**< The logging prefix */
-   atomic_schar log_lock;             /**< The logging lock */
+   int log_type;                       /**< The logging type */
+   int log_level;                      /**< The logging level */
+   char log_path[MISC_LENGTH];         /**< The logging path */
+   int log_mode;                       /**< The logging mode */
+   size_t log_rotation_size;           /**< bytes to force log rotation */
+   pgexporter_time_t log_rotation_age; /**< Log rotation interval */
+   char log_line_prefix[MISC_LENGTH];  /**< The logging prefix */
+   atomic_schar log_lock;              /**< The logging lock */
 
    bool tls;                     /**< Is TLS enabled */
    char tls_cert_file[MAX_PATH]; /**< TLS certificate path */
@@ -400,9 +417,9 @@ struct configuration
    char metrics_key_file[MAX_PATH];  /**< Metrics TLS key path */
    char metrics_ca_file[MAX_PATH];   /**< Metrics TLS CA certificate path */
 
-   int blocking_timeout;       /**< The blocking timeout in seconds */
-   int authentication_timeout; /**< The authentication timeout in seconds */
-   char pidfile[MAX_PATH];     /**< File containing the PID */
+   pgexporter_time_t blocking_timeout;       /**< The blocking timeout */
+   pgexporter_time_t authentication_timeout; /**< The authentication timeout */
+   char pidfile[MAX_PATH];                   /**< File containing the PID */
 
    unsigned int update_process_title; /**< Behaviour for updating the process title */
 

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -884,6 +884,45 @@ pgexporter_is_valid_metric_name(char* name);
 int
 pgexporter_normalize_path(char* directory_path, char* filename, char* default_path, char* path_buffer, size_t buffer_size);
 
+/**
+ * Time format specifiers for pgexporter_time_format()
+ */
+enum pgexporter_time_format_t {
+   FORMAT_TIME_MS,        /**< Milliseconds */
+   FORMAT_TIME_S,         /**< Seconds */
+   FORMAT_TIME_MIN,       /**< Minutes */
+   FORMAT_TIME_HOUR,      /**< Hours */
+   FORMAT_TIME_DAY,       /**< Days */
+   FORMAT_TIME_TIMESTAMP, /**< Timestamp */
+};
+
+/**
+ * Convert a time value to a raw integer in the specified unit
+ * @param t The time value
+ * @param fmt The output format
+ * @return The time in the requested unit
+ */
+int64_t
+pgexporter_time_convert(pgexporter_time_t t, enum pgexporter_time_format_t fmt);
+
+/**
+ * Check if a time value is valid (non-zero, non-disabled)
+ * @param t The time value
+ * @return true if enabled, otherwise false
+ */
+bool
+pgexporter_time_is_valid(pgexporter_time_t t);
+
+/**
+ * Format a time value into a string
+ * @param t The time value
+ * @param fmt The output format
+ * @param output The output string
+ * @return 0 on success, otherwise 1
+ */
+int
+pgexporter_time_format(pgexporter_time_t t, enum pgexporter_time_format_t fmt, char** output);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgexporter/configuration.c
+++ b/src/libpgexporter/configuration.c
@@ -48,6 +48,7 @@
 #include <ctype.h>
 #include <err.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -76,8 +77,8 @@ static int as_hugepage(char* str);
 static int as_server_type(char* str);
 static unsigned int as_update_process_title(char* str, unsigned int default_policy);
 static int as_logging_rotation_size(char* str, size_t* size);
-static int as_logging_rotation_age(char* str, int* age);
-static int as_seconds(char* str, int* age, int default_age);
+static int as_logging_rotation_age(char* str, pgexporter_time_t* time);
+static int as_milliseconds(char* str, pgexporter_time_t* time, pgexporter_time_t default_age);
 static int as_bytes(char* str, long* bytes, long default_bytes);
 static int as_endpoints(char* str, struct configuration* config, bool reload);
 static bool transfer_configuration(struct configuration* config, struct configuration* reload);
@@ -105,13 +106,13 @@ pgexporter_init_configuration(void* shm)
    config = (struct configuration*)shm;
 
    config->metrics = -1;
-   config->metrics_query_timeout = 0;
+   config->metrics_query_timeout = PGEXPORTER_TIME_DISABLED;
    config->cache = true;
    config->number_of_metric_names = 0;
    memset(config->metric_names, 0, sizeof(config->metric_names));
 
    config->bridge = -1;
-   config->bridge_cache_max_age = 300;
+   config->bridge_cache_max_age = PGEXPORTER_TIME_SEC(300);
    config->bridge_cache_max_size = PROMETHEUS_DEFAULT_BRIDGE_CACHE_SIZE;
    config->bridge_json = -1;
    config->bridge_json_cache_max_size = PROMETHEUS_DEFAULT_BRIDGE_JSON_CACHE_SIZE;
@@ -123,8 +124,8 @@ pgexporter_init_configuration(void* shm)
    }
    config->tls = false;
 
-   config->blocking_timeout = 30;
-   config->authentication_timeout = 5;
+   config->blocking_timeout = PGEXPORTER_TIME_SEC(30);
+   config->authentication_timeout = PGEXPORTER_TIME_SEC(5);
 
    config->keep_alive = true;
    config->nodelay = true;
@@ -400,7 +401,7 @@ pgexporter_read_configuration(void* shm, char* filename)
                {
                   if (!strcmp(section, "pgexporter"))
                   {
-                     if (as_seconds(value, &config->metrics_cache_max_age, 0))
+                     if (as_milliseconds(value, &config->metrics_cache_max_age, PGEXPORTER_TIME_DISABLED))
                      {
                         unknown = true;
                      }
@@ -414,7 +415,7 @@ pgexporter_read_configuration(void* shm, char* filename)
                {
                   if (!strcmp(section, "pgexporter"))
                   {
-                     if (as_int(value, &config->metrics_query_timeout))
+                     if (as_milliseconds(value, &config->metrics_query_timeout, PGEXPORTER_TIME_DISABLED))
                      {
                         unknown = true;
                      }
@@ -479,7 +480,7 @@ pgexporter_read_configuration(void* shm, char* filename)
                {
                   if (!strcmp(section, "pgexporter"))
                   {
-                     if (as_seconds(value, &config->bridge_cache_max_age, 300))
+                     if (as_milliseconds(value, &config->bridge_cache_max_age, PGEXPORTER_TIME_SEC(300)))
                      {
                         unknown = true;
                      }
@@ -713,7 +714,7 @@ pgexporter_read_configuration(void* shm, char* filename)
                {
                   if (!strcmp(section, "pgexporter"))
                   {
-                     if (as_int(value, &config->blocking_timeout))
+                     if (as_milliseconds(value, &config->blocking_timeout, PGEXPORTER_TIME_SEC(30)))
                      {
                         unknown = true;
                      }
@@ -1212,10 +1213,10 @@ pgexporter_validate_configuration(void* shm)
       }
    }
 
-   if (config->metrics_query_timeout > 0 && config->metrics_query_timeout < 50)
+   if (pgexporter_time_is_valid(config->metrics_query_timeout) && pgexporter_time_convert(config->metrics_query_timeout, FORMAT_TIME_MS) < 50)
    {
-      pgexporter_log_warn("metrics_query_timeout=%dms is too low, using 50ms minimum", config->metrics_query_timeout);
-      config->metrics_query_timeout = 50;
+      pgexporter_log_warn("metrics_query_timeout=%" PRId64 "ms is too low, using 50ms minimum", pgexporter_time_convert(config->metrics_query_timeout, FORMAT_TIME_MS));
+      config->metrics_query_timeout = PGEXPORTER_TIME_MS(50);
    }
    return 0;
 }
@@ -2005,19 +2006,19 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
       }
       else if (!strcmp(key, "metrics_cache_max_age"))
       {
-         if (as_seconds(config_value, &config->metrics_cache_max_age, 0))
+         if (as_milliseconds(config_value, &config->metrics_cache_max_age, PGEXPORTER_TIME_DISABLED))
          {
             unknown = true;
          }
-         pgexporter_json_put(response, key, (uintptr_t)config->metrics_cache_max_age, ValueInt64);
+         pgexporter_json_put(response, key, (uintptr_t)pgexporter_time_convert(config->metrics_cache_max_age, FORMAT_TIME_S), ValueInt64);
       }
       else if (!strcmp(key, "metrics_query_timeout"))
       {
-         if (as_int(config_value, &config->metrics_query_timeout))
+         if (as_milliseconds(config_value, &config->metrics_query_timeout, PGEXPORTER_TIME_DISABLED))
          {
             unknown = true;
          }
-         pgexporter_json_put(response, key, (uintptr_t)config->metrics_query_timeout, ValueInt64);
+         pgexporter_json_put(response, key, (uintptr_t)pgexporter_time_convert(config->metrics_query_timeout, FORMAT_TIME_MS), ValueInt64);
       }
       else if (!strcmp(key, "metrics_path"))
       {
@@ -2060,11 +2061,11 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
       }
       else if (!strcmp(key, "bridge_cache_max_age"))
       {
-         if (as_seconds(config_value, &config->bridge_cache_max_age, 0))
+         if (as_milliseconds(config_value, &config->bridge_cache_max_age, PGEXPORTER_TIME_DISABLED))
          {
             unknown = true;
          }
-         pgexporter_json_put(response, key, (uintptr_t)config->bridge_cache_max_age, ValueInt64);
+         pgexporter_json_put(response, key, (uintptr_t)pgexporter_time_convert(config->bridge_cache_max_age, FORMAT_TIME_S), ValueInt64);
       }
       else if (!strcmp(key, "bridge_json"))
       {
@@ -2218,11 +2219,11 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
       }
       else if (!strcmp(key, "blocking_timeout"))
       {
-         if (as_int(config_value, &config->blocking_timeout))
+         if (as_milliseconds(config_value, &config->blocking_timeout, PGEXPORTER_TIME_SEC(30)))
          {
             unknown = true;
          }
-         pgexporter_json_put(response, key, (uintptr_t)config->blocking_timeout, ValueInt64);
+         pgexporter_json_put(response, key, (uintptr_t)pgexporter_time_convert(config->blocking_timeout, FORMAT_TIME_S), ValueInt64);
       }
       else if (!strcmp(key, "pidfile"))
       {
@@ -2273,7 +2274,7 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
          {
             unknown = true;
          }
-         pgexporter_json_put(response, key, (uintptr_t)config->log_rotation_age, ValueInt32);
+         pgexporter_json_put(response, key, (uintptr_t)pgexporter_time_convert(config->log_rotation_age, FORMAT_TIME_S), ValueInt32);
       }
       else if (!strcmp(key, "log_line_prefix"))
       {
@@ -2439,9 +2440,9 @@ add_configuration_response(struct json* res)
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_UNIX_SOCKET_DIR, (uintptr_t)config->unix_socket_dir, ValueString);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_METRICS, (uintptr_t)config->metrics, ValueInt64);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_METRICS_PATH, (uintptr_t)config->metrics_path, ValueString);
-   pgexporter_json_put(res, CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, (uintptr_t)config->metrics_cache_max_age, ValueInt64);
+   pgexporter_json_put(res, CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, (uintptr_t)pgexporter_time_convert(config->metrics_cache_max_age, FORMAT_TIME_S), ValueInt64);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_SIZE, (uintptr_t)config->metrics_cache_max_size, ValueInt64);
-   pgexporter_json_put(res, CONFIGURATION_ARGUMENT_METRICS_QUERY_TIMEOUT, (uintptr_t)config->metrics_query_timeout, ValueInt64);
+   pgexporter_json_put(res, CONFIGURATION_ARGUMENT_METRICS_QUERY_TIMEOUT, (uintptr_t)pgexporter_time_convert(config->metrics_query_timeout, FORMAT_TIME_MS), ValueInt64);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_BRIDGE, (uintptr_t)config->bridge, ValueInt64);
 
    if (config->number_of_endpoints > 0)
@@ -2464,7 +2465,7 @@ add_configuration_response(struct json* res)
    }
 
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_BRIDGE_ENDPOINTS, (uintptr_t)data, ValueString);
-   pgexporter_json_put(res, CONFIGURATION_ARGUMENT_BRIDGE_CACHE_MAX_AGE, (uintptr_t)config->bridge_cache_max_age, ValueInt64);
+   pgexporter_json_put(res, CONFIGURATION_ARGUMENT_BRIDGE_CACHE_MAX_AGE, (uintptr_t)pgexporter_time_convert(config->bridge_cache_max_age, FORMAT_TIME_S), ValueInt64);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_BRIDGE_CACHE_MAX_SIZE, (uintptr_t)config->bridge_cache_max_size, ValueInt64);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_BRIDGE_JSON, (uintptr_t)config->bridge_json, ValueInt64);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_BRIDGE_JSON_CACHE_MAX_SIZE, (uintptr_t)config->bridge_json_cache_max_size, ValueInt64);
@@ -2473,11 +2474,11 @@ add_configuration_response(struct json* res)
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_LOG_TYPE, (uintptr_t)config->log_type, ValueInt32);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_LOG_LEVEL, (uintptr_t)config->log_level, ValueInt32);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_LOG_PATH, (uintptr_t)config->log_path, ValueString);
-   pgexporter_json_put(res, CONFIGURATION_ARGUMENT_LOG_ROTATION_AGE, (uintptr_t)config->log_rotation_age, ValueInt64);
+   pgexporter_json_put(res, CONFIGURATION_ARGUMENT_LOG_ROTATION_AGE, (uintptr_t)pgexporter_time_convert(config->log_rotation_age, FORMAT_TIME_S), ValueInt64);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_LOG_ROTATION_SIZE, (uintptr_t)config->log_rotation_size, ValueInt64);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_LOG_LINE_PREFIX, (uintptr_t)config->log_line_prefix, ValueString);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_LOG_MODE, (uintptr_t)config->log_mode, ValueInt32);
-   pgexporter_json_put(res, CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, (uintptr_t)config->blocking_timeout, ValueInt64);
+   pgexporter_json_put(res, CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, (uintptr_t)pgexporter_time_convert(config->blocking_timeout, FORMAT_TIME_S), ValueInt64);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_TLS, (uintptr_t)config->tls, ValueBool);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_TLS_CERT_FILE, (uintptr_t)config->tls_cert_file, ValueString);
    pgexporter_json_put(res, CONFIGURATION_ARGUMENT_TLS_CA_FILE, (uintptr_t)config->tls_ca_file, ValueString);
@@ -3071,50 +3072,55 @@ as_logging_rotation_size(char* str, size_t* size)
 
 /**
  * Parses the log_rotation_age string.
- * The string accepts
+ * The string accepts:
+ * - ms for milliseconds
  * - s for seconds
  * - m for minutes
  * - h for hours
  * - d for days
  * - w for weeks
  *
- * The default is expressed in seconds.
- * The function sets the number of rotationg age as minutes.
+ * The default is expressed in milliseconds.
  * Returns 1 for errors, 0 for correct parsing.
  *
+ * @param str the value to parse as retrieved from the configuration
+ * @param time a pointer to the value that is going to store
+ *        the resulting number of milliseconds
+ * @return 0 on success, 1 on error
  */
 static int
-as_logging_rotation_age(char* str, int* age)
+as_logging_rotation_age(char* str, pgexporter_time_t* time)
 {
-   return as_seconds(str, age, PGEXPORTER_LOGGING_ROTATION_DISABLED);
+   return as_milliseconds(str, time, PGEXPORTER_TIME_DISABLED);
 }
 
 /**
- * Parses an age string, providing the resulting value as seconds.
+ * Parses an age string, providing the resulting value as milliseconds.
  * An age string is expressed by a number and a suffix that indicates
  * the multiplier. Accepted suffixes, case insensitive, are:
+ * - ms for milliseconds
  * - s for seconds
  * - m for minutes
  * - h for hours
  * - d for days
  * - w for weeks
  *
- * The default is expressed in seconds.
+ * The default is expressed in milliseconds.
  *
  * @param str the value to parse as retrieved from the configuration
  * @param age a pointer to the value that is going to store
- *        the resulting number of seconds
- * @param default_age a value to set when the parsing is unsuccesful
-
+ *        the resulting number of milliseconds
+ * @param default_age a value to set when the parsing is unsuccessful
+ *
  */
 static int
-as_seconds(char* str, int* age, int default_age)
+as_milliseconds(char* str, pgexporter_time_t* age, pgexporter_time_t default_age)
 {
-   int multiplier = 1;
+   int64_t multiplier = 1000;
    int index;
    char value[MISC_LENGTH];
    bool multiplier_set = false;
-   int i_value = default_age;
+   int i_value = 0;
 
    if (is_empty_string(str))
    {
@@ -3136,30 +3142,43 @@ as_seconds(char* str, int* age, int default_age)
       }
       else if (isalpha(str[i]) && !multiplier_set)
       {
-         if (str[i] == 's' || str[i] == 'S')
+         // Check for 'ms'
+         if ((str[i] == 'm' || str[i] == 'M') &&
+             i + 1 < strlen(str) &&
+             (str[i + 1] == 's' || str[i + 1] == 'S'))
          {
             multiplier = 1;
+            multiplier_set = true;
+            i++; // Skip the 's' in 'ms'
+         }
+         else if (str[i] == 's' || str[i] == 'S')
+         {
+            multiplier = 1000;
             multiplier_set = true;
          }
          else if (str[i] == 'm' || str[i] == 'M')
          {
-            multiplier = 60;
+            multiplier = 60 * 1000;
             multiplier_set = true;
          }
          else if (str[i] == 'h' || str[i] == 'H')
          {
-            multiplier = 3600;
+            multiplier = 3600 * 1000;
             multiplier_set = true;
          }
          else if (str[i] == 'd' || str[i] == 'D')
          {
-            multiplier = 24 * 3600;
+            multiplier = 24 * 3600 * 1000;
             multiplier_set = true;
          }
          else if (str[i] == 'w' || str[i] == 'W')
          {
-            multiplier = 24 * 3600 * 7;
+            multiplier = 7 * 24 * 3600 * 1000;
             multiplier_set = true;
+         }
+         else
+         {
+            goto error;
          }
       }
       else
@@ -3176,7 +3195,7 @@ as_seconds(char* str, int* age, int default_age)
       // must be a positive number!
       if (i_value >= 0)
       {
-         *age = i_value * multiplier;
+         *age = PGEXPORTER_TIME_MS(i_value * multiplier);
       }
       else
       {
@@ -3484,7 +3503,7 @@ transfer_configuration(struct configuration* config, struct configuration* reloa
    config->log_level = reload->log_level;
    // if the log main parameters have changed, we need
    // to restart the logging system
-   if (strncmp(config->log_path, reload->log_path, MISC_LENGTH) || config->log_rotation_size != reload->log_rotation_size || config->log_rotation_age != reload->log_rotation_age || config->log_mode != reload->log_mode)
+   if (strncmp(config->log_path, reload->log_path, MISC_LENGTH) || config->log_rotation_size != reload->log_rotation_size || pgexporter_time_convert(config->log_rotation_age, FORMAT_TIME_MS) != pgexporter_time_convert(reload->log_rotation_age, FORMAT_TIME_MS) || config->log_mode != reload->log_mode)
    {
       pgexporter_log_debug("Log restart triggered!");
       pgexporter_stop_logging();

--- a/src/libpgexporter/queries.c
+++ b/src/libpgexporter/queries.c
@@ -1187,20 +1187,20 @@ pgexporter_apply_metrics_timeout(int server)
 
    config = (struct configuration*)shmem;
 
-   if (config->metrics_query_timeout > 0)
+   if (pgexporter_time_is_valid(config->metrics_query_timeout))
    {
       char* set_query = pgexporter_append(NULL, "SET statement_timeout = ");
-      set_query = pgexporter_append_int(set_query, config->metrics_query_timeout);
+      set_query = pgexporter_append_int(set_query, (int)pgexporter_time_convert(config->metrics_query_timeout, FORMAT_TIME_MS));
       set_query = pgexporter_append(set_query, ";");
       if (pgexporter_execute_command(server, set_query) != 0)
       {
-         pgexporter_log_debug("Failed to set statement_timeout=%dms on server '%s'",
-                              config->metrics_query_timeout, &config->servers[server].name[0]);
+         pgexporter_log_debug("Failed to set statement_timeout=%" PRId64 "ms on server '%s'",
+                              pgexporter_time_convert(config->metrics_query_timeout, FORMAT_TIME_MS), &config->servers[server].name[0]);
       }
       else
       {
-         pgexporter_log_debug("Set statement_timeout=%dms on server '%s'",
-                              config->metrics_query_timeout, &config->servers[server].name[0]);
+         pgexporter_log_debug("Set statement_timeout=%" PRId64 "ms on server '%s'",
+                              pgexporter_time_convert(config->metrics_query_timeout, FORMAT_TIME_MS), &config->servers[server].name[0]);
       }
       free(set_query);
    }

--- a/src/libpgexporter/security.c
+++ b/src/libpgexporter/security.c
@@ -127,7 +127,7 @@ pgexporter_remote_management_auth(int client_fd, char* address, SSL** client_ssl
    *client_ssl = NULL;
 
    /* Receive client calls - at any point if client exits return AUTH_ERROR */
-   status = pgexporter_read_timeout_message(NULL, client_fd, config->authentication_timeout, &msg);
+   status = pgexporter_read_timeout_message(NULL, client_fd, pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S), &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -175,7 +175,7 @@ pgexporter_remote_management_auth(int client_fd, char* address, SSL** client_ssl
             goto error;
          }
 
-         status = pgexporter_read_timeout_message(c_ssl, client_fd, config->authentication_timeout, &msg);
+         status = pgexporter_read_timeout_message(c_ssl, client_fd, pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S), &msg);
          if (status != MESSAGE_STATUS_OK)
          {
             goto error;
@@ -191,7 +191,7 @@ pgexporter_remote_management_auth(int client_fd, char* address, SSL** client_ssl
          }
          pgexporter_clear_message();
 
-         status = pgexporter_read_timeout_message(NULL, client_fd, config->authentication_timeout, &msg);
+         status = pgexporter_read_timeout_message(NULL, client_fd, pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S), &msg);
          if (status != MESSAGE_STATUS_OK)
          {
             goto error;
@@ -836,7 +836,7 @@ retry:
    status = pgexporter_read_timeout_message(c_ssl, client_fd, 1, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
-      if (difftime(time(NULL), start_time) < config->authentication_timeout)
+      if (difftime(time(NULL), start_time) < pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S))
       {
          if (pgexporter_socket_isvalid(client_fd))
          {
@@ -886,7 +886,7 @@ retry:
       goto error;
    }
 
-   status = pgexporter_read_timeout_message(c_ssl, client_fd, config->authentication_timeout, &msg);
+   status = pgexporter_read_timeout_message(c_ssl, client_fd, pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S), &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;

--- a/src/main.c
+++ b/src/main.c
@@ -942,7 +942,7 @@ main(int argc, char** argv)
       errx(1, "Error in creating and initializing prometheus cache shared memory");
    }
 
-   if (config->bridge > 0 && config->bridge_cache_max_age > 0 && config->bridge_cache_max_size > 0)
+   if (config->bridge > 0 && pgexporter_time_is_valid(config->bridge_cache_max_age) && config->bridge_cache_max_size > 0)
    {
       if (pgexporter_bridge_init_cache(&bridge_cache_shmem_size, &bridge_cache_shmem))
       {

--- a/test/include/tscommon.h
+++ b/test/include/tscommon.h
@@ -65,6 +65,24 @@ pgexporter_test_setup(void);
 void
 pgexporter_test_teardown(void);
 
+/**
+ * Assert that conf set succeeds and the response matches the expected value
+ */
+void
+pgexporter_test_assert_conf_set_ok(char* key, char* value, int64_t expected);
+
+/**
+ * Assert that conf set fails for the given key/value
+ */
+void
+pgexporter_test_assert_conf_set_fail(char* key, char* value);
+
+/**
+ * Assert that conf get returns the expected value for the given key
+ */
+void
+pgexporter_test_assert_conf_get_ok(char* key, int64_t expected);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/include/tssuite.h
+++ b/test/include/tssuite.h
@@ -53,4 +53,11 @@ pgexporter_test_database_suite();
 Suite*
 pgexporter_test_http_suite();
 
+/**
+ * Set up configuration test suite for pgexporter
+ * @return The suite
+ */
+Suite*
+pgexporter_test_configuration_suite();
+
 #endif

--- a/test/runner.c
+++ b/test/runner.c
@@ -38,6 +38,7 @@ main(int argc, char* argv[])
    Suite* cli_suite;
    Suite* database_suite;
    Suite* http_suite;
+   Suite* configuration_suite;
    SRunner* sr;
 
    pgexporter_test_environment_create();
@@ -45,9 +46,11 @@ main(int argc, char* argv[])
    cli_suite = pgexporter_test_cli_suite();
    database_suite = pgexporter_test_database_suite();
    http_suite = pgexporter_test_http_suite();
+   configuration_suite = pgexporter_test_configuration_suite();
 
    sr = srunner_create(cli_suite);
    srunner_add_suite(sr, database_suite);
+   srunner_add_suite(sr, configuration_suite);
    srunner_add_suite(sr, http_suite);
    srunner_set_log(sr, "-");
    srunner_set_fork_status(sr, CK_NOFORK);

--- a/test/testcases/test_configuration.c
+++ b/test/testcases/test_configuration.c
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <pgexporter.h>
+#include <configuration.h>
+#include <shmem.h>
+#include <tscommon.h>
+#include <tssuite.h>
+#include <utils.h>
+
+// Test conf set with various time units
+START_TEST(test_configuration_accept_time)
+{
+   // Zero / disabled
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "0", 0);
+
+   // Seconds (response in seconds)
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "10s", 10);
+
+   // Minutes (response in seconds)
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "2m", 120);
+
+   // Hours (response in seconds)
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "1h", 3600);
+
+   // Days (response in seconds)
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "1d", 86400);
+
+   // Weeks (response in seconds)
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "1w", 7 * 24 * 3600);
+
+   // Milliseconds (response in milliseconds)
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_QUERY_TIMEOUT, "5ms", 5);
+
+   // Uppercase suffix
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_QUERY_TIMEOUT, "50MS", 50);
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_QUERY_TIMEOUT, "1S", 1000);
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_QUERY_TIMEOUT, "2M", 120000);
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "1H", 3600);
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "1D", 86400);
+}
+END_TEST
+
+// Test conf set rejects invalid time values
+START_TEST(test_configuration_reject_invalid_time)
+{
+   // Invalid suffix
+   pgexporter_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "10x");
+
+   // Negative value
+   pgexporter_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "-1s");
+
+   // Mixed units
+   pgexporter_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "1h5ms");
+   pgexporter_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "1h 5ms");
+
+   // Space between number and unit
+   pgexporter_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "10 s");
+
+   // Non-numeric
+   pgexporter_test_assert_conf_set_fail(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "abc");
+}
+END_TEST
+
+// Test conf get returns correct values after conf set
+START_TEST(test_configuration_get_returns_set_values)
+{
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, "45s", 45);
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, "2m", 120);
+   pgexporter_test_assert_conf_set_ok(CONFIGURATION_ARGUMENT_METRICS_QUERY_TIMEOUT, "500ms", 500);
+
+   pgexporter_test_assert_conf_get_ok(CONFIGURATION_ARGUMENT_BLOCKING_TIMEOUT, 45);
+   pgexporter_test_assert_conf_get_ok(CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE, 120);
+   pgexporter_test_assert_conf_get_ok(CONFIGURATION_ARGUMENT_METRICS_QUERY_TIMEOUT, 500);
+}
+END_TEST
+
+// Test pgexporter_time_format produces correct strings
+START_TEST(test_configuration_time_format_output)
+{
+   pgexporter_time_t t;
+   char* str = NULL;
+   int ret;
+
+   // Milliseconds
+   t = PGEXPORTER_TIME_MS(500);
+   ret = pgexporter_time_format(t, FORMAT_TIME_MS, &str);
+   ck_assert_int_eq(ret, 0);
+   ck_assert_str_eq(str, "500ms");
+   free(str);
+
+   // Seconds
+   t = PGEXPORTER_TIME_SEC(10);
+   ret = pgexporter_time_format(t, FORMAT_TIME_S, &str);
+   ck_assert_int_eq(ret, 0);
+   ck_assert_str_eq(str, "10s");
+   free(str);
+
+   // Minutes
+   t = PGEXPORTER_TIME_MIN(5);
+   ret = pgexporter_time_format(t, FORMAT_TIME_MIN, &str);
+   ck_assert_int_eq(ret, 0);
+   ck_assert_str_eq(str, "5m");
+   free(str);
+
+   // Hours
+   t = PGEXPORTER_TIME_HOUR(2);
+   ret = pgexporter_time_format(t, FORMAT_TIME_HOUR, &str);
+   ck_assert_int_eq(ret, 0);
+   ck_assert_str_eq(str, "2h");
+   free(str);
+
+   // Days
+   t = PGEXPORTER_TIME_DAY(1);
+   ret = pgexporter_time_format(t, FORMAT_TIME_DAY, &str);
+   ck_assert_int_eq(ret, 0);
+   ck_assert_str_eq(str, "1d");
+   free(str);
+
+   // Timestamp (epoch 0)
+   t = PGEXPORTER_TIME_MS(0);
+   ret = pgexporter_time_format(t, FORMAT_TIME_TIMESTAMP, &str);
+   ck_assert_int_eq(ret, 0);
+   ck_assert_str_eq(str, "1970-01-01T00:00:00.000Z");
+   free(str);
+
+   // Timestamp (1000ms = 1 second)
+   t = PGEXPORTER_TIME_MS(1000);
+   ret = pgexporter_time_format(t, FORMAT_TIME_TIMESTAMP, &str);
+   ck_assert_int_eq(ret, 0);
+   ck_assert_str_eq(str, "1970-01-01T00:00:01.000Z");
+   free(str);
+
+   // Timestamp with millisecond precision
+   t = PGEXPORTER_TIME_MS(1500);
+   ret = pgexporter_time_format(t, FORMAT_TIME_TIMESTAMP, &str);
+   ck_assert_int_eq(ret, 0);
+   ck_assert_str_eq(str, "1970-01-01T00:00:01.500Z");
+   free(str);
+
+   // Timestamp for year 2000
+   t = PGEXPORTER_TIME_MS(946684800000LL);
+   ret = pgexporter_time_format(t, FORMAT_TIME_TIMESTAMP, &str);
+   ck_assert_int_eq(ret, 0);
+   ck_assert_str_eq(str, "2000-01-01T00:00:00.000Z");
+   free(str);
+
+   // NULL output should return error
+   ret = pgexporter_time_format(t, FORMAT_TIME_MS, NULL);
+   ck_assert_int_eq(ret, 1);
+}
+END_TEST
+
+Suite*
+pgexporter_test_configuration_suite()
+{
+   Suite* s;
+   TCase* tc_configuration;
+
+   s = suite_create("pgexporter_test_configuration");
+
+   tc_configuration = tcase_create("Configuration");
+
+   tcase_set_timeout(tc_configuration, 60);
+   tcase_add_checked_fixture(tc_configuration, pgexporter_test_setup, pgexporter_test_teardown);
+
+   tcase_add_test(tc_configuration, test_configuration_accept_time);
+   tcase_add_test(tc_configuration, test_configuration_reject_invalid_time);
+   tcase_add_test(tc_configuration, test_configuration_get_returns_set_values);
+   tcase_add_test(tc_configuration, test_configuration_time_format_output);
+
+   suite_add_tcase(s, tc_configuration);
+
+   return s;
+}


### PR DESCRIPTION
fix #194 

Introduce a new uniform time-based metric type `pgexporter_time_t` that stores time in **milliseconds**, which is the smallest time unit needed by pgexporter.

 Apply the new uniform time type to:
 * `blocking_timeout`
 * `metrics_cache_max_age`
 * `metrics_query_timeout`
 * `bridge_cache_max_age`
 * `log_rotation_age`
 * `authentication_timeout`