### PR TITLE
[#406]: Add Multixact ID Age (datminmxid) metric

### DIFF
--- a/contrib/grafana/postgresql_dashboard_pg13.json
+++ b/contrib/grafana/postgresql_dashboard_pg13.json
@@ -1332,6 +1332,74 @@
       "type": "bargauge"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 91
+      },
+      "id": 35,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,

--- a/contrib/grafana/postgresql_dashboard_pg14.json
+++ b/contrib/grafana/postgresql_dashboard_pg14.json
@@ -1458,6 +1458,74 @@
       "type": "bargauge"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "id": 50,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,

--- a/contrib/grafana/postgresql_dashboard_pg15.json
+++ b/contrib/grafana/postgresql_dashboard_pg15.json
@@ -1458,6 +1458,74 @@
       "type": "bargauge"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "id": 50,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,

--- a/contrib/grafana/postgresql_dashboard_pg16.json
+++ b/contrib/grafana/postgresql_dashboard_pg16.json
@@ -1458,6 +1458,74 @@
       "type": "bargauge"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "id": 50,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,

--- a/contrib/grafana/postgresql_dashboard_pg17.json
+++ b/contrib/grafana/postgresql_dashboard_pg17.json
@@ -1458,6 +1458,74 @@
       "type": "bargauge"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "id": 50,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,

--- a/contrib/grafana/postgresql_dashboard_pg18.json
+++ b/contrib/grafana/postgresql_dashboard_pg18.json
@@ -1458,6 +1458,74 @@
       "type": "bargauge"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "id": 50,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,

--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -570,7 +570,7 @@
       "sort": "data",
       "queries": [
         {
-          "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
+          "query": "SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;",
           "version": 10,
           "columns": [
             {
@@ -582,6 +582,11 @@
               "type": "counter",
               "name": "age",
               "description": "Age since last vaccum."
+            },
+            {
+              "type": "counter",
+              "name": "age_datminmxid",
+              "description": "Multixact age since last vacuum."
             }
           ]
         }

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -570,7 +570,7 @@
       "sort": "data",
       "queries": [
         {
-          "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
+          "query": "SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;",
           "version": 10,
           "columns": [
             {
@@ -582,6 +582,11 @@
               "type": "counter",
               "name": "age",
               "description": "Age since last vaccum."
+            },
+            {
+              "type": "counter",
+              "name": "age_datminmxid",
+              "description": "Multixact age since last vacuum."
             }
           ]
         }

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -570,7 +570,7 @@
       "sort": "data",
       "queries": [
         {
-          "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
+          "query": "SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;",
           "version": 10,
           "columns": [
             {
@@ -582,6 +582,11 @@
               "type": "counter",
               "name": "age",
               "description": "Age since last vaccum."
+            },
+            {
+              "type": "counter",
+              "name": "age_datminmxid",
+              "description": "Multixact age since last vacuum."
             }
           ]
         }

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -570,7 +570,7 @@
       "sort": "data",
       "queries": [
         {
-          "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
+          "query": "SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;",
           "version": 10,
           "columns": [
             {
@@ -582,6 +582,11 @@
               "type": "counter",
               "name": "age",
               "description": "Age since last vaccum."
+            },
+            {
+              "type": "counter",
+              "name": "age_datminmxid",
+              "description": "Multixact age since last vacuum."
             }
           ]
         }

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -535,7 +535,7 @@
       "sort": "data",
       "queries": [
         {
-          "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
+          "query": "SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;",
           "version": 10,
           "columns": [
             {
@@ -547,6 +547,11 @@
               "type": "counter",
               "name": "age",
               "description": "Age since last vaccum."
+            },
+            {
+              "type": "counter",
+              "name": "age_datminmxid",
+              "description": "Multixact age since last vacuum."
             }
           ]
         }

--- a/contrib/json/postgresql-18.json
+++ b/contrib/json/postgresql-18.json
@@ -570,7 +570,7 @@
       "sort": "data",
       "queries": [
         {
-          "query": "SELECT datname, age(datfrozenxid) as age FROM pg_database;",
+          "query": "SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;",
           "version": 10,
           "columns": [
             {
@@ -582,6 +582,11 @@
               "type": "counter",
               "name": "age",
               "description": "Age since last vaccum."
+            },
+            {
+              "type": "counter",
+              "name": "age_datminmxid",
+              "description": "Multixact age since last vacuum."
             }
           ]
         }

--- a/contrib/prometheus_scrape/extra.info
+++ b/contrib/prometheus_scrape/extra.info
@@ -2745,6 +2745,12 @@ pgexporter_pg_db_vacuum_age
 * datname: The name of the database.
 Version: 10+
 
+pgexporter_pg_db_vacuum_age_datminmxid
++ Represents the multixact age (number of multixacts) of the oldest unfrozen multixact ID (`datminmxid`) within each database. Useful for monitoring multixact wraparound risk.
+* server: The configured name/identifier for the PostgreSQL server.
+* datname: The name of the database.
+Version: 10+
+
 pgexporter_pg_view_vacuum_age
 + Reports the age (number of transactions) of the oldest unfrozen transaction ID (`relfrozenxid`) for each table or materialized view (including TOAST tables). Indicates need for vacuuming.
 * server: The configured name/identifier for the PostgreSQL server.

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -309,7 +309,7 @@ metrics:
   collector: db_vacuum
   sort: data
   queries:
-  - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
+  - query: SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;
     version: 10
     columns:
     - type: label
@@ -318,6 +318,9 @@ metrics:
     - type: counter
       name: age
       description: Age since last vaccum.
+    - type: counter
+      name: age_datminmxid
+      description: Multixact age since last vacuum.
 - tag: pg_view_vacuum
   collector: db_vacuum
   sort: data

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -309,7 +309,7 @@ metrics:
   collector: db_vacuum
   sort: data
   queries:
-  - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
+  - query: SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;
     version: 10
     columns:
     - type: label
@@ -318,6 +318,9 @@ metrics:
     - type: counter
       name: age
       description: Age since last vaccum.
+    - type: counter
+      name: age_datminmxid
+      description: Multixact age since last vacuum.
 - tag: pg_view_vacuum
   collector: db_vacuum
   sort: data

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -309,7 +309,7 @@ metrics:
   collector: db_vacuum
   sort: data
   queries:
-  - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
+  - query: SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;
     version: 10
     columns:
     - type: label
@@ -318,6 +318,9 @@ metrics:
     - type: counter
       name: age
       description: Age since last vaccum.
+    - type: counter
+      name: age_datminmxid
+      description: Multixact age since last vacuum.
 - tag: pg_view_vacuum
   collector: db_vacuum
   sort: data

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -309,7 +309,7 @@ metrics:
   collector: db_vacuum
   sort: data
   queries:
-  - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
+  - query: SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;
     version: 10
     columns:
     - type: label
@@ -318,6 +318,9 @@ metrics:
     - type: counter
       name: age
       description: Age since last vaccum.
+    - type: counter
+      name: age_datminmxid
+      description: Multixact age since last vacuum.
 - tag: pg_view_vacuum
   collector: db_vacuum
   sort: data

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -288,7 +288,7 @@ metrics:
   collector: db_vacuum
   sort: data
   queries:
-  - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
+  - query: SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;
     version: 10
     columns:
     - type: label
@@ -297,6 +297,9 @@ metrics:
     - type: counter
       name: age
       description: Age since last vaccum.
+    - type: counter
+      name: age_datminmxid
+      description: Multixact age since last vacuum.
 - tag: pg_view_vacuum
   collector: db_vacuum
   sort: data

--- a/contrib/yaml/postgresql-18.yaml
+++ b/contrib/yaml/postgresql-18.yaml
@@ -309,7 +309,7 @@ metrics:
   collector: db_vacuum
   sort: data
   queries:
-  - query: SELECT datname, age(datfrozenxid) as age FROM pg_database;
+  - query: SELECT datname, age(datfrozenxid) as age, mxid_age(datminmxid) as age_datminmxid FROM pg_database;
     version: 10
     columns:
     - type: label
@@ -318,6 +318,9 @@ metrics:
     - type: counter
       name: age
       description: Age since last vaccum.
+    - type: counter
+      name: age_datminmxid
+      description: Multixact age since last vacuum.
 - tag: pg_view_vacuum
   collector: db_vacuum
   sort: data

--- a/doc/manual/en/06-prometheus.md
+++ b/doc/manual/en/06-prometheus.md
@@ -4033,6 +4033,15 @@ Represents the age (number of transactions) of the oldest unfrozen transaction I
 | server | The configured name/identifier for the PostgreSQL server. |
 | datname | The name of the database. |
 
+## pgexporter_pg_db_vacuum_age_datminmxid
+
+Represents the multixact age (number of multixacts) of the oldest unfrozen multixact ID (`datminmxid`) within each database. Useful for monitoring multixact wraparound risk.
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| datname | The name of the database. |
+
 ## pgexporter_pg_view_vacuum_age
 
 Reports the age (number of transactions) of the oldest unfrozen transaction ID (`relfrozenxid`) for each table or materialized view (including TOAST tables). Indicates need for vacuuming.

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -618,7 +618,8 @@ extern "C" {
                       "  - queries:\n"                                                                                                                                                  \
                       "    - query: SELECT\n"                                                                                                                                           \
                       "                datname,\n"                                                                                                                                      \
-                      "                age(datfrozenxid) as age\n"                                                                                                                      \
+                      "                age(datfrozenxid) as age,\n"                                                                                                                     \
+                      "                mxid_age(datminmxid) as age_datminmxid\n"                                                                                                        \
                       "              FROM pg_database;\n"                                                                                                                               \
                       "      version: 10\n"                                                                                                                                             \
                       "      columns:\n"                                                                                                                                                \
@@ -628,6 +629,9 @@ extern "C" {
                       "        - type: counter\n"                                                                                                                                       \
                       "          name: age\n"                                                                                                                                           \
                       "          description: Age since last vaccum.\n"                                                                                                                 \
+                      "        - type: counter\n"                                                                                                                                       \
+                      "          name: age_datminmxid\n"                                                                                                                                \
+                      "          description: Multixact age since last vacuum.\n"                                                                                                       \
                       "    tag: pg_db_vacuum\n"                                                                                                                                         \
                       "    sort: data\n"                                                                                                                                                \
                       "    collector: db_vacuum\n"                                                                                                                                      \


### PR DESCRIPTION
Fix: #406 

Extend the current query to include `age(datminmxid)` instead of creating a new one, since it uses the same `pg_database` source, is related to `age(datfrozenxid)`, and avoids extra query overhead. 

**Screen shot**
I create stress-test to ensure it works fine.
<img width="1332" height="303" alt="Screenshot from 2026-02-15 14-50-20" src="https://github.com/user-attachments/assets/3413ecc9-def8-41ab-8878-d87c7c322f01" />
