### PR TITLE
[#408]: Add missing metrics to pg_stat_walreceiver

### DIFF
--- a/contrib/grafana/postgresql_dashboard_pg13.json
+++ b/contrib/grafana/postgresql_dashboard_pg13.json
@@ -1042,106 +1042,6 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Replication slots status",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 75
-      },
-      "id": 14,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_replication_slots_active",
-          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_stat_replication",
-          "legendFormat": "Streaming WAL - {{application_name}}",
-          "refId": "B"
-        }
-      ],
-      "title": "Replication Status",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
       "description": "WAL archiver statistics",
       "fieldConfig": {
         "defaults": {
@@ -1209,10 +1109,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
-        "y": 83
+        "w": 12,
+        "h": 8,
+        "y": 75
       },
       "id": 15,
       "options": {
@@ -1268,6 +1168,174 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Replication slots status",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "w": 12,
+        "h": 8,
+        "y": 75
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_replication_slots_active",
+          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_replication",
+          "legendFormat": "Streaming WAL - {{application_name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Replication Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 83
+      },
+      "id": 35,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Age of databases since last vacuum",
       "fieldConfig": {
         "defaults": {
@@ -1296,10 +1364,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 12,
-        "y": 91
+        "w": 12,
+        "h": 8,
+        "y": 83
       },
       "id": 16,
       "options": {
@@ -1336,7 +1404,123 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Multixact age of databases since last vacuum",
+      "description": "WAL receiver LSN positions for monitoring replication progress on replica servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "LSN (numeric)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 91
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_receive_start_lsn",
+          "legendFormat": "Receive Start LSN ({{slot_name}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_written_lsn",
+          "legendFormat": "Written LSN ({{slot_name}})",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_flushed_lsn",
+          "legendFormat": "Flushed LSN ({{slot_name}})",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_latest_end_lsn",
+          "legendFormat": "Latest End LSN ({{slot_name}})",
+          "refId": "D"
+        }
+      ],
+      "title": "WAL Receiver LSN Positions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Time lag between WAL sender and receiver messages. High values indicate replication delay.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1351,30 +1535,30 @@
               },
               {
                 "color": "yellow",
-                "value": 100000000
+                "value": 5
               },
               {
                 "color": "red",
-                "value": 180000000
+                "value": 30
               }
             ]
           },
-          "unit": "locale"
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "x": 12,
         "w": 12,
-        "x": 0,
+        "h": 8,
         "y": 91
       },
-      "id": 35,
+      "id": 37,
       "options": {
-        "displayMode": "gradient",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -1382,7 +1566,8 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "11.6.0",
       "targets": [
@@ -1391,13 +1576,131 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
-          "legendFormat": "{{datname}}",
+          "expr": "pgexporter_pg_stat_walreceiver_last_msg_receipt_time - pgexporter_pg_stat_walreceiver_last_msg_send_time",
+          "legendFormat": "Message Lag ({{slot_name}})",
           "refId": "A"
         }
       ],
-      "title": "Database Age (MultiXact ID Wraparound)",
-      "type": "bargauge"
+      "title": "WAL Receiver Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "WAL receiver connection and status information",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "streaming": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Streaming"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 24,
+        "h": 5,
+        "y": 99
+      },
+      "id": 38,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_received_tli",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false,
+              "__name__": true
+            },
+            "renameByName": {
+              "Value": "Timeline",
+              "sender_host": "Sender Host",
+              "sender_port": "Sender Port",
+              "slot_name": "Slot Name",
+              "status": "Status",
+              "server": "Server"
+            }
+          }
+        }
+      ],
+      "title": "WAL Receiver Status",
+      "type": "table"
     },
     {
       "collapsed": false,
@@ -1405,7 +1708,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 99
+        "y": 104
       },
       "id": 17,
       "panels": [],
@@ -1448,7 +1751,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 100
+        "y": 105
       },
       "id": 27,
       "options": {
@@ -1516,7 +1819,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 100
+        "y": 105
       },
       "id": 28,
       "options": {
@@ -1584,7 +1887,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 100
+        "y": 105
       },
       "id": 29,
       "options": {
@@ -1652,7 +1955,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 107
+        "y": 112
       },
       "id": 18,
       "options": {
@@ -1722,7 +2025,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 117
+        "y": 122
       },
       "id": 19,
       "options": {
@@ -1792,7 +2095,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 127
+        "y": 132
       },
       "id": 20,
       "options": {
@@ -1883,7 +2186,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 137
+        "y": 142
       },
       "id": 21,
       "options": {
@@ -1940,7 +2243,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 147
+        "y": 152
       },
       "id": 30,
       "panels": [],
@@ -1984,7 +2287,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 148
+        "y": 153
       },
       "id": 34,
       "options": {
@@ -2079,7 +2382,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 148
+        "y": 153
       },
       "id": 32,
       "options": {
@@ -2154,7 +2457,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 155
+        "y": 160
       },
       "id": 33,
       "options": {

--- a/contrib/grafana/postgresql_dashboard_pg14.json
+++ b/contrib/grafana/postgresql_dashboard_pg14.json
@@ -1109,9 +1109,9 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
+        "w": 12,
+        "h": 8,
         "y": 75
       },
       "id": 14,
@@ -1161,106 +1161,6 @@
         }
       ],
       "title": "WAL Generation",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Replication slots status",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 83
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_replication_slots_active",
-          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_stat_replication",
-          "legendFormat": "Streaming WAL - {{application_name}}",
-          "refId": "B"
-        }
-      ],
-      "title": "Replication Status",
       "type": "timeseries"
     },
     {
@@ -1335,10 +1235,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
-        "y": 91
+        "w": 12,
+        "h": 8,
+        "y": 83
       },
       "id": 16,
       "options": {
@@ -1394,6 +1294,174 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Replication slots status",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "w": 12,
+        "h": 8,
+        "y": 83
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_replication_slots_active",
+          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_replication",
+          "legendFormat": "Streaming WAL - {{application_name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Replication Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 91
+      },
+      "id": 50,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Age of databases since last vacuum",
       "fieldConfig": {
         "defaults": {
@@ -1422,10 +1490,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 12,
-        "y": 99
+        "w": 12,
+        "h": 8,
+        "y": 91
       },
       "id": 17,
       "options": {
@@ -1462,7 +1530,123 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Multixact age of databases since last vacuum",
+      "description": "WAL receiver LSN positions for monitoring replication progress on replica servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "LSN (numeric)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 99
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_receive_start_lsn",
+          "legendFormat": "Receive Start LSN ({{slot_name}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_written_lsn",
+          "legendFormat": "Written LSN ({{slot_name}})",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_flushed_lsn",
+          "legendFormat": "Flushed LSN ({{slot_name}})",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_latest_end_lsn",
+          "legendFormat": "Latest End LSN ({{slot_name}})",
+          "refId": "D"
+        }
+      ],
+      "title": "WAL Receiver LSN Positions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Time lag between WAL sender and receiver messages. High values indicate replication delay.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1477,30 +1661,30 @@
               },
               {
                 "color": "yellow",
-                "value": 100000000
+                "value": 5
               },
               {
                 "color": "red",
-                "value": 180000000
+                "value": 30
               }
             ]
           },
-          "unit": "locale"
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "x": 12,
         "w": 12,
-        "x": 0,
+        "h": 8,
         "y": 99
       },
-      "id": 50,
+      "id": 52,
       "options": {
-        "displayMode": "gradient",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -1508,7 +1692,8 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "11.6.0",
       "targets": [
@@ -1517,13 +1702,131 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
-          "legendFormat": "{{datname}}",
+          "expr": "pgexporter_pg_stat_walreceiver_last_msg_receipt_time - pgexporter_pg_stat_walreceiver_last_msg_send_time",
+          "legendFormat": "Message Lag ({{slot_name}})",
           "refId": "A"
         }
       ],
-      "title": "Database Age (MultiXact ID Wraparound)",
-      "type": "bargauge"
+      "title": "WAL Receiver Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "WAL receiver connection and status information",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "streaming": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Streaming"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 24,
+        "h": 5,
+        "y": 107
+      },
+      "id": 53,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_received_tli",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false,
+              "__name__": true
+            },
+            "renameByName": {
+              "Value": "Timeline",
+              "sender_host": "Sender Host",
+              "sender_port": "Sender Port",
+              "slot_name": "Slot Name",
+              "status": "Status",
+              "server": "Server"
+            }
+          }
+        }
+      ],
+      "title": "WAL Receiver Status",
+      "type": "table"
     },
     {
       "collapsed": false,
@@ -1531,7 +1834,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 107
+        "y": 112
       },
       "id": 18,
       "panels": [],
@@ -1574,7 +1877,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 108
+        "y": 113
       },
       "id": 27,
       "options": {
@@ -1642,7 +1945,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 108
+        "y": 113
       },
       "id": 28,
       "options": {
@@ -1710,7 +2013,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 108
+        "y": 113
       },
       "id": 29,
       "options": {
@@ -1778,7 +2081,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 115
+        "y": 120
       },
       "id": 19,
       "options": {
@@ -1848,7 +2151,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 125
+        "y": 130
       },
       "id": 20,
       "options": {
@@ -1918,7 +2221,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 135
+        "y": 140
       },
       "id": 21,
       "options": {
@@ -2009,7 +2312,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 145
+        "y": 150
       },
       "id": 22,
       "options": {
@@ -2066,7 +2369,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 155
+        "y": 160
       },
       "id": 23,
       "panels": [],
@@ -2131,7 +2434,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 156
+        "y": 161
       },
       "id": 24,
       "options": {
@@ -2179,7 +2482,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 164
+        "y": 169
       },
       "id": 30,
       "panels": [],
@@ -2223,7 +2526,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 165
+        "y": 170
       },
       "id": 31,
       "options": {
@@ -2318,7 +2621,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 165
+        "y": 170
       },
       "id": 32,
       "options": {
@@ -2393,7 +2696,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 172
+        "y": 177
       },
       "id": 33,
       "options": {

--- a/contrib/grafana/postgresql_dashboard_pg15.json
+++ b/contrib/grafana/postgresql_dashboard_pg15.json
@@ -1109,9 +1109,9 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
+        "w": 12,
+        "h": 8,
         "y": 75
       },
       "id": 14,
@@ -1161,106 +1161,6 @@
         }
       ],
       "title": "WAL Generation",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Replication slots status",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 83
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_replication_slots_active",
-          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_stat_replication",
-          "legendFormat": "Streaming WAL - {{application_name}}",
-          "refId": "B"
-        }
-      ],
-      "title": "Replication Status",
       "type": "timeseries"
     },
     {
@@ -1335,10 +1235,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
-        "y": 91
+        "w": 12,
+        "h": 8,
+        "y": 83
       },
       "id": 16,
       "options": {
@@ -1394,6 +1294,174 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Replication slots status",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "w": 12,
+        "h": 8,
+        "y": 83
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_replication_slots_active",
+          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_replication",
+          "legendFormat": "Streaming WAL - {{application_name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Replication Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 91
+      },
+      "id": 50,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Age of databases since last vacuum",
       "fieldConfig": {
         "defaults": {
@@ -1422,10 +1490,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 12,
-        "y": 99
+        "w": 12,
+        "h": 8,
+        "y": 91
       },
       "id": 17,
       "options": {
@@ -1462,7 +1530,123 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Multixact age of databases since last vacuum",
+      "description": "WAL receiver LSN positions for monitoring replication progress on replica servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "LSN (numeric)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 99
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_receive_start_lsn",
+          "legendFormat": "Receive Start LSN ({{slot_name}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_written_lsn",
+          "legendFormat": "Written LSN ({{slot_name}})",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_flushed_lsn",
+          "legendFormat": "Flushed LSN ({{slot_name}})",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_latest_end_lsn",
+          "legendFormat": "Latest End LSN ({{slot_name}})",
+          "refId": "D"
+        }
+      ],
+      "title": "WAL Receiver LSN Positions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Time lag between WAL sender and receiver messages. High values indicate replication delay.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1477,30 +1661,30 @@
               },
               {
                 "color": "yellow",
-                "value": 100000000
+                "value": 5
               },
               {
                 "color": "red",
-                "value": 180000000
+                "value": 30
               }
             ]
           },
-          "unit": "locale"
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "x": 12,
         "w": 12,
-        "x": 0,
+        "h": 8,
         "y": 99
       },
-      "id": 50,
+      "id": 52,
       "options": {
-        "displayMode": "gradient",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -1508,7 +1692,8 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "11.6.0",
       "targets": [
@@ -1517,13 +1702,131 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
-          "legendFormat": "{{datname}}",
+          "expr": "pgexporter_pg_stat_walreceiver_last_msg_receipt_time - pgexporter_pg_stat_walreceiver_last_msg_send_time",
+          "legendFormat": "Message Lag ({{slot_name}})",
           "refId": "A"
         }
       ],
-      "title": "Database Age (MultiXact ID Wraparound)",
-      "type": "bargauge"
+      "title": "WAL Receiver Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "WAL receiver connection and status information",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "streaming": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Streaming"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 24,
+        "h": 5,
+        "y": 107
+      },
+      "id": 53,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_received_tli",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false,
+              "__name__": true
+            },
+            "renameByName": {
+              "Value": "Timeline",
+              "sender_host": "Sender Host",
+              "sender_port": "Sender Port",
+              "slot_name": "Slot Name",
+              "status": "Status",
+              "server": "Server"
+            }
+          }
+        }
+      ],
+      "title": "WAL Receiver Status",
+      "type": "table"
     },
     {
       "collapsed": false,
@@ -1531,7 +1834,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 107
+        "y": 112
       },
       "id": 18,
       "panels": [],
@@ -1574,7 +1877,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 108
+        "y": 113
       },
       "id": 27,
       "options": {
@@ -1642,7 +1945,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 108
+        "y": 113
       },
       "id": 28,
       "options": {
@@ -1710,7 +2013,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 108
+        "y": 113
       },
       "id": 29,
       "options": {
@@ -1778,7 +2081,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 115
+        "y": 120
       },
       "id": 19,
       "options": {
@@ -1848,7 +2151,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 125
+        "y": 130
       },
       "id": 20,
       "options": {
@@ -1918,7 +2221,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 135
+        "y": 140
       },
       "id": 21,
       "options": {
@@ -2009,7 +2312,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 145
+        "y": 150
       },
       "id": 22,
       "options": {
@@ -2066,7 +2369,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 155
+        "y": 160
       },
       "id": 23,
       "panels": [],
@@ -2131,7 +2434,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 156
+        "y": 161
       },
       "id": 24,
       "options": {
@@ -2179,7 +2482,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 164
+        "y": 169
       },
       "id": 30,
       "panels": [],
@@ -2223,7 +2526,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 165
+        "y": 170
       },
       "id": 31,
       "options": {
@@ -2318,7 +2621,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 165
+        "y": 170
       },
       "id": 32,
       "options": {
@@ -2393,7 +2696,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 172
+        "y": 177
       },
       "id": 33,
       "options": {

--- a/contrib/grafana/postgresql_dashboard_pg16.json
+++ b/contrib/grafana/postgresql_dashboard_pg16.json
@@ -1109,9 +1109,9 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
+        "w": 12,
+        "h": 8,
         "y": 75
       },
       "id": 14,
@@ -1161,106 +1161,6 @@
         }
       ],
       "title": "WAL Generation",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Replication slots status",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 83
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_replication_slots_active",
-          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_stat_replication",
-          "legendFormat": "Streaming WAL - {{application_name}}",
-          "refId": "B"
-        }
-      ],
-      "title": "Replication Status",
       "type": "timeseries"
     },
     {
@@ -1335,10 +1235,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
-        "y": 91
+        "w": 12,
+        "h": 8,
+        "y": 83
       },
       "id": 16,
       "options": {
@@ -1394,6 +1294,174 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Replication slots status",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "w": 12,
+        "h": 8,
+        "y": 83
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_replication_slots_active",
+          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_replication",
+          "legendFormat": "Streaming WAL - {{application_name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Replication Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 91
+      },
+      "id": 50,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Age of databases since last vacuum",
       "fieldConfig": {
         "defaults": {
@@ -1422,10 +1490,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 12,
-        "y": 99
+        "w": 12,
+        "h": 8,
+        "y": 91
       },
       "id": 17,
       "options": {
@@ -1462,7 +1530,123 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Multixact age of databases since last vacuum",
+      "description": "WAL receiver LSN positions for monitoring replication progress on replica servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "LSN (numeric)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 99
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_receive_start_lsn",
+          "legendFormat": "Receive Start LSN ({{slot_name}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_written_lsn",
+          "legendFormat": "Written LSN ({{slot_name}})",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_flushed_lsn",
+          "legendFormat": "Flushed LSN ({{slot_name}})",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_latest_end_lsn",
+          "legendFormat": "Latest End LSN ({{slot_name}})",
+          "refId": "D"
+        }
+      ],
+      "title": "WAL Receiver LSN Positions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Time lag between WAL sender and receiver messages. High values indicate replication delay.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1477,30 +1661,30 @@
               },
               {
                 "color": "yellow",
-                "value": 100000000
+                "value": 5
               },
               {
                 "color": "red",
-                "value": 180000000
+                "value": 30
               }
             ]
           },
-          "unit": "locale"
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "x": 12,
         "w": 12,
-        "x": 0,
+        "h": 8,
         "y": 99
       },
-      "id": 50,
+      "id": 52,
       "options": {
-        "displayMode": "gradient",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -1508,7 +1692,8 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "11.6.0",
       "targets": [
@@ -1517,13 +1702,131 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
-          "legendFormat": "{{datname}}",
+          "expr": "pgexporter_pg_stat_walreceiver_last_msg_receipt_time - pgexporter_pg_stat_walreceiver_last_msg_send_time",
+          "legendFormat": "Message Lag ({{slot_name}})",
           "refId": "A"
         }
       ],
-      "title": "Database Age (MultiXact ID Wraparound)",
-      "type": "bargauge"
+      "title": "WAL Receiver Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "WAL receiver connection and status information",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "streaming": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Streaming"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 24,
+        "h": 5,
+        "y": 107
+      },
+      "id": 53,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_received_tli",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false,
+              "__name__": true
+            },
+            "renameByName": {
+              "Value": "Timeline",
+              "sender_host": "Sender Host",
+              "sender_port": "Sender Port",
+              "slot_name": "Slot Name",
+              "status": "Status",
+              "server": "Server"
+            }
+          }
+        }
+      ],
+      "title": "WAL Receiver Status",
+      "type": "table"
     },
     {
       "collapsed": false,
@@ -1531,7 +1834,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 107
+        "y": 112
       },
       "id": 18,
       "panels": [],
@@ -1574,7 +1877,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 108
+        "y": 113
       },
       "id": 27,
       "options": {
@@ -1642,7 +1945,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 108
+        "y": 113
       },
       "id": 28,
       "options": {
@@ -1710,7 +2013,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 108
+        "y": 113
       },
       "id": 29,
       "options": {
@@ -1778,7 +2081,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 115
+        "y": 120
       },
       "id": 19,
       "options": {
@@ -1848,7 +2151,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 125
+        "y": 130
       },
       "id": 20,
       "options": {
@@ -1918,7 +2221,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 135
+        "y": 140
       },
       "id": 21,
       "options": {
@@ -2009,7 +2312,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 145
+        "y": 150
       },
       "id": 22,
       "options": {
@@ -2066,7 +2369,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 155
+        "y": 160
       },
       "id": 23,
       "panels": [],
@@ -2148,7 +2451,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 156
+        "y": 161
       },
       "id": 24,
       "options": {
@@ -2266,7 +2569,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 164
+        "y": 169
       },
       "id": 25,
       "options": {
@@ -2314,7 +2617,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 172
+        "y": 177
       },
       "id": 30,
       "panels": [],
@@ -2358,7 +2661,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 173
+        "y": 178
       },
       "id": 31,
       "options": {
@@ -2453,7 +2756,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 173
+        "y": 178
       },
       "id": 32,
       "options": {
@@ -2528,7 +2831,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 180
+        "y": 185
       },
       "id": 33,
       "options": {

--- a/contrib/grafana/postgresql_dashboard_pg17.json
+++ b/contrib/grafana/postgresql_dashboard_pg17.json
@@ -1109,9 +1109,9 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
+        "w": 12,
+        "h": 8,
         "y": 75
       },
       "id": 14,
@@ -1161,106 +1161,6 @@
         }
       ],
       "title": "WAL Generation",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Replication slots status",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 83
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_replication_slots_active",
-          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_stat_replication",
-          "legendFormat": "Streaming WAL - {{application_name}}",
-          "refId": "B"
-        }
-      ],
-      "title": "Replication Status",
       "type": "timeseries"
     },
     {
@@ -1335,10 +1235,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
-        "y": 91
+        "w": 12,
+        "h": 8,
+        "y": 83
       },
       "id": 16,
       "options": {
@@ -1394,6 +1294,174 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Replication slots status",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "w": 12,
+        "h": 8,
+        "y": 83
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_replication_slots_active",
+          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_replication",
+          "legendFormat": "Streaming WAL - {{application_name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Replication Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 91
+      },
+      "id": 50,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Age of databases since last vacuum",
       "fieldConfig": {
         "defaults": {
@@ -1422,10 +1490,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 12,
-        "y": 99
+        "w": 12,
+        "h": 8,
+        "y": 91
       },
       "id": 17,
       "options": {
@@ -1462,7 +1530,123 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Multixact age of databases since last vacuum",
+      "description": "WAL receiver LSN positions for monitoring replication progress on replica servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "LSN (numeric)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 99
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_receive_start_lsn",
+          "legendFormat": "Receive Start LSN ({{slot_name}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_written_lsn",
+          "legendFormat": "Written LSN ({{slot_name}})",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_flushed_lsn",
+          "legendFormat": "Flushed LSN ({{slot_name}})",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_latest_end_lsn",
+          "legendFormat": "Latest End LSN ({{slot_name}})",
+          "refId": "D"
+        }
+      ],
+      "title": "WAL Receiver LSN Positions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Time lag between WAL sender and receiver messages. High values indicate replication delay.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1477,30 +1661,30 @@
               },
               {
                 "color": "yellow",
-                "value": 100000000
+                "value": 5
               },
               {
                 "color": "red",
-                "value": 180000000
+                "value": 30
               }
             ]
           },
-          "unit": "locale"
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "x": 12,
         "w": 12,
-        "x": 0,
+        "h": 8,
         "y": 99
       },
-      "id": 50,
+      "id": 52,
       "options": {
-        "displayMode": "gradient",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -1508,7 +1692,8 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "11.6.0",
       "targets": [
@@ -1517,13 +1702,131 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
-          "legendFormat": "{{datname}}",
+          "expr": "pgexporter_pg_stat_walreceiver_last_msg_receipt_time - pgexporter_pg_stat_walreceiver_last_msg_send_time",
+          "legendFormat": "Message Lag ({{slot_name}})",
           "refId": "A"
         }
       ],
-      "title": "Database Age (MultiXact ID Wraparound)",
-      "type": "bargauge"
+      "title": "WAL Receiver Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "WAL receiver connection and status information",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "streaming": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Streaming"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 24,
+        "h": 5,
+        "y": 107
+      },
+      "id": 53,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_received_tli",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false,
+              "__name__": true
+            },
+            "renameByName": {
+              "Value": "Timeline",
+              "sender_host": "Sender Host",
+              "sender_port": "Sender Port",
+              "slot_name": "Slot Name",
+              "status": "Status",
+              "server": "Server"
+            }
+          }
+        }
+      ],
+      "title": "WAL Receiver Status",
+      "type": "table"
     },
     {
       "collapsed": false,
@@ -1531,7 +1834,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 107
+        "y": 112
       },
       "id": 18,
       "panels": [],
@@ -1574,7 +1877,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 108
+        "y": 113
       },
       "id": 27,
       "options": {
@@ -1642,7 +1945,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 108
+        "y": 113
       },
       "id": 28,
       "options": {
@@ -1710,7 +2013,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 108
+        "y": 113
       },
       "id": 29,
       "options": {
@@ -1778,7 +2081,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 115
+        "y": 120
       },
       "id": 19,
       "options": {
@@ -1848,7 +2151,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 125
+        "y": 130
       },
       "id": 20,
       "options": {
@@ -1918,7 +2221,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 135
+        "y": 140
       },
       "id": 21,
       "options": {
@@ -2009,7 +2312,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 145
+        "y": 150
       },
       "id": 22,
       "options": {
@@ -2066,7 +2369,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 155
+        "y": 160
       },
       "id": 23,
       "panels": [],
@@ -2148,7 +2451,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 156
+        "y": 161
       },
       "id": 24,
       "options": {
@@ -2266,7 +2569,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 164
+        "y": 169
       },
       "id": 25,
       "options": {
@@ -2334,7 +2637,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 172
+        "y": 177
       },
       "id": 26,
       "options": {
@@ -2385,7 +2688,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 180
+        "y": 185
       },
       "id": 30,
       "panels": [],
@@ -2429,7 +2732,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 181
+        "y": 186
       },
       "id": 31,
       "options": {
@@ -2524,7 +2827,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 181
+        "y": 186
       },
       "id": 32,
       "options": {
@@ -2599,7 +2902,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 188
+        "y": 193
       },
       "id": 33,
       "options": {

--- a/contrib/grafana/postgresql_dashboard_pg18.json
+++ b/contrib/grafana/postgresql_dashboard_pg18.json
@@ -1109,9 +1109,9 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
+        "w": 12,
+        "h": 8,
         "y": 75
       },
       "id": 14,
@@ -1161,106 +1161,6 @@
         }
       ],
       "title": "WAL Generation",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Replication slots status",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 83
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_replication_slots_active",
-          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "pgexporter_pg_stat_replication",
-          "legendFormat": "Streaming WAL - {{application_name}}",
-          "refId": "B"
-        }
-      ],
-      "title": "Replication Status",
       "type": "timeseries"
     },
     {
@@ -1335,10 +1235,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
-        "y": 91
+        "w": 12,
+        "h": 8,
+        "y": 83
       },
       "id": 16,
       "options": {
@@ -1394,6 +1294,174 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Replication slots status",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "w": 12,
+        "h": 8,
+        "y": 83
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_replication_slots_active",
+          "legendFormat": "Active - {{slot_name}} ({{slot_type}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_replication",
+          "legendFormat": "Streaming WAL - {{application_name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Replication Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Multixact age of databases since last vacuum",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 100000000
+              },
+              {
+                "color": "red",
+                "value": 180000000
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 91
+      },
+      "id": 50,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Age (MultiXact ID Wraparound)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Age of databases since last vacuum",
       "fieldConfig": {
         "defaults": {
@@ -1422,10 +1490,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 12,
-        "y": 99
+        "w": 12,
+        "h": 8,
+        "y": 91
       },
       "id": 17,
       "options": {
@@ -1462,7 +1530,123 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Multixact age of databases since last vacuum",
+      "description": "WAL receiver LSN positions for monitoring replication progress on replica servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "LSN (numeric)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 99
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_receive_start_lsn",
+          "legendFormat": "Receive Start LSN ({{slot_name}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_written_lsn",
+          "legendFormat": "Written LSN ({{slot_name}})",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_flushed_lsn",
+          "legendFormat": "Flushed LSN ({{slot_name}})",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_latest_end_lsn",
+          "legendFormat": "Latest End LSN ({{slot_name}})",
+          "refId": "D"
+        }
+      ],
+      "title": "WAL Receiver LSN Positions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Time lag between WAL sender and receiver messages. High values indicate replication delay.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1477,30 +1661,30 @@
               },
               {
                 "color": "yellow",
-                "value": 100000000
+                "value": 5
               },
               {
                 "color": "red",
-                "value": 180000000
+                "value": 30
               }
             ]
           },
-          "unit": "locale"
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "x": 12,
         "w": 12,
-        "x": 0,
+        "h": 8,
         "y": 99
       },
-      "id": 50,
+      "id": 52,
       "options": {
-        "displayMode": "gradient",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -1508,7 +1692,8 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "11.6.0",
       "targets": [
@@ -1517,13 +1702,131 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "pgexporter_pg_db_vacuum_age_datminmxid",
-          "legendFormat": "{{datname}}",
+          "expr": "pgexporter_pg_stat_walreceiver_last_msg_receipt_time - pgexporter_pg_stat_walreceiver_last_msg_send_time",
+          "legendFormat": "Message Lag ({{slot_name}})",
           "refId": "A"
         }
       ],
-      "title": "Database Age (MultiXact ID Wraparound)",
-      "type": "bargauge"
+      "title": "WAL Receiver Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "WAL receiver connection and status information",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "streaming": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Streaming"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 24,
+        "h": 5,
+        "y": 107
+      },
+      "id": 53,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pgexporter_pg_stat_walreceiver_received_tli",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false,
+              "__name__": true
+            },
+            "renameByName": {
+              "Value": "Timeline",
+              "sender_host": "Sender Host",
+              "sender_port": "Sender Port",
+              "slot_name": "Slot Name",
+              "status": "Status",
+              "server": "Server"
+            }
+          }
+        }
+      ],
+      "title": "WAL Receiver Status",
+      "type": "table"
     },
     {
       "collapsed": false,
@@ -1531,7 +1834,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 107
+        "y": 112
       },
       "id": 18,
       "panels": [],
@@ -1574,7 +1877,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 108
+        "y": 113
       },
       "id": 27,
       "options": {
@@ -1642,7 +1945,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 108
+        "y": 113
       },
       "id": 28,
       "options": {
@@ -1710,7 +2013,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 108
+        "y": 113
       },
       "id": 29,
       "options": {
@@ -1778,7 +2081,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 115
+        "y": 120
       },
       "id": 19,
       "options": {
@@ -1848,7 +2151,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 125
+        "y": 130
       },
       "id": 20,
       "options": {
@@ -1918,7 +2221,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 135
+        "y": 140
       },
       "id": 21,
       "options": {
@@ -2009,7 +2312,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 145
+        "y": 150
       },
       "id": 22,
       "options": {
@@ -2066,7 +2369,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 155
+        "y": 160
       },
       "id": 23,
       "panels": [],
@@ -2148,7 +2451,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 156
+        "y": 161
       },
       "id": 24,
       "options": {
@@ -2266,7 +2569,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 164
+        "y": 169
       },
       "id": 25,
       "options": {
@@ -2334,7 +2637,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 165
+        "y": 170
       },
       "id": 26,
       "options": {
@@ -2385,7 +2688,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 180
+        "y": 185
       },
       "id": 30,
       "panels": [],
@@ -2429,7 +2732,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 181
+        "y": 186
       },
       "id": 31,
       "options": {
@@ -2524,7 +2827,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 181
+        "y": 186
       },
       "id": 32,
       "options": {
@@ -2599,7 +2902,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 188
+        "y": 193
       },
       "id": 33,
       "options": {

--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -692,6 +692,84 @@
       ]
     },
     {
+      "tag": "pg_stat_walreceiver",
+      "collector": "stat_walreceiver",
+      "server": "replica",
+      "queries": [
+        {
+          "query": "SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "slot_name",
+              "type": "label",
+              "description": "Replication slot name."
+            },
+            {
+              "name": "status",
+              "type": "label",
+              "description": "WAL receiver activity status."
+            },
+            {
+              "name": "receive_start_lsn",
+              "type": "counter",
+              "description": "First WAL position received."
+            },
+            {
+              "name": "receive_start_tli",
+              "type": "gauge",
+              "description": "Timeline of first WAL position received."
+            },
+            {
+              "name": "written_lsn",
+              "type": "counter",
+              "description": "Last WAL position written to disk."
+            },
+            {
+              "name": "flushed_lsn",
+              "type": "counter",
+              "description": "Last WAL position flushed to disk."
+            },
+            {
+              "name": "received_tli",
+              "type": "gauge",
+              "description": "Timeline of last WAL position received."
+            },
+            {
+              "name": "last_msg_send_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message sent by sender."
+            },
+            {
+              "name": "last_msg_receipt_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message received."
+            },
+            {
+              "name": "latest_end_lsn",
+              "type": "counter",
+              "description": "Latest WAL end position reported to sender."
+            },
+            {
+              "name": "latest_end_time",
+              "type": "counter",
+              "description": "Epoch timestamp of latest end position report."
+            },
+            {
+              "name": "sender_host",
+              "type": "label",
+              "description": "Upstream sender host."
+            },
+            {
+              "name": "sender_port",
+              "type": "gauge",
+              "description": "Upstream sender port."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "tag": "pg_gss_auth",
       "collector": "gssapi",
       "queries": [

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -692,6 +692,84 @@
       ]
     },
     {
+      "tag": "pg_stat_walreceiver",
+      "collector": "stat_walreceiver",
+      "server": "replica",
+      "queries": [
+        {
+          "query": "SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "slot_name",
+              "type": "label",
+              "description": "Replication slot name."
+            },
+            {
+              "name": "status",
+              "type": "label",
+              "description": "WAL receiver activity status."
+            },
+            {
+              "name": "receive_start_lsn",
+              "type": "counter",
+              "description": "First WAL position received."
+            },
+            {
+              "name": "receive_start_tli",
+              "type": "gauge",
+              "description": "Timeline of first WAL position received."
+            },
+            {
+              "name": "written_lsn",
+              "type": "counter",
+              "description": "Last WAL position written to disk."
+            },
+            {
+              "name": "flushed_lsn",
+              "type": "counter",
+              "description": "Last WAL position flushed to disk."
+            },
+            {
+              "name": "received_tli",
+              "type": "gauge",
+              "description": "Timeline of last WAL position received."
+            },
+            {
+              "name": "last_msg_send_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message sent by sender."
+            },
+            {
+              "name": "last_msg_receipt_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message received."
+            },
+            {
+              "name": "latest_end_lsn",
+              "type": "counter",
+              "description": "Latest WAL end position reported to sender."
+            },
+            {
+              "name": "latest_end_time",
+              "type": "counter",
+              "description": "Epoch timestamp of latest end position report."
+            },
+            {
+              "name": "sender_host",
+              "type": "label",
+              "description": "Upstream sender host."
+            },
+            {
+              "name": "sender_port",
+              "type": "gauge",
+              "description": "Upstream sender port."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "tag": "pg_gss_auth",
       "collector": "gssapi",
       "queries": [

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -692,6 +692,84 @@
       ]
     },
     {
+      "tag": "pg_stat_walreceiver",
+      "collector": "stat_walreceiver",
+      "server": "replica",
+      "queries": [
+        {
+          "query": "SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "slot_name",
+              "type": "label",
+              "description": "Replication slot name."
+            },
+            {
+              "name": "status",
+              "type": "label",
+              "description": "WAL receiver activity status."
+            },
+            {
+              "name": "receive_start_lsn",
+              "type": "counter",
+              "description": "First WAL position received."
+            },
+            {
+              "name": "receive_start_tli",
+              "type": "gauge",
+              "description": "Timeline of first WAL position received."
+            },
+            {
+              "name": "written_lsn",
+              "type": "counter",
+              "description": "Last WAL position written to disk."
+            },
+            {
+              "name": "flushed_lsn",
+              "type": "counter",
+              "description": "Last WAL position flushed to disk."
+            },
+            {
+              "name": "received_tli",
+              "type": "gauge",
+              "description": "Timeline of last WAL position received."
+            },
+            {
+              "name": "last_msg_send_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message sent by sender."
+            },
+            {
+              "name": "last_msg_receipt_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message received."
+            },
+            {
+              "name": "latest_end_lsn",
+              "type": "counter",
+              "description": "Latest WAL end position reported to sender."
+            },
+            {
+              "name": "latest_end_time",
+              "type": "counter",
+              "description": "Epoch timestamp of latest end position report."
+            },
+            {
+              "name": "sender_host",
+              "type": "label",
+              "description": "Upstream sender host."
+            },
+            {
+              "name": "sender_port",
+              "type": "gauge",
+              "description": "Upstream sender port."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "tag": "pg_gss_auth",
       "collector": "gssapi",
       "queries": [

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -692,6 +692,84 @@
       ]
     },
     {
+      "tag": "pg_stat_walreceiver",
+      "collector": "stat_walreceiver",
+      "server": "replica",
+      "queries": [
+        {
+          "query": "SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "slot_name",
+              "type": "label",
+              "description": "Replication slot name."
+            },
+            {
+              "name": "status",
+              "type": "label",
+              "description": "WAL receiver activity status."
+            },
+            {
+              "name": "receive_start_lsn",
+              "type": "counter",
+              "description": "First WAL position received."
+            },
+            {
+              "name": "receive_start_tli",
+              "type": "gauge",
+              "description": "Timeline of first WAL position received."
+            },
+            {
+              "name": "written_lsn",
+              "type": "counter",
+              "description": "Last WAL position written to disk."
+            },
+            {
+              "name": "flushed_lsn",
+              "type": "counter",
+              "description": "Last WAL position flushed to disk."
+            },
+            {
+              "name": "received_tli",
+              "type": "gauge",
+              "description": "Timeline of last WAL position received."
+            },
+            {
+              "name": "last_msg_send_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message sent by sender."
+            },
+            {
+              "name": "last_msg_receipt_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message received."
+            },
+            {
+              "name": "latest_end_lsn",
+              "type": "counter",
+              "description": "Latest WAL end position reported to sender."
+            },
+            {
+              "name": "latest_end_time",
+              "type": "counter",
+              "description": "Epoch timestamp of latest end position report."
+            },
+            {
+              "name": "sender_host",
+              "type": "label",
+              "description": "Upstream sender host."
+            },
+            {
+              "name": "sender_port",
+              "type": "gauge",
+              "description": "Upstream sender port."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "tag": "pg_gss_auth",
       "collector": "gssapi",
       "queries": [

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -657,6 +657,84 @@
       ]
     },
     {
+      "tag": "pg_stat_walreceiver",
+      "collector": "stat_walreceiver",
+      "server": "replica",
+      "queries": [
+        {
+          "query": "SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "slot_name",
+              "type": "label",
+              "description": "Replication slot name."
+            },
+            {
+              "name": "status",
+              "type": "label",
+              "description": "WAL receiver activity status."
+            },
+            {
+              "name": "receive_start_lsn",
+              "type": "counter",
+              "description": "First WAL position received."
+            },
+            {
+              "name": "receive_start_tli",
+              "type": "gauge",
+              "description": "Timeline of first WAL position received."
+            },
+            {
+              "name": "written_lsn",
+              "type": "counter",
+              "description": "Last WAL position written to disk."
+            },
+            {
+              "name": "flushed_lsn",
+              "type": "counter",
+              "description": "Last WAL position flushed to disk."
+            },
+            {
+              "name": "received_tli",
+              "type": "gauge",
+              "description": "Timeline of last WAL position received."
+            },
+            {
+              "name": "last_msg_send_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message sent by sender."
+            },
+            {
+              "name": "last_msg_receipt_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message received."
+            },
+            {
+              "name": "latest_end_lsn",
+              "type": "counter",
+              "description": "Latest WAL end position reported to sender."
+            },
+            {
+              "name": "latest_end_time",
+              "type": "counter",
+              "description": "Epoch timestamp of latest end position report."
+            },
+            {
+              "name": "sender_host",
+              "type": "label",
+              "description": "Upstream sender host."
+            },
+            {
+              "name": "sender_port",
+              "type": "gauge",
+              "description": "Upstream sender port."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "tag": "pg_gss_auth",
       "collector": "gssapi",
       "queries": [

--- a/contrib/json/postgresql-18.json
+++ b/contrib/json/postgresql-18.json
@@ -692,6 +692,84 @@
       ]
     },
     {
+      "tag": "pg_stat_walreceiver",
+      "collector": "stat_walreceiver",
+      "server": "replica",
+      "queries": [
+        {
+          "query": "SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;",
+          "version": 13,
+          "columns": [
+            {
+              "name": "slot_name",
+              "type": "label",
+              "description": "Replication slot name."
+            },
+            {
+              "name": "status",
+              "type": "label",
+              "description": "WAL receiver activity status."
+            },
+            {
+              "name": "receive_start_lsn",
+              "type": "counter",
+              "description": "First WAL position received."
+            },
+            {
+              "name": "receive_start_tli",
+              "type": "gauge",
+              "description": "Timeline of first WAL position received."
+            },
+            {
+              "name": "written_lsn",
+              "type": "counter",
+              "description": "Last WAL position written to disk."
+            },
+            {
+              "name": "flushed_lsn",
+              "type": "counter",
+              "description": "Last WAL position flushed to disk."
+            },
+            {
+              "name": "received_tli",
+              "type": "gauge",
+              "description": "Timeline of last WAL position received."
+            },
+            {
+              "name": "last_msg_send_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message sent by sender."
+            },
+            {
+              "name": "last_msg_receipt_time",
+              "type": "counter",
+              "description": "Epoch timestamp of last message received."
+            },
+            {
+              "name": "latest_end_lsn",
+              "type": "counter",
+              "description": "Latest WAL end position reported to sender."
+            },
+            {
+              "name": "latest_end_time",
+              "type": "counter",
+              "description": "Epoch timestamp of latest end position report."
+            },
+            {
+              "name": "sender_host",
+              "type": "label",
+              "description": "Upstream sender host."
+            },
+            {
+              "name": "sender_port",
+              "type": "gauge",
+              "description": "Upstream sender port."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "tag": "pg_gss_auth",
       "collector": "gssapi",
       "queries": [

--- a/contrib/prometheus_scrape/extra.info
+++ b/contrib/prometheus_scrape/extra.info
@@ -3190,6 +3190,86 @@ pgexporter_pg_wal_last_received
 * sender: The address/identifier of the upstream WAL sender.
 Version: 11+
 
+pgexporter_pg_stat_walreceiver_receive_start_lsn
++ First WAL byte+1 position when receiver is started (numeric representation).
+* server: The configured name/identifier for the PostgreSQL server (the replica).
+* slot_name: Replication slot name.
+* status: WAL receiver activity status.
+* sender_host: Upstream sender host.
+Version: 13+
+
+pgexporter_pg_stat_walreceiver_receive_start_tli
++ Timeline number of first WAL byte+1 position when receiver is started.
+* server: The configured name/identifier for the PostgreSQL server (the replica).
+* slot_name: Replication slot name.
+* status: WAL receiver activity status.
+* sender_host: Upstream sender host.
+Version: 13+
+
+pgexporter_pg_stat_walreceiver_written_lsn
++ Last WAL byte+1 position written to disk (numeric representation).
+* server: The configured name/identifier for the PostgreSQL server (the replica).
+* slot_name: Replication slot name.
+* status: WAL receiver activity status.
+* sender_host: Upstream sender host.
+Version: 13+
+
+pgexporter_pg_stat_walreceiver_flushed_lsn
++ Last WAL byte+1 position flushed to disk (numeric representation).
+* server: The configured name/identifier for the PostgreSQL server (the replica).
+* slot_name: Replication slot name.
+* status: WAL receiver activity status.
+* sender_host: Upstream sender host.
+Version: 13+
+
+pgexporter_pg_stat_walreceiver_received_tli
++ Timeline number of last WAL byte+1 position received.
+* server: The configured name/identifier for the PostgreSQL server (the replica).
+* slot_name: Replication slot name.
+* status: WAL receiver activity status.
+* sender_host: Upstream sender host.
+Version: 13+
+
+pgexporter_pg_stat_walreceiver_last_msg_send_time
++ Epoch timestamp of last message sent by the WAL sender.
+* server: The configured name/identifier for the PostgreSQL server (the replica).
+* slot_name: Replication slot name.
+* status: WAL receiver activity status.
+* sender_host: Upstream sender host.
+Version: 13+
+
+pgexporter_pg_stat_walreceiver_last_msg_receipt_time
++ Epoch timestamp of last message received from the WAL sender.
+* server: The configured name/identifier for the PostgreSQL server (the replica).
+* slot_name: Replication slot name.
+* status: WAL receiver activity status.
+* sender_host: Upstream sender host.
+Version: 13+
+
+pgexporter_pg_stat_walreceiver_latest_end_lsn
++ Last WAL byte+1 position reported to the WAL sender (numeric representation).
+* server: The configured name/identifier for the PostgreSQL server (the replica).
+* slot_name: Replication slot name.
+* status: WAL receiver activity status.
+* sender_host: Upstream sender host.
+Version: 13+
+
+pgexporter_pg_stat_walreceiver_latest_end_time
++ Epoch timestamp of last report sent to the WAL sender.
+* server: The configured name/identifier for the PostgreSQL server (the replica).
+* slot_name: Replication slot name.
+* status: WAL receiver activity status.
+* sender_host: Upstream sender host.
+Version: 13+
+
+pgexporter_pg_stat_walreceiver_sender_port
++ Port number of the upstream WAL sender.
+* server: The configured name/identifier for the PostgreSQL server (the replica).
+* slot_name: Replication slot name.
+* status: WAL receiver activity status.
+* sender_host: Upstream sender host.
+Version: 13+
+
 pgexporter_pg_wait_events_count
 + Counts the occurrences of different wait event types encountered by backends since statistics were reset (from `pg_stat_get_wait_backend` or similar).
 * server: The configured name/identifier for the PostgreSQL server.

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -374,6 +374,52 @@ metrics:
       type: label
     - type: counter
       description: Time since last message received from WAL sender
+- tag: pg_stat_walreceiver
+  collector: stat_walreceiver
+  server: replica
+  queries:
+  - query: SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;
+    version: 13
+    columns:
+    - name: slot_name
+      type: label
+      description: Replication slot name.
+    - name: status
+      type: label
+      description: WAL receiver activity status.
+    - name: receive_start_lsn
+      type: counter
+      description: First WAL position received.
+    - name: receive_start_tli
+      type: gauge
+      description: Timeline of first WAL position received.
+    - name: written_lsn
+      type: counter
+      description: Last WAL position written to disk.
+    - name: flushed_lsn
+      type: counter
+      description: Last WAL position flushed to disk.
+    - name: received_tli
+      type: gauge
+      description: Timeline of last WAL position received.
+    - name: last_msg_send_time
+      type: counter
+      description: Epoch timestamp of last message sent by sender.
+    - name: last_msg_receipt_time
+      type: counter
+      description: Epoch timestamp of last message received.
+    - name: latest_end_lsn
+      type: counter
+      description: Latest WAL end position reported to sender.
+    - name: latest_end_time
+      type: counter
+      description: Epoch timestamp of latest end position report.
+    - name: sender_host
+      type: label
+      description: Upstream sender host.
+    - name: sender_port
+      type: gauge
+      description: Upstream sender port.
 - tag: pg_gss_auth
   collector: gssapi
   queries:

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -374,6 +374,52 @@ metrics:
       type: label
     - type: counter
       description: Time since last message received from WAL sender
+- tag: pg_stat_walreceiver
+  collector: stat_walreceiver
+  server: replica
+  queries:
+  - query: SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;
+    version: 13
+    columns:
+    - name: slot_name
+      type: label
+      description: Replication slot name.
+    - name: status
+      type: label
+      description: WAL receiver activity status.
+    - name: receive_start_lsn
+      type: counter
+      description: First WAL position received.
+    - name: receive_start_tli
+      type: gauge
+      description: Timeline of first WAL position received.
+    - name: written_lsn
+      type: counter
+      description: Last WAL position written to disk.
+    - name: flushed_lsn
+      type: counter
+      description: Last WAL position flushed to disk.
+    - name: received_tli
+      type: gauge
+      description: Timeline of last WAL position received.
+    - name: last_msg_send_time
+      type: counter
+      description: Epoch timestamp of last message sent by sender.
+    - name: last_msg_receipt_time
+      type: counter
+      description: Epoch timestamp of last message received.
+    - name: latest_end_lsn
+      type: counter
+      description: Latest WAL end position reported to sender.
+    - name: latest_end_time
+      type: counter
+      description: Epoch timestamp of latest end position report.
+    - name: sender_host
+      type: label
+      description: Upstream sender host.
+    - name: sender_port
+      type: gauge
+      description: Upstream sender port.
 - tag: pg_gss_auth
   collector: gssapi
   queries:

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -374,6 +374,52 @@ metrics:
       type: label
     - type: counter
       description: Time since last message received from WAL sender
+- tag: pg_stat_walreceiver
+  collector: stat_walreceiver
+  server: replica
+  queries:
+  - query: SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;
+    version: 13
+    columns:
+    - name: slot_name
+      type: label
+      description: Replication slot name.
+    - name: status
+      type: label
+      description: WAL receiver activity status.
+    - name: receive_start_lsn
+      type: counter
+      description: First WAL position received.
+    - name: receive_start_tli
+      type: gauge
+      description: Timeline of first WAL position received.
+    - name: written_lsn
+      type: counter
+      description: Last WAL position written to disk.
+    - name: flushed_lsn
+      type: counter
+      description: Last WAL position flushed to disk.
+    - name: received_tli
+      type: gauge
+      description: Timeline of last WAL position received.
+    - name: last_msg_send_time
+      type: counter
+      description: Epoch timestamp of last message sent by sender.
+    - name: last_msg_receipt_time
+      type: counter
+      description: Epoch timestamp of last message received.
+    - name: latest_end_lsn
+      type: counter
+      description: Latest WAL end position reported to sender.
+    - name: latest_end_time
+      type: counter
+      description: Epoch timestamp of latest end position report.
+    - name: sender_host
+      type: label
+      description: Upstream sender host.
+    - name: sender_port
+      type: gauge
+      description: Upstream sender port.
 - tag: pg_gss_auth
   collector: gssapi
   queries:

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -374,6 +374,52 @@ metrics:
       type: label
     - type: counter
       description: Time since last message received from WAL sender
+- tag: pg_stat_walreceiver
+  collector: stat_walreceiver
+  server: replica
+  queries:
+  - query: SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;
+    version: 13
+    columns:
+    - name: slot_name
+      type: label
+      description: Replication slot name.
+    - name: status
+      type: label
+      description: WAL receiver activity status.
+    - name: receive_start_lsn
+      type: counter
+      description: First WAL position received.
+    - name: receive_start_tli
+      type: gauge
+      description: Timeline of first WAL position received.
+    - name: written_lsn
+      type: counter
+      description: Last WAL position written to disk.
+    - name: flushed_lsn
+      type: counter
+      description: Last WAL position flushed to disk.
+    - name: received_tli
+      type: gauge
+      description: Timeline of last WAL position received.
+    - name: last_msg_send_time
+      type: counter
+      description: Epoch timestamp of last message sent by sender.
+    - name: last_msg_receipt_time
+      type: counter
+      description: Epoch timestamp of last message received.
+    - name: latest_end_lsn
+      type: counter
+      description: Latest WAL end position reported to sender.
+    - name: latest_end_time
+      type: counter
+      description: Epoch timestamp of latest end position report.
+    - name: sender_host
+      type: label
+      description: Upstream sender host.
+    - name: sender_port
+      type: gauge
+      description: Upstream sender port.
 - tag: pg_gss_auth
   collector: gssapi
   queries:

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -353,6 +353,52 @@ metrics:
       type: label
     - type: counter
       description: Time since last message received from WAL sender
+- tag: pg_stat_walreceiver
+  collector: stat_walreceiver
+  server: replica
+  queries:
+  - query: SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;
+    version: 13
+    columns:
+    - name: slot_name
+      type: label
+      description: Replication slot name.
+    - name: status
+      type: label
+      description: WAL receiver activity status.
+    - name: receive_start_lsn
+      type: counter
+      description: First WAL position received.
+    - name: receive_start_tli
+      type: gauge
+      description: Timeline of first WAL position received.
+    - name: written_lsn
+      type: counter
+      description: Last WAL position written to disk.
+    - name: flushed_lsn
+      type: counter
+      description: Last WAL position flushed to disk.
+    - name: received_tli
+      type: gauge
+      description: Timeline of last WAL position received.
+    - name: last_msg_send_time
+      type: counter
+      description: Epoch timestamp of last message sent by sender.
+    - name: last_msg_receipt_time
+      type: counter
+      description: Epoch timestamp of last message received.
+    - name: latest_end_lsn
+      type: counter
+      description: Latest WAL end position reported to sender.
+    - name: latest_end_time
+      type: counter
+      description: Epoch timestamp of latest end position report.
+    - name: sender_host
+      type: label
+      description: Upstream sender host.
+    - name: sender_port
+      type: gauge
+      description: Upstream sender port.
 - tag: pg_gss_auth
   collector: gssapi
   queries:

--- a/contrib/yaml/postgresql-18.yaml
+++ b/contrib/yaml/postgresql-18.yaml
@@ -374,6 +374,52 @@ metrics:
       type: label
     - type: counter
       description: Time since last message received from WAL sender
+- tag: pg_stat_walreceiver
+  collector: stat_walreceiver
+  server: replica
+  queries:
+  - query: SELECT COALESCE(slot_name, '') AS slot_name, COALESCE(status, '') AS status, (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn, receive_start_tli, (written_lsn - '0/0') % (2^52)::bigint AS written_lsn, (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn, received_tli, extract(epoch from last_msg_send_time) AS last_msg_send_time, extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time, (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn, extract(epoch from latest_end_time) AS latest_end_time, COALESCE(sender_host, '') AS sender_host, COALESCE(sender_port, 0) AS sender_port FROM pg_stat_wal_receiver;
+    version: 13
+    columns:
+    - name: slot_name
+      type: label
+      description: Replication slot name.
+    - name: status
+      type: label
+      description: WAL receiver activity status.
+    - name: receive_start_lsn
+      type: counter
+      description: First WAL position received.
+    - name: receive_start_tli
+      type: gauge
+      description: Timeline of first WAL position received.
+    - name: written_lsn
+      type: counter
+      description: Last WAL position written to disk.
+    - name: flushed_lsn
+      type: counter
+      description: Last WAL position flushed to disk.
+    - name: received_tli
+      type: gauge
+      description: Timeline of last WAL position received.
+    - name: last_msg_send_time
+      type: counter
+      description: Epoch timestamp of last message sent by sender.
+    - name: last_msg_receipt_time
+      type: counter
+      description: Epoch timestamp of last message received.
+    - name: latest_end_lsn
+      type: counter
+      description: Latest WAL end position reported to sender.
+    - name: latest_end_time
+      type: counter
+      description: Epoch timestamp of latest end position report.
+    - name: sender_host
+      type: label
+      description: Upstream sender host.
+    - name: sender_port
+      type: gauge
+      description: Upstream sender port.
 - tag: pg_gss_auth
   collector: gssapi
   queries:

--- a/doc/manual/en/06-prometheus.md
+++ b/doc/manual/en/06-prometheus.md
@@ -3992,6 +3992,116 @@ Counts active WAL streaming replication connections, grouped by the `application
 | application_name | The application name reported by the replication connection. |
 | state | Hardcoded to 'streaming' in the query. |
 
+## pgexporter_pg_stat_walreceiver_receive_start_lsn
+
+First WAL byte+1 position when receiver is started (numeric representation).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server (the replica). |
+| slot_name | Replication slot name. |
+| status | WAL receiver activity status. |
+| sender_host | Upstream sender host. |
+
+## pgexporter_pg_stat_walreceiver_receive_start_tli
+
+Timeline number of first WAL byte+1 position when receiver is started.
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server (the replica). |
+| slot_name | Replication slot name. |
+| status | WAL receiver activity status. |
+| sender_host | Upstream sender host. |
+
+## pgexporter_pg_stat_walreceiver_written_lsn
+
+Last WAL byte+1 position written to disk (numeric representation).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server (the replica). |
+| slot_name | Replication slot name. |
+| status | WAL receiver activity status. |
+| sender_host | Upstream sender host. |
+
+## pgexporter_pg_stat_walreceiver_flushed_lsn
+
+Last WAL byte+1 position flushed to disk (numeric representation).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server (the replica). |
+| slot_name | Replication slot name. |
+| status | WAL receiver activity status. |
+| sender_host | Upstream sender host. |
+
+## pgexporter_pg_stat_walreceiver_received_tli
+
+Timeline number of last WAL byte+1 position received.
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server (the replica). |
+| slot_name | Replication slot name. |
+| status | WAL receiver activity status. |
+| sender_host | Upstream sender host. |
+
+## pgexporter_pg_stat_walreceiver_last_msg_send_time
+
+Epoch timestamp of last message sent by the WAL sender.
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server (the replica). |
+| slot_name | Replication slot name. |
+| status | WAL receiver activity status. |
+| sender_host | Upstream sender host. |
+
+## pgexporter_pg_stat_walreceiver_last_msg_receipt_time
+
+Epoch timestamp of last message received from the WAL sender.
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server (the replica). |
+| slot_name | Replication slot name. |
+| status | WAL receiver activity status. |
+| sender_host | Upstream sender host. |
+
+## pgexporter_pg_stat_walreceiver_latest_end_lsn
+
+Last WAL byte+1 position reported to the WAL sender (numeric representation).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server (the replica). |
+| slot_name | Replication slot name. |
+| status | WAL receiver activity status. |
+| sender_host | Upstream sender host. |
+
+## pgexporter_pg_stat_walreceiver_latest_end_time
+
+Epoch timestamp of last report sent to the WAL sender.
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server (the replica). |
+| slot_name | Replication slot name. |
+| status | WAL receiver activity status. |
+| sender_host | Upstream sender host. |
+
+## pgexporter_pg_stat_walreceiver_sender_port
+
+Port number of the upstream WAL sender.
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server (the replica). |
+| slot_name | Replication slot name. |
+| status | WAL receiver activity status. |
+| sender_host | Upstream sender host. |
+
 ## pgexporter_pg_stat_archiver_archived_count
 
 Reflects `archived_count` from `pg_stat_archiver`: the total number of WAL files successfully archived since server start.

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -728,6 +728,68 @@ extern "C" {
                       "    collector: wal_last_received\n"                                                                                                                              \
                       "    server: replica\n"                                                                                                                                           \
                       "\n"                                                                                                                                                              \
+                      "# WAL receiver statistics\n"                                                                                                                                     \
+                      "  - queries:\n"                                                                                                                                                  \
+                      "    - query: SELECT\n"                                                                                                                                           \
+                      "              COALESCE(slot_name, '') AS slot_name,\n"                                                                                                           \
+                      "              COALESCE(status, '') AS status,\n"                                                                                                                 \
+                      "              (receive_start_lsn - '0/0') % (2^52)::bigint AS receive_start_lsn,\n"                                                                              \
+                      "              receive_start_tli,\n"                                                                                                                              \
+                      "              (written_lsn - '0/0') % (2^52)::bigint AS written_lsn,\n"                                                                                          \
+                      "              (flushed_lsn - '0/0') % (2^52)::bigint AS flushed_lsn,\n"                                                                                          \
+                      "              received_tli,\n"                                                                                                                                   \
+                      "              extract(epoch from last_msg_send_time) AS last_msg_send_time,\n"                                                                                   \
+                      "              extract(epoch from last_msg_receipt_time) AS last_msg_receipt_time,\n"                                                                             \
+                      "              (latest_end_lsn - '0/0') % (2^52)::bigint AS latest_end_lsn,\n"                                                                                    \
+                      "              extract(epoch from latest_end_time) AS latest_end_time,\n"                                                                                         \
+                      "              COALESCE(sender_host, '') AS sender_host,\n"                                                                                                       \
+                      "              COALESCE(sender_port, 0) AS sender_port\n"                                                                                                         \
+                      "              FROM pg_stat_wal_receiver;\n"                                                                                                                      \
+                      "      version: 13\n"                                                                                                                                             \
+                      "      columns:\n"                                                                                                                                                \
+                      "        - name: slot_name\n"                                                                                                                                     \
+                      "          type: label\n"                                                                                                                                         \
+                      "          description: Replication slot name.\n"                                                                                                                 \
+                      "        - name: status\n"                                                                                                                                        \
+                      "          type: label\n"                                                                                                                                         \
+                      "          description: WAL receiver activity status.\n"                                                                                                          \
+                      "        - name: receive_start_lsn\n"                                                                                                                             \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: First WAL position received.\n"                                                                                                           \
+                      "        - name: receive_start_tli\n"                                                                                                                             \
+                      "          type: gauge\n"                                                                                                                                         \
+                      "          description: Timeline of first WAL position received.\n"                                                                                               \
+                      "        - name: written_lsn\n"                                                                                                                                   \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Last WAL position written to disk.\n"                                                                                                     \
+                      "        - name: flushed_lsn\n"                                                                                                                                   \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Last WAL position flushed to disk.\n"                                                                                                     \
+                      "        - name: received_tli\n"                                                                                                                                  \
+                      "          type: gauge\n"                                                                                                                                         \
+                      "          description: Timeline of last WAL position received.\n"                                                                                                \
+                      "        - name: last_msg_send_time\n"                                                                                                                            \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Epoch timestamp of last message sent by sender.\n"                                                                                        \
+                      "        - name: last_msg_receipt_time\n"                                                                                                                         \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Epoch timestamp of last message received.\n"                                                                                              \
+                      "        - name: latest_end_lsn\n"                                                                                                                                \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Latest WAL end position reported to sender.\n"                                                                                            \
+                      "        - name: latest_end_time\n"                                                                                                                               \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Epoch timestamp of latest end position report.\n"                                                                                         \
+                      "        - name: sender_host\n"                                                                                                                                   \
+                      "          type: label\n"                                                                                                                                         \
+                      "          description: Upstream sender host.\n"                                                                                                                  \
+                      "        - name: sender_port\n"                                                                                                                                   \
+                      "          type: gauge\n"                                                                                                                                         \
+                      "          description: Upstream sender port.\n"                                                                                                                  \
+                      "    tag: pg_stat_walreceiver\n"                                                                                                                                  \
+                      "    collector: stat_walreceiver\n"                                                                                                                               \
+                      "    server: replica\n"                                                                                                                                           \
+                      "\n"                                                                                                                                                              \
                       "#\n"                                                                                                                                                             \
                       "# PostgreSQL 12\n"                                                                                                                                               \
                       "#\n"                                                                                                                                                             \


### PR DESCRIPTION
fixes: #408 

I have added new Panels to Grafana Dashboards:
1. `WAL Receiver LSN Positions` - Detects replication backlog and replicas falling behind.
2. `WAL Receiver Lag` - Identifies replication delays and performance issues.
3. `WAL Receiver Status` - Confirms replication is connected and streaming correctly.

## Screen shots

Existing Wal Panels
<img width="1391" height="576" alt="image" src="https://github.com/user-attachments/assets/4ed7ff79-c381-466d-ac4a-c7f5225a85a8" />


PG13
<img width="1337" height="503" alt="Screenshot from 2026-02-15 21-02-30" src="https://github.com/user-attachments/assets/5286de8b-135b-4664-bbee-59d2012af3d2" />

PG14-18
<img width="1380" height="719" alt="image" src="https://github.com/user-attachments/assets/0b363ae2-ba9b-40c0-99bc-32423ab5eba5" />

The free space shown here comes from the **WAL Archiving** metrics, which were added starting from PG 14+.
