### PR TITLE
[#399]: fix incorrect metric names on Grafana dashboards

### DIFF
--- a/contrib/grafana/postgresql_dashboard_pg13.json
+++ b/contrib/grafana/postgresql_dashboard_pg13.json
@@ -1609,7 +1609,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_calls)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_most_executed_calls)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"
@@ -1679,7 +1679,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_total_exec_time)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_slowest_execution_total_exec_time)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"
@@ -1749,7 +1749,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_wal_bytes)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_highest_wal_wal_bytes)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"

--- a/contrib/grafana/postgresql_dashboard_pg15.json
+++ b/contrib/grafana/postgresql_dashboard_pg15.json
@@ -1735,7 +1735,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_calls)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_most_executed_calls)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"
@@ -1805,7 +1805,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_total_exec_time)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_slowest_execution_total_exec_time)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"
@@ -1875,7 +1875,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_wal_bytes)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_highest_wal_wal_bytes)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"

--- a/contrib/grafana/postgresql_dashboard_pg16.json
+++ b/contrib/grafana/postgresql_dashboard_pg16.json
@@ -1735,7 +1735,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_calls)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_most_executed_calls)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"
@@ -1805,7 +1805,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_total_exec_time)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_slowest_execution_total_exec_time)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"
@@ -1875,7 +1875,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_wal_bytes)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_highest_wal_wal_bytes)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"

--- a/contrib/grafana/postgresql_dashboard_pg17.json
+++ b/contrib/grafana/postgresql_dashboard_pg17.json
@@ -1735,7 +1735,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_calls)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_most_executed_calls)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"
@@ -1805,7 +1805,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_total_exec_time)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_slowest_execution_total_exec_time)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"
@@ -1875,7 +1875,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_wal_bytes)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_highest_wal_wal_bytes)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"

--- a/contrib/grafana/postgresql_dashboard_pg18.json
+++ b/contrib/grafana/postgresql_dashboard_pg18.json
@@ -1735,7 +1735,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_calls)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_most_executed_calls)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"
@@ -1805,7 +1805,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_total_exec_time)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_slowest_execution_total_exec_time)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"
@@ -1875,7 +1875,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, pgexporter_pg_stat_statements_wal_bytes)",
+          "expr": "topk(10, pgexporter_pg_stat_statements_highest_wal_wal_bytes)",
           "format": "time_series",
           "legendFormat": "{{query}}",
           "refId": "A"


### PR DESCRIPTION
fixes: #399 

PG15 dashboard displays "Query Anaylsis" data correctly 

<img width="1319" height="905" alt="image" src="https://github.com/user-attachments/assets/3648e6dd-1181-4a55-aa38-d554a66e0ee3" />
