### PR TITLE
[#416] Fixed Prometheus label parsing

### DIFF
--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -204,7 +204,7 @@
       "collector": "installed_extensions",
       "queries": [
         {
-          "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
+          "query": "SELECT extname AS extensions, 1 AS installed FROM pg_extension;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -204,7 +204,7 @@
       "collector": "installed_extensions",
       "queries": [
         {
-          "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
+          "query": "SELECT extname AS extensions, 1 AS installed FROM pg_extension;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -204,7 +204,7 @@
       "collector": "installed_extensions",
       "queries": [
         {
-          "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
+          "query": "SELECT extname AS extensions, 1 AS installed FROM pg_extension;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -204,7 +204,7 @@
       "collector": "installed_extensions",
       "queries": [
         {
-          "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
+          "query": "SELECT extname AS extensions, 1 AS installed FROM pg_extension;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -169,7 +169,7 @@
       "collector": "installed_extensions",
       "queries": [
         {
-          "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
+          "query": "SELECT extname AS extensions, 1 AS installed FROM pg_extension;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-18.json
+++ b/contrib/json/postgresql-18.json
@@ -204,7 +204,7 @@
       "collector": "installed_extensions",
       "queries": [
         {
-          "query": "SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;",
+          "query": "SELECT extname AS extensions, 1 AS installed FROM pg_extension;",
           "version": 10,
           "columns": [
             {

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -111,7 +111,7 @@ metrics:
 - tag: pg_installed_extensions
   collector: installed_extensions
   queries:
-  - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
+  - query: SELECT extname AS extensions, 1 AS installed FROM pg_extension;
     version: 10
     columns:
     - name: extensions

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -111,7 +111,7 @@ metrics:
 - tag: pg_installed_extensions
   collector: installed_extensions
   queries:
-  - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
+  - query: SELECT extname AS extensions, 1 AS installed FROM pg_extension;
     version: 10
     columns:
     - name: extensions

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -111,7 +111,7 @@ metrics:
 - tag: pg_installed_extensions
   collector: installed_extensions
   queries:
-  - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
+  - query: SELECT extname AS extensions, 1 AS installed FROM pg_extension;
     version: 10
     columns:
     - name: extensions

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -111,7 +111,7 @@ metrics:
 - tag: pg_installed_extensions
   collector: installed_extensions
   queries:
-  - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
+  - query: SELECT extname AS extensions, 1 AS installed FROM pg_extension;
     version: 10
     columns:
     - name: extensions

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -90,7 +90,7 @@ metrics:
 - tag: pg_installed_extensions
   collector: installed_extensions
   queries:
-  - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
+  - query: SELECT extname AS extensions, 1 AS installed FROM pg_extension;
     version: 10
     columns:
     - name: extensions

--- a/contrib/yaml/postgresql-18.yaml
+++ b/contrib/yaml/postgresql-18.yaml
@@ -111,7 +111,7 @@ metrics:
 - tag: pg_installed_extensions
   collector: installed_extensions
   queries:
-  - query: SELECT array_agg(extname) AS extensions, count(*) FROM pg_extension;
+  - query: SELECT extname AS extensions, 1 AS installed FROM pg_extension;
     version: 10
     columns:
     - name: extensions

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -321,8 +321,8 @@ extern "C" {
                       "# Get number of installed extensions.\n"                                                                                                                         \
                       "  - queries:\n"                                                                                                                                                  \
                       "    - query: SELECT\n"                                                                                                                                           \
-                      "                array_agg(extname) AS extensions,\n"                                                                                                             \
-                      "                count(*)\n"                                                                                                                                      \
+                      "                extname AS extensions,\n"                                                                                                                        \
+                      "                1 AS installed\n"                                                                                                                                \
                       "              FROM pg_extension;\n"                                                                                                                              \
                       "      version: 10\n"                                                                                                                                             \
                       "      columns:\n"                                                                                                                                                \


### PR DESCRIPTION
### Changes
- Replaced delimiter based tokenisation with quote aware parsing
- Enabled support for special characters in values (like `{}`)
- Added escape sequence and whitespaces handling