### PR TITLE
Fix missing liburing-devel in RPM Dockerfile and source name in Docker build script

### DIFF
--- a/contrib/docker/rpm/Dockerfile
+++ b/contrib/docker/rpm/Dockerfile
@@ -4,7 +4,20 @@ FROM almalinux:$OS_VERSION-minimal
 
 RUN microdnf upgrade -y
 RUN microdnf install -y git gcc cmake make rpm-build rpm-devel rpmlint diffutils patch rpmdevtools chrpath
-RUN microdnf install --enablerepo=crb -y check-devel zlib-devel bzip2-devel lz4-devel libev-devel libatomic openssl-devel python3-docutils doxygen libyaml-devel lz4 systemd-devel
+RUN microdnf install --enablerepo=crb -y \
+    check-devel \
+    zlib-devel \
+    bzip2-devel \
+    lz4-devel \
+    libev-devel \
+    libatomic \
+    liburing-devel \
+    openssl-devel \
+    python3-docutils \
+    doxygen \
+    libyaml-devel \
+    lz4 \
+    systemd-devel
 RUN microdnf clean all && rm -rf /var/cache/yum
 WORKDIR /root
 RUN rpmdev-setuptree

--- a/contrib/docker/rpm/README.md
+++ b/contrib/docker/rpm/README.md
@@ -6,3 +6,5 @@ Here you find a Docker file to create an environment containing all the dependen
 1. Run it with `docker run -it -v ./target:/root/rpmbuild/RPMS:Z pgexporter-build /bin/bash`
 1. Run `~/build.sh` inside the container
 1. The RPM will be placed in the `./target` directory (outside the container, from where you ran it)
+
+**ATTENTION** You need to rebuild the Docker image for each build, since the repository contents are copied into it during build time!

--- a/contrib/docker/rpm/build.sh
+++ b/contrib/docker/rpm/build.sh
@@ -6,6 +6,6 @@ cd ~/pgexporter/build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make package_source
 VERSION=$(grep -Po "Version:\s*\K(\d+\.\d+\.\d+)" ~/pgexporter/pgexporter.spec)
-cp pgexporter-$VERSION.tar.gz ~/rpmbuild/SOURCES/$VERSION.tar.gz
+cp pgexporter-$VERSION.tar.gz ~/rpmbuild/SOURCES/
 cd ~/pgexporter
 QA_RPATHS=0x0001 rpmbuild -bb pgexporter.spec


### PR DESCRIPTION
This PR contains two fixes and a documentation extension for contrib/docker/rpm:
- `liburing-devel` was missing from RPM Dockerfile
- the expected source .tar.gz name in pgexporter.spec changed from `0.8.0.tar.gz` to `pgexporter-0.8.0.tar.gz` in [bd991cc](https://github.com/pgexporter/pgexporter/commit/bd991cc73a1950ca6968998285af1b08e10333b8#diff-02f1b9ab3afc3ca6014337df3bc29e0199f51f5cc82d061dd1b3be5fd7f43283L7-R7)
- add note to contrib/docker/rpm/README.md to rebuild the docker image for each RPM rebuild. Could probably be handled more elegantly, but a note in the README should be a sufficient first step