### PR TITLE
[#415] Replace libcheck with MCTF testing framework

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,4 @@ Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
 Amr Shams (NightBird) <amr.shams2015.a@gmail.com>
 Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
+Shashidhar B M <shashidhar.i.0119@gmail.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,17 +106,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_DARWIN_C_SOURCE -I${HOMEBREW_PREFIX}/include")
 endif()
 
-find_package(Check)
-if (CHECK_FOUND)
-  message(STATUS "check found")
-  add_library(Check::check SHARED IMPORTED)
-  set_target_properties(Check::check PROPERTIES
-    IMPORTED_LOCATION ${CHECK_LIBRARY}
-    INTERFACE_INCLUDE_DIRECTORIES ${CHECK_INCLUDE_DIR})
-else ()
-  set(check FALSE)
-  message(STATUS "check needed. The test suite process will be skipped.")
-endif()
 
 find_package(ZLIB)
 if (ZLIB_FOUND)

--- a/doc/TEST.md
+++ b/doc/TEST.md
@@ -22,30 +22,69 @@ All the configuration, logs, coverage reports and data will be in `/tmp/pgexport
 the script exits normally or not. pgexporter will be force shutdown if it doesn't terminate normally.
 So don't worry about your local setup being tampered. The container will be stopped and removed when the script exits or is terminated.
 
-To run one particular test case or suite (unfortunately check doesn't support running one single test at the moment),
-run `CK_RUN_CASE=<test_case_name> <PATH_TO_PGEXPORTER>/pgexporter/test/check.sh` or
-`CK_RUN_SUITE=<test_suite_name> <PATH_TO_PGEXPORTER>/pgexporter/test/check.sh`. Alternatively, you can first export the environment variables
-and then run the script:
-```
-export CK_RUN_CASE=<test_case_name>
-<PATH_TO_PGEXPORTER>/pgexporter/test/check.sh
-```
+**Running Specific Test Cases or Modules**
 
-The environment variables will be automatically unset when the test is finished or aborted.
+To run one particular test case or module, use `<PATH_TO_PGEXPORTER>/test/check.sh -t <test_case_name>` or `<PATH_TO_PGEXPORTER>/test/check.sh -m <module_name>`. Alternatively, if the test environment is already set up by a previous run of `check.sh`, you can run the test binary directly: `<PATH_TO_PGEXPORTER>/build/test/pgexporter-test -t <test_case_name>` or `<PATH_TO_PGEXPORTER>/build/test/pgexporter-test -m <module_name>` (with the same environment variables set).
 
 It is recommended that you **ALWAYS** run tests before raising PR.
 
+**MCTF Framework Overview**
+
+MCTF (Minimal C Test Framework) is pgexporter's custom test framework designed for simplicity and ease of use.
+
+**What MCTF Can Do:**
+
+- **Automatic test registration** – Tests are automatically registered via the `MCTF_TEST` macro
+- **Module organization** – Module names are automatically extracted from file names (e.g. `test_cli.c` → module `cli`)
+- **Flexible assertions** – Assert macros with optional printf-style error messages
+- **Test filtering** – Run tests by name pattern (`-t`) or by module (`-m`)
+- **Test skipping** – Skip tests conditionally using `MCTF_SKIP()` when prerequisites aren't met
+- **Cleanup pattern** – Structured cleanup using goto labels for resource management
+- **Error tracking** – Automatic error tracking with line numbers and custom error messages
+- **Multiple assertion types** – Various assertion macros (`MCTF_ASSERT`, `MCTF_ASSERT_PTR_NONNULL`, `MCTF_ASSERT_INT_EQ`, `MCTF_ASSERT_STR_EQ`, etc.)
+
+**What MCTF Cannot Do (Limitations):**
+
+- **No test fixtures** – No automatic setup/teardown per test suite (you must handle setup and cleanup manually in each test)
+- **No parameterized tests** – Tests cannot be parameterized (each variation needs a separate test function)
+- **No parallel or async execution** – Tests run sequentially and synchronously
+- **No built-in timeouts** – No framework-level test timeouts (rely on OS-level signals or manual timeouts)
+- **No test organization beyond modules** – No test suites, groups, tags, or metadata beyond module names extracted from filenames
+
 **Add Testcases**
 
-To add an additional testcase, go to [testcases](https://github.com/pgexporter/pgexporter/tree/main/test/testcases) directory inside the `pgexporter` project.
+To add an additional testcase, go to the [testcases](https://github.com/pgexporter/pgexporter/tree/main/test/testcases) directory inside the pgexporter project. Create a `.c` file that contains the test and use the `MCTF_TEST()` macro to define your test. Tests are automatically registered and module names are extracted from file names.
 
-Create a `.c` file that contains the test suite and define the suite inside `/test/include/tssuite.h`. Add the above created suite to the test runner in [runner.c](https://github.com/pgexporter/pgexporter/tree/main/test/runner.c)
+**Example test structure:**
+
+```c
+#include <mctf.h>
+#include <tsclient.h>
+
+MCTF_TEST(test_my_feature)
+{
+   int result = some_function();
+   MCTF_ASSERT(result == 0, cleanup, "function should return 0");
+
+cleanup:
+   MCTF_FINISH();
+}
+```
+
+**MCTF_ASSERT usage:** The `MCTF_ASSERT` macro supports optional error messages with printf-style formatting.
+
+- **Without message:** `MCTF_ASSERT(condition, cleanup);` – No error message displayed
+- **With simple message:** `MCTF_ASSERT(condition, cleanup, "error message");`
+- **With formatted message:** `MCTF_ASSERT(condition, cleanup, "got %d, expected 0", value);`
+
+Format arguments (e.g. `value`) are optional and only needed when the message contains format specifiers (`%d`, `%s`, etc.). Multiple format arguments: `MCTF_ASSERT(a == b, cleanup, "expected %d but got %d", expected, actual);`
 
 **Test Directory**
 
 After running the tests, you will find:
 
 * **pgexporter log:** `/tmp/pgexporter-test/log/`
+* **HTML test report:** `/tmp/pgexporter-test/log/pgexporter-test-report.html` (generated after each run)
 * **postgres log:** `/tmp/pgexporter-test/pg_log/`, the log level is set to debug5.
 * **code coverage reports:** `/tmp/pgexporter-test/coverage/`
 
@@ -66,8 +105,6 @@ may also run `PGEXPORTER_TEST_PORT=<your-port> ./check.sh`.
 
 **Configuration**
 
-| Name                | Default | Value           | Description                                          |
-|---------------------|---------|-----------------|------------------------------------------------------|
-| CK_RUN_CASE         |         | test case name  | Run one single test case                             |
-| CK_RUN_SUITE        |         | test suite name | Run one single test suite                            |
-| PGEXPORTER_TEST_PORT| 6432    | port number     | The port name pgexporter use to connect to the db    |
+| Name                 | Default | Value           | Description                                          |
+|----------------------|---------|-----------------|------------------------------------------------------|
+| PGEXPORTER_TEST_PORT | 6432    | port number     | The port pgexporter uses to connect to the database |

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -33,6 +33,7 @@ Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
 Amr Shams (NightBird) <amr.shams2015.a@gmail.com>
 Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
+Shashidhar B M <shashidhar.i.0119@gmail.com>
 ```
 
 ## Committers

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,16 +26,20 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-if (check)
+FILE(GLOB_RECURSE LIB_SOURCE_FILES "libpgexportertest/*.c")
+FILE(GLOB_RECURSE HEADER_FILES "include/*.h")
+# Order matches main runner: cli, database, configuration, http (http last so shutdown runs last)
+set(TESTCASE_FILES
+  testcases/test_http.c
+  testcases/test_configuration.c
+  testcases/test_database.c
+  testcases/test_cli.c
+)
+set(SOURCE_FILES ${LIB_SOURCE_FILES} ${TESTCASE_FILES} ${HEADER_FILES})
 
-  FILE(GLOB_RECURSE SOURCE_FILES "libpgexportertest/*.c" "testcases/*.c")
-  FILE(GLOB_RECURSE HEADER_FILES "include/*.h")
-
-  set(SOURCES ${SOURCE_FILES} ${HEADER_FILES})
-  set(ENABLE_COVERAGE OFF)
-
-  add_compile_options(-O0)
-  add_compile_options(-DDEBUG)
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_options(-O0)
+    add_compile_options(-DDEBUG)
 
   if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
@@ -112,7 +116,8 @@ if (check)
       endif()
     endif()
   endif()
-  add_executable(pgexporter-test runner.c ${SOURCES})
+  endif() # CMAKE_BUILD_TYPE STREQUAL "Debug"
+  add_executable(pgexporter-test runner.c ${SOURCE_FILES})
   if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
   target_compile_options(pgexporter-test PRIVATE
     -fprofile-instr-generate
@@ -128,18 +133,17 @@ endif()
   target_include_directories(pgexporter-test PRIVATE ${CMAKE_SOURCE_DIR}/src/include ${CMAKE_SOURCE_DIR}/test/include)
 
   if(EXISTS "/etc/debian_version")
-    target_link_libraries(pgexporter-test Check::check subunit pthread rt m pgexporter)
+    target_link_libraries(pgexporter-test pthread rt m pgexporter)
   elseif(APPLE)
-    target_link_libraries(pgexporter-test Check::check m pgexporter)
+    target_link_libraries(pgexporter-test m pgexporter)
   else()
-    target_link_libraries(pgexporter-test Check::check pthread rt m pgexporter)
+    target_link_libraries(pgexporter-test pthread rt m pgexporter)
   endif()
 
   add_custom_target(custom_clean
     COMMAND ${CMAKE_COMMAND} -E remove -f *.o pgexporter-test
     COMMENT "Cleaning up..."
   )
-endif()
 
 configure_file(
   "${CMAKE_SOURCE_DIR}/test/check.sh"

--- a/test/include/html_report.h
+++ b/test/include/html_report.h
@@ -27,37 +27,39 @@
  *
  */
 
-#ifndef PGEXPORTER_TEST_SUITE_H
-#define PGEXPORTER_TEST_SUITE_H
+#ifndef PGEXPORTER_HTML_REPORT_H
+#define PGEXPORTER_HTML_REPORT_H
 
-#include <check.h>
-
-/**
- * Set up CLI test suite for pgexporter
- * @return The suite
- */
-Suite*
-pgexporter_test_cli_suite();
-
-/**
- * Set up database test suite for pgexporter
- * @return The suite
- */
-Suite*
-pgexporter_test_database_suite();
-
-/**
- * Set up HTTP test suite for pgexporter
- * @return The suite
- */
-Suite*
-pgexporter_test_http_suite();
-
-/**
- * Set up configuration test suite for pgexporter
- * @return The suite
- */
-Suite*
-pgexporter_test_configuration_suite();
-
+#ifdef __cplusplus
+extern "C" {
 #endif
+
+#include "mctf.h"
+#include <stddef.h>
+
+/**
+ * Build the path for the HTML report file.
+ * Uses TEST_BASE_DIR (set by test environment) or PGEXPORTER_TEST_BASE_DIR.
+ * @param path Output buffer for the path
+ * @param size Size of the buffer
+ * @return 0 on success, 1 on failure
+ */
+int
+html_report_build_path(char* path, size_t size);
+
+/**
+ * Generate an HTML report from MCTF results.
+ * Must be called after mctf_run_tests() and before mctf_cleanup().
+ * @param path File path for the HTML report
+ * @param filter_type Filter that was used when running tests
+ * @param filter Filter string that was used
+ * @return 0 on success, 1 on failure
+ */
+int
+html_report_generate(const char* path, mctf_filter_type_t filter_type, const char* filter);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PGEXPORTER_HTML_REPORT_H */

--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PGEXPORTER_MCTF_H
+#define PGEXPORTER_MCTF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Special return codes */
+#define MCTF_CODE_SKIPPED (-1)
+
+/* Global error number for MCTF */
+extern int mctf_errno;
+
+/* Global error message for MCTF */
+extern char* mctf_errmsg;
+
+/* Test function type */
+typedef int (*mctf_test_func_t)(void);
+
+/**
+ * Test registration structure
+ */
+typedef struct mctf_test
+{
+   const char* name;       /**< Test name */
+   const char* module;     /**< Module name */
+   const char* file;       /**< Source file name */
+   mctf_test_func_t func;  /**< Test function pointer */
+   struct mctf_test* next; /**< Next test in linked list */
+} mctf_test_t;
+
+/**
+ * Test result structure
+ */
+typedef struct mctf_result
+{
+   const char* test_name;     /**< Name of the executed test */
+   const char* file;          /**< Source file name */
+   bool passed;               /**< True if test passed */
+   bool skipped;              /**< True if test was skipped */
+   int error_code;            /**< Error code or line number */
+   const char* error_message; /**< Error message, if any */
+   long elapsed_ms;           /**< Test execution time in milliseconds */
+} mctf_result_t;
+
+/**
+ * Test runner state
+ */
+typedef struct mctf_runner
+{
+   mctf_test_t* tests;     /**< Linked list of registered tests */
+   mctf_result_t* results; /**< Array of test results */
+   size_t test_count;      /**< Total number of tests */
+   size_t result_count;    /**< Total number of results */
+   size_t passed_count;    /**< Number of passed tests */
+   size_t failed_count;    /**< Number of failed tests */
+   size_t skipped_count;   /**< Number of skipped tests */
+} mctf_runner_t;
+
+/**
+ * Initialize the MCTF framework
+ */
+void
+mctf_init(void);
+
+/**
+ * Cleanup the MCTF framework
+ */
+void
+mctf_cleanup(void);
+
+/**
+ * Register a test function
+ * @param name The test name
+ * @param module The module name
+ * @param file The source file name
+ * @param func The test function
+ */
+void
+mctf_register_test(const char* name, const char* module, const char* file, mctf_test_func_t func);
+
+/**
+ * Extract module name from file path (internal use)
+ */
+const char*
+mctf_extract_module_name(const char* file_path);
+
+/**
+ * Extract filename from file path (internal use)
+ */
+const char*
+mctf_extract_filename(const char* file_path);
+
+/**
+ * Filter type for test execution
+ */
+typedef enum {
+   MCTF_FILTER_NONE,  /* Run all tests */
+   MCTF_FILTER_TEST,  /* Filter by test name */
+   MCTF_FILTER_MODULE /* Filter by module name */
+} mctf_filter_type_t;
+
+/**
+ * Run all registered tests
+ * @param filter_type Type of filter to apply
+ * @param filter Filter string
+ * @return Number of failed tests
+ */
+int
+mctf_run_tests(mctf_filter_type_t filter_type, const char* filter);
+
+/**
+ * Print test results summary
+ */
+void
+mctf_print_summary(void);
+
+/**
+ * Log all available environment variables
+ *
+ * This is typically called by the test runner before the test suite starts,
+ * so that the execution context is captured in the test output and log.
+ */
+void
+mctf_log_environment(void);
+
+/**
+ * Open a log file for MCTF output
+ * All subsequent test runner output will be duplicated to this file.
+ *
+ * @param path Filesystem path of the log file
+ * @return 0 on success, non-zero on failure
+ */
+int
+mctf_open_log(const char* path);
+
+/**
+ * Close the MCTF log file if it is open
+ */
+void
+mctf_close_log(void);
+
+/**
+ * Get test results
+ * @param count [out] Number of results
+ * @return Array of test results
+ */
+const mctf_result_t*
+mctf_get_results(size_t* count);
+
+/* Macros for test functions */
+
+/**
+ * Assert a condition, jump to error label on failure
+ * @param condition The condition to check
+ * @param error_label Label to jump to on failure
+ * @param ... Optional error message (format string) and printf-style format arguments
+ *
+ * Usage examples:
+ *   MCTF_ASSERT(result == 0, cleanup);  // No error message
+ *   MCTF_ASSERT(result == 0, cleanup, "function should return 0");  // Simple message
+ *   MCTF_ASSERT(result == 0, cleanup, "function returned %d, expected 0", result);  // With format argument
+ *   MCTF_ASSERT(a == b, cleanup, "expected %d but got %d", expected, actual);  // Multiple format arguments
+ *
+ * Note: Format arguments (like 'value' in the examples) are optional and only needed when
+ * the message string contains format specifiers (%d, %s, etc.)
+ */
+#define MCTF_ASSERT(condition, error_label, ...)                     \
+   do                                                                \
+   {                                                                 \
+      if (!(condition))                                              \
+      {                                                              \
+         mctf_errno = __LINE__;                                      \
+         if (mctf_errmsg)                                            \
+            free(mctf_errmsg);                                       \
+         mctf_errmsg = NULL;                                         \
+         __VA_OPT__(                                                 \
+            {                                                        \
+               size_t mctf_len = snprintf(NULL, 0, __VA_ARGS__) + 1; \
+               mctf_errmsg = malloc(mctf_len);                       \
+               if (mctf_errmsg)                                      \
+                  snprintf(mctf_errmsg, mctf_len, __VA_ARGS__);      \
+            })                                                       \
+         goto error_label;                                           \
+      }                                                              \
+      mctf_errno = 0;                                                \
+      if (mctf_errmsg)                                               \
+      {                                                              \
+         free(mctf_errmsg);                                          \
+         mctf_errmsg = NULL;                                         \
+      }                                                              \
+   }                                                                 \
+   while (0)
+
+/**
+ * Assert pointer is not null
+ */
+#define MCTF_ASSERT_PTR_NONNULL(ptr, error_label, ...) \
+   MCTF_ASSERT((ptr) != NULL, error_label __VA_OPT__(, ) __VA_ARGS__)
+
+/**
+ * Assert pointer is null
+ */
+#define MCTF_ASSERT_PTR_NULL(ptr, error_label, ...) \
+   MCTF_ASSERT((ptr) == NULL, error_label __VA_OPT__(, ) __VA_ARGS__)
+
+/**
+ * Assert two integers are equal
+ */
+#define MCTF_ASSERT_INT_EQ(actual, expected, error_label, ...) \
+   MCTF_ASSERT((actual) == (expected), error_label __VA_OPT__(, ) __VA_ARGS__)
+
+/**
+ * Assert two strings are equal
+ */
+#define MCTF_ASSERT_STR_EQ(actual, expected, error_label, ...) \
+   MCTF_ASSERT(strcmp((actual), (expected)) == 0, error_label __VA_OPT__(, ) __VA_ARGS__)
+
+/**
+ * Internal macro for skip with format
+ */
+#define MCTF_SKIP_FMT(...)                                        \
+   do                                                             \
+   {                                                              \
+      mctf_errno = __LINE__;                                      \
+      if (mctf_errmsg)                                            \
+         free(mctf_errmsg);                                       \
+      mctf_errmsg = NULL;                                         \
+      __VA_OPT__(                                                 \
+         {                                                        \
+            size_t mctf_len = snprintf(NULL, 0, __VA_ARGS__) + 1; \
+            mctf_errmsg = malloc(mctf_len);                       \
+            if (mctf_errmsg)                                      \
+               snprintf(mctf_errmsg, mctf_len, __VA_ARGS__);      \
+         })                                                       \
+      return MCTF_CODE_SKIPPED;                                   \
+   }                                                              \
+   while (0)
+
+/**
+ * Helper macros for argument selection - do not use directly
+ */
+#define MCTF_SKIP(...) MCTF_SKIP_FMT(__VA_ARGS__)
+
+/**
+ * Finish a test function - returns mctf_errno
+ */
+#define MCTF_FINISH() \
+   return mctf_errno
+
+/**
+ * Register a test function with auto-naming and auto-module detection
+ * Usage: MCTF_TEST(test_function_name) { ... }
+ * The module name is automatically extracted from the source file name.
+ */
+#define MCTF_TEST(name)                                                               \
+   static int name(void);                                                             \
+   static void __attribute__((constructor)) mctf_register_##name(void)                \
+   {                                                                                  \
+      const char* file_path = __FILE__;                                               \
+      const char* filename = mctf_extract_filename(file_path);                        \
+      mctf_register_test(#name, mctf_extract_module_name(file_path), filename, name); \
+   }                                                                                  \
+   static int name(void)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/test/include/tscommon.h
+++ b/test/include/tscommon.h
@@ -66,21 +66,24 @@ void
 pgexporter_test_teardown(void);
 
 /**
- * Assert that conf set succeeds and the response matches the expected value
+ * Conf set succeeds and the response matches the expected value.
+ * @return 0 on success, -1 on failure
  */
-void
+int
 pgexporter_test_assert_conf_set_ok(char* key, char* value, int64_t expected);
 
 /**
- * Assert that conf set fails for the given key/value
+ * Conf set fails for the given key/value.
+ * @return 0 on success, -1 on failure
  */
-void
+int
 pgexporter_test_assert_conf_set_fail(char* key, char* value);
 
 /**
- * Assert that conf get returns the expected value for the given key
+ * Conf get returns the expected value for the given key.
+ * @return 0 on success, -1 on failure
  */
-void
+int
 pgexporter_test_assert_conf_get_ok(char* key, int64_t expected);
 
 #ifdef __cplusplus

--- a/test/libpgexportertest/html_report.c
+++ b/test/libpgexportertest/html_report.c
@@ -1,0 +1,307 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <mctf.h>
+#include <html_report.h>
+#include <tscommon.h>
+#include <pgexporter.h>
+#include <utils.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int
+html_report_build_path(char* path, size_t size)
+{
+   char base[MAX_PATH];
+   char* slash = NULL;
+   int n;
+
+   if (path == NULL || size == 0)
+   {
+      return 1;
+   }
+
+   memset(base, 0, sizeof(base));
+
+   if (TEST_BASE_DIR[0] != '\0')
+   {
+      memcpy(base, TEST_BASE_DIR, sizeof(base) - 1);
+      base[sizeof(base) - 1] = '\0';
+   }
+   else
+   {
+      char* env_base_dir = getenv("PGEXPORTER_TEST_BASE_DIR");
+      if (env_base_dir == NULL || env_base_dir[0] == '\0')
+      {
+         return 1;
+      }
+      memcpy(base, env_base_dir, sizeof(base) - 1);
+      base[sizeof(base) - 1] = '\0';
+   }
+
+   slash = strrchr(base, '/');
+   if (slash == NULL)
+   {
+      return 1;
+   }
+
+   *slash = '\0';
+
+   n = snprintf(path, size, "%s/log/pgexporter-test-report.html", base);
+   if (n <= 0 || (size_t)n >= size)
+   {
+      return 1;
+   }
+
+   return 0;
+}
+
+int
+html_report_generate(const char* path, mctf_filter_type_t filter_type, const char* filter)
+{
+   if (path == NULL || path[0] == '\0')
+   {
+      return 1;
+   }
+
+   size_t count = 0;
+   const mctf_result_t* results = mctf_get_results(&count);
+
+   if (results == NULL || count == 0)
+   {
+      return 1;
+   }
+
+   char* dir_path = strdup(path);
+   if (dir_path != NULL)
+   {
+      char* last_slash = strrchr(dir_path, '/');
+      if (last_slash != NULL)
+      {
+         *last_slash = '\0';
+         pgexporter_mkdir(dir_path);
+      }
+      free(dir_path);
+   }
+
+   FILE* f = fopen(path, "w");
+   if (f == NULL)
+   {
+      fprintf(stderr, "Warning: Failed to open HTML report file at '%s'\n", path);
+      return 1;
+   }
+
+   size_t passed = 0;
+   size_t failed = 0;
+   size_t skipped = 0;
+
+   for (size_t i = 0; i < count; i++)
+   {
+      if (results[i].skipped)
+      {
+         skipped++;
+      }
+      else if (results[i].passed)
+      {
+         passed++;
+      }
+      else
+      {
+         failed++;
+      }
+   }
+
+   fprintf(f, "<!DOCTYPE html>\n");
+   fprintf(f, "<html lang=\"en\">\n");
+   fprintf(f, "<head>\n");
+   fprintf(f, "  <meta charset=\"UTF-8\" />\n");
+   fprintf(f, "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />\n");
+   fprintf(f, "  <title>pgexporter Test Report</title>\n");
+   fprintf(f, "  <style>\n");
+   fprintf(f, "    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background-color: #0b1020; color: #f5f5f7; margin: 0; padding: 24px; }\n");
+   fprintf(f, "    h1 { margin-top: 0; font-size: 24px; }\n");
+   fprintf(f, "    .summary { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 24px; }\n");
+   fprintf(f, "    .card { border-radius: 8px; padding: 12px 16px; background: linear-gradient(135deg, #151a30, #13162a); box-shadow: 0 10px 30px rgba(0,0,0,0.35); min-width: 140px; }\n");
+   fprintf(f, "    .card-label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; color: #a0a4c0; margin-bottom: 4px; }\n");
+   fprintf(f, "    .card-value { font-size: 18px; font-weight: 600; }\n");
+   fprintf(f, "    .card-value.pass { color: #4ade80; }\n");
+   fprintf(f, "    .card-value.fail { color: #fb7185; }\n");
+   fprintf(f, "    .card-value.skip { color: #fbbf24; }\n");
+   fprintf(f, "    .filter { margin-bottom: 24px; font-size: 14px; color: #a0a4c0; }\n");
+   fprintf(f, "    table { border-collapse: collapse; width: 100%%; background-color: #0f172a; border-radius: 10px; overflow: hidden; box-shadow: 0 8px 24px rgba(0,0,0,0.35); }\n");
+   fprintf(f, "    thead { background: linear-gradient(90deg, #1d2640, #111827); }\n");
+   fprintf(f, "    th, td { padding: 10px 12px; font-size: 13px; text-align: left; }\n");
+   fprintf(f, "    th { font-weight: 600; color: #e5e7eb; border-bottom: 1px solid rgba(148, 163, 184, 0.5); }\n");
+   fprintf(f, "    tbody tr { background-color: #020617; }\n");
+   fprintf(f, "    tbody tr:hover { background-color: #111827; }\n");
+   fprintf(f, "    .status-pill { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; }\n");
+   fprintf(f, "    .status-pass { background-color: rgba(22, 163, 74, 0.15); color: #4ade80; border: 1px solid rgba(34, 197, 94, 0.4); }\n");
+   fprintf(f, "    .status-fail { background-color: rgba(220, 38, 38, 0.18); color: #fb7185; border: 1px solid rgba(248, 113, 113, 0.5); }\n");
+   fprintf(f, "    .status-skip { background-color: rgba(245, 158, 11, 0.18); color: #fbbf24; border: 1px solid rgba(251, 191, 36, 0.5); }\n");
+   fprintf(f, "    .file { color: #9ca3af; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace; font-size: 12px; }\n");
+   fprintf(f, "    .time { color: #60a5fa; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace; font-size: 12px; font-weight: 500; }\n");
+   fprintf(f, "    .message { color: #e5e7eb; }\n");
+   fprintf(f, "    .no-message { color: #6b7280; font-style: italic; }\n");
+   fprintf(f, "    .footer { margin-top: 24px; font-size: 12px; color: #6b7280; }\n");
+   fprintf(f, "  </style>\n");
+   fprintf(f, "</head>\n");
+   fprintf(f, "<body>\n");
+   fprintf(f, "  <h1>pgexporter Test Report</h1>\n");
+
+   fprintf(f, "  <div class=\"filter\">\n");
+   fprintf(f, "    <strong>Executed tests:</strong> ");
+   switch (filter_type)
+   {
+      case MCTF_FILTER_MODULE:
+         fprintf(f, "Module filter = <code>%s</code>\n", filter ? filter : "");
+         break;
+      case MCTF_FILTER_TEST:
+         fprintf(f, "Test name filter = <code>%s</code>\n", filter ? filter : "");
+         break;
+      case MCTF_FILTER_NONE:
+      default:
+         fprintf(f, "Full suite (no filter)\n");
+         break;
+   }
+   fprintf(f, "  </div>\n");
+
+   fprintf(f, "  <div class=\"summary\">\n");
+   fprintf(f, "    <div class=\"card\">\n");
+   fprintf(f, "      <div class=\"card-label\">Total</div>\n");
+   fprintf(f, "      <div class=\"card-value\">%zu</div>\n", count);
+   fprintf(f, "    </div>\n");
+   fprintf(f, "    <div class=\"card\">\n");
+   fprintf(f, "      <div class=\"card-label\">Passed</div>\n");
+   fprintf(f, "      <div class=\"card-value pass\">%zu</div>\n", passed);
+   fprintf(f, "    </div>\n");
+   fprintf(f, "    <div class=\"card\">\n");
+   fprintf(f, "      <div class=\"card-label\">Failed</div>\n");
+   fprintf(f, "      <div class=\"card-value fail\">%zu</div>\n", failed);
+   fprintf(f, "    </div>\n");
+   fprintf(f, "    <div class=\"card\">\n");
+   fprintf(f, "      <div class=\"card-label\">Skipped</div>\n");
+   fprintf(f, "      <div class=\"card-value skip\">%zu</div>\n", skipped);
+   fprintf(f, "    </div>\n");
+   fprintf(f, "  </div>\n");
+
+   fprintf(f, "  <table>\n");
+   fprintf(f, "    <thead>\n");
+   fprintf(f, "      <tr>\n");
+   fprintf(f, "        <th style=\"width: 22%%;\">Test</th>\n");
+   fprintf(f, "        <th style=\"width: 12%%;\">Status</th>\n");
+   fprintf(f, "        <th style=\"width: 10%%;\">Time</th>\n");
+   fprintf(f, "        <th style=\"width: 26%%;\">File</th>\n");
+   fprintf(f, "        <th style=\"width: 10%%;\">Code</th>\n");
+   fprintf(f, "        <th>Message</th>\n");
+   fprintf(f, "      </tr>\n");
+   fprintf(f, "    </thead>\n");
+   fprintf(f, "    <tbody>\n");
+
+   for (size_t i = 0; i < count; i++)
+   {
+      const mctf_result_t* r = &results[i];
+      const char* status_class = "status-fail";
+      const char* status_label = "FAIL";
+
+      if (r->skipped)
+      {
+         status_class = "status-skip";
+         status_label = "SKIP";
+      }
+      else if (r->passed)
+      {
+         status_class = "status-pass";
+         status_label = "PASS";
+      }
+
+      long total_seconds = r->elapsed_ms / 1000;
+      long hours = total_seconds / 3600;
+      long minutes = (total_seconds % 3600) / 60;
+      long seconds = total_seconds % 60;
+      long milliseconds = r->elapsed_ms % 1000;
+      char time_str[32];
+      if (hours > 0)
+      {
+         snprintf(time_str, sizeof(time_str), "%02ld:%02ld:%02ld.%03ld", hours, minutes, seconds, milliseconds);
+      }
+      else if (minutes > 0)
+      {
+         snprintf(time_str, sizeof(time_str), "%02ld:%02ld.%03ld", minutes, seconds, milliseconds);
+      }
+      else if (seconds > 0)
+      {
+         snprintf(time_str, sizeof(time_str), "%ld.%03lds", seconds, milliseconds);
+      }
+      else
+      {
+         snprintf(time_str, sizeof(time_str), "%ldms", milliseconds);
+      }
+
+      fprintf(f, "      <tr>\n");
+      fprintf(f, "        <td>%s</td>\n", r->test_name ? r->test_name : "(unknown)");
+      fprintf(f, "        <td><span class=\"status-pill %s\">%s</span></td>\n", status_class, status_label);
+      fprintf(f, "        <td class=\"time\">%s</td>\n", time_str);
+      fprintf(f, "        <td class=\"file\">%s</td>\n", r->file ? r->file : "(unknown)");
+
+      if (r->error_code != 0)
+      {
+         fprintf(f, "        <td>%d</td>\n", r->error_code);
+      }
+      else
+      {
+         fprintf(f, "        <td>&ndash;</td>\n");
+      }
+
+      if (r->error_message && r->error_message[0] != '\0')
+      {
+         fprintf(f, "        <td class=\"message\">%s</td>\n", r->error_message);
+      }
+      else
+      {
+         fprintf(f, "        <td class=\"no-message\">No additional message</td>\n");
+      }
+
+      fprintf(f, "      </tr>\n");
+   }
+
+   fprintf(f, "    </tbody>\n");
+   fprintf(f, "  </table>\n");
+
+   fprintf(f, "  <div class=\"footer\">\n");
+   fprintf(f, "    Generated by pgexporter MCTF test runner.\n");
+   fprintf(f, "  </div>\n");
+
+   fprintf(f, "</body>\n");
+   fprintf(f, "</html>\n");
+
+   fclose(f);
+   return 0;
+}

--- a/test/libpgexportertest/mctf.c
+++ b/test/libpgexportertest/mctf.c
@@ -1,0 +1,521 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <mctf.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+extern char** environ;
+
+/* Global error number */
+int mctf_errno = 0;
+
+/* Global error message */
+char* mctf_errmsg = NULL;
+
+/* Global test runner */
+static mctf_runner_t g_runner = {0};
+static bool g_initialized = false;
+
+/* Optional log file for test runner output */
+static FILE* mctf_log_file = NULL;
+
+static void
+mctf_vlogf(FILE* out, const char* fmt, va_list ap)
+{
+   if (out != NULL)
+   {
+      vfprintf(out, fmt, ap);
+      fflush(out);
+   }
+}
+
+static void
+mctf_logf(const char* fmt, ...)
+{
+   va_list ap;
+
+   /* Always log to stdout */
+   va_start(ap, fmt);
+   mctf_vlogf(stdout, fmt, ap);
+   va_end(ap);
+
+   /* Mirror to log file if configured */
+   if (mctf_log_file != NULL)
+   {
+      va_start(ap, fmt);
+      mctf_vlogf(mctf_log_file, fmt, ap);
+      va_end(ap);
+   }
+}
+
+static void
+mctf_log_errorf(const char* fmt, ...)
+{
+   va_list ap;
+
+   /* Always log to stderr */
+   va_start(ap, fmt);
+   mctf_vlogf(stderr, fmt, ap);
+   va_end(ap);
+
+   /* Mirror to log file if configured */
+   if (mctf_log_file != NULL)
+   {
+      va_start(ap, fmt);
+      mctf_vlogf(mctf_log_file, fmt, ap);
+      va_end(ap);
+   }
+}
+
+void
+mctf_log_environment(void)
+{
+   char** env;
+
+   mctf_logf("=== Test Environment Variables ===\n");
+
+   if (environ == NULL)
+   {
+      mctf_logf("  (no environment variables available)\n\n");
+      return;
+   }
+
+   for (env = environ; *env != NULL; env++)
+   {
+      mctf_logf("  %s\n", *env);
+   }
+
+   mctf_logf("=== End Environment Variables ===\n\n");
+}
+
+int
+mctf_open_log(const char* path)
+{
+   FILE* f;
+
+   if (path == NULL || strlen(path) == 0)
+   {
+      return 1;
+   }
+
+   f = fopen(path, "a");
+   if (f == NULL)
+   {
+      return 1;
+   }
+
+   mctf_log_file = f;
+   return 0;
+}
+
+void
+mctf_close_log(void)
+{
+   if (mctf_log_file != NULL)
+   {
+      fclose(mctf_log_file);
+      mctf_log_file = NULL;
+   }
+}
+
+void
+mctf_init(void)
+{
+   g_initialized = true;
+}
+
+void
+mctf_cleanup(void)
+{
+   mctf_test_t* test = g_runner.tests;
+   while (test)
+   {
+      mctf_test_t* next = test->next;
+      free((void*)test->name);
+      free((void*)test->module);
+      free((void*)test->file);
+      free(test);
+      test = next;
+   }
+
+   if (g_runner.results)
+   {
+      for (size_t i = 0; i < g_runner.result_count; i++)
+      {
+         if (g_runner.results[i].error_message)
+         {
+            free((void*)g_runner.results[i].error_message);
+         }
+      }
+      free(g_runner.results);
+   }
+
+   if (mctf_errmsg)
+   {
+      free(mctf_errmsg);
+      mctf_errmsg = NULL;
+   }
+
+   g_initialized = false;
+   memset(&g_runner, 0, sizeof(g_runner));
+}
+
+void
+mctf_register_test(const char* name, const char* module, const char* file, mctf_test_func_t func)
+{
+   if (!g_initialized)
+   {
+      mctf_init();
+   }
+
+   mctf_test_t* test = calloc(1, sizeof(mctf_test_t));
+   if (!test)
+   {
+      mctf_log_errorf("MCTF: Failed to allocate memory for test '%s'\n", name);
+      return;
+   }
+
+   test->name = strdup(name);
+   if (!test->name)
+   {
+      mctf_log_errorf("MCTF: Failed to allocate memory for test name '%s'\n", name);
+      free(test);
+      return;
+   }
+
+   test->module = module ? strdup(module) : strdup("unknown");
+   if (!test->module)
+   {
+      mctf_log_errorf("MCTF: Failed to allocate memory for test module '%s'\n", module ? module : "unknown");
+      free((void*)test->name);
+      free(test);
+      return;
+   }
+
+   test->file = file ? strdup(file) : strdup("unknown");
+   if (!test->file)
+   {
+      mctf_log_errorf("MCTF: Failed to allocate memory for test file '%s'\n", file ? file : "unknown");
+      free((void*)test->name);
+      free((void*)test->module);
+      free(test);
+      return;
+   }
+
+   test->func = func;
+   test->next = g_runner.tests;
+   g_runner.tests = test;
+   g_runner.test_count++;
+}
+
+const char*
+mctf_extract_filename(const char* file_path)
+{
+   const char* basename = strrchr(file_path, '/');
+   return basename ? basename + 1 : file_path;
+}
+
+const char*
+mctf_extract_module_name(const char* file_path)
+{
+   /* Extract filename first, then process it to get module name */
+   const char* basename = mctf_extract_filename(file_path);
+
+   /* Remove "test_" prefix if present */
+   if (strncmp(basename, "test_", 5) == 0)
+   {
+      basename += 5;
+   }
+
+   /* Remove ".c" suffix if present */
+   size_t len = strlen(basename);
+   if (len > 2 && strcmp(basename + len - 2, ".c") == 0)
+   {
+      len -= 2;
+   }
+
+   static char module[256];
+   strncpy(module, basename, len);
+   module[len] = '\0';
+   return module;
+}
+
+
+static bool
+matches_filter(mctf_filter_type_t filter_type, const char* test_name, const char* module, const char* filter)
+{
+   if (filter_type == MCTF_FILTER_NONE || !filter || filter[0] == '\0')
+   {
+      return true;
+   }
+
+   switch (filter_type)
+   {
+      case MCTF_FILTER_MODULE:
+         return module && strstr(module, filter) != NULL;
+      case MCTF_FILTER_TEST:
+         return strstr(test_name, filter) != NULL;
+      default:
+         return false;
+   }
+}
+
+
+int
+mctf_run_tests(mctf_filter_type_t filter_type, const char* filter)
+{
+   size_t tests_to_run = 0;
+   mctf_test_t* test;
+
+   if (!g_initialized)
+   {
+      mctf_init();
+   }
+   for (test = g_runner.tests; test; test = test->next)
+   {
+      if (matches_filter(filter_type, test->name, test->module, filter))
+      {
+         tests_to_run++;
+      }
+   }
+
+   if (tests_to_run == 0)
+   {
+      switch (filter_type)
+      {
+         case MCTF_FILTER_NONE:
+            mctf_log_errorf("MCTF: No tests registered (total registered: %zu)\n", g_runner.test_count);
+            break;
+         case MCTF_FILTER_MODULE:
+            mctf_log_errorf("MCTF: No tests found in module '%s'\n", filter);
+            break;
+         case MCTF_FILTER_TEST:
+            mctf_log_errorf("MCTF: No tests found matching filter '%s'\n", filter);
+            break;
+      }
+      return 0;
+   }
+
+   /* Allocate results array */
+   g_runner.results = calloc(tests_to_run, sizeof(mctf_result_t));
+   if (!g_runner.results)
+   {
+      mctf_log_errorf("MCTF: Failed to allocate memory for results\n");
+      return -1;
+   }
+
+   g_runner.result_count = 0;
+   g_runner.passed_count = 0;
+   g_runner.failed_count = 0;
+   g_runner.skipped_count = 0;
+
+   mctf_logf("\n=== Running MCTF Tests ===\n");
+   switch (filter_type)
+   {
+      case MCTF_FILTER_MODULE:
+         mctf_logf("Module: %s\n", filter);
+         break;
+      case MCTF_FILTER_TEST:
+         mctf_logf("Test filter: %s\n", filter);
+         break;
+      default:
+         break;
+   }
+   mctf_logf("Total tests to run: %zu\n\n", tests_to_run);
+
+   const char* current_module = NULL;
+   for (test = g_runner.tests; test; test = test->next)
+   {
+      if (!matches_filter(filter_type, test->name, test->module, filter))
+      {
+         continue;
+      }
+
+      if (!current_module || strcmp(current_module, test->module) != 0)
+      {
+         if (current_module)
+         {
+            mctf_logf("\n");
+         }
+         mctf_logf("--- %s ---\n", test->module);
+         current_module = test->module;
+      }
+
+      mctf_result_t* result = &g_runner.results[g_runner.result_count];
+      result->test_name = test->name;
+      result->file = test->file;
+      result->passed = false;
+      result->skipped = false;
+      result->error_code = 0;
+      result->error_message = NULL;
+      result->elapsed_ms = 0;
+
+      struct timespec start_time, end_time;
+      clock_gettime(CLOCK_MONOTONIC, &start_time);
+
+      mctf_errno = 0;
+      if (mctf_errmsg) { free(mctf_errmsg); mctf_errmsg = NULL; }
+      int ret = test->func();
+
+      clock_gettime(CLOCK_MONOTONIC, &end_time);
+
+      long elapsed_ms = (end_time.tv_sec - start_time.tv_sec) * 1000 +
+                        (end_time.tv_nsec - start_time.tv_nsec) / 1000000;
+
+      result->elapsed_ms = elapsed_ms;
+
+      long total_seconds = elapsed_ms / 1000;
+      long hours = total_seconds / 3600;
+      long minutes = (total_seconds % 3600) / 60;
+      long seconds = total_seconds % 60;
+      long milliseconds = elapsed_ms % 1000;
+
+      if (ret == MCTF_CODE_SKIPPED)
+      {
+         result->skipped = true;
+         result->error_code = mctf_errno;  /* Store line number */
+         result->error_message = mctf_errmsg ? strdup(mctf_errmsg) : NULL;  /* Store skip message */
+         g_runner.skipped_count++;
+
+         mctf_logf("  %s (%02ld:%02ld:%02ld,%03ld) [SKIP] (%s:%d)\n",
+                   test->name, hours, minutes, seconds, milliseconds,
+                   test->file, result->error_code);
+
+         mctf_errno = 0;
+         if (mctf_errmsg) { free(mctf_errmsg); mctf_errmsg = NULL; }
+      }
+      else if (ret == 0 && mctf_errno == 0)
+      {
+         result->passed = true;
+         g_runner.passed_count++;
+         mctf_logf("%s (%02ld:%02ld:%02ld,%03ld) [PASS]\n",
+                   test->name, hours, minutes, seconds, milliseconds);
+      }
+      else
+      {
+         result->passed = false;
+         result->error_code = (ret != 0) ? ret : mctf_errno;
+         result->error_message = mctf_errmsg ? strdup(mctf_errmsg) : NULL;
+         if (mctf_errmsg)
+         {
+            free(mctf_errmsg);
+            mctf_errmsg = NULL;
+         }
+         g_runner.failed_count++;
+         mctf_logf("  %s (%02ld:%02ld:%02ld,%03ld) [FAIL] (%s:%d)\n",
+                   test->name, hours, minutes, seconds, milliseconds,
+                   test->file, result->error_code);
+      }
+
+      g_runner.result_count++;
+   }
+
+   return (int)g_runner.failed_count;
+}
+
+void
+mctf_print_summary(void)
+{
+   mctf_logf("\n=== Test Summary ===\n");
+   mctf_logf("Total tests: %zu\n", g_runner.result_count);
+   mctf_logf("Passed: %zu\n", g_runner.passed_count);
+   mctf_logf("Failed: %zu\n", g_runner.failed_count);
+   mctf_logf("Skipped: %zu\n", g_runner.skipped_count);
+
+   if (g_runner.skipped_count > 0)
+   {
+      mctf_logf("\nSkipped tests:\n");
+      for (size_t i = 0; i < g_runner.result_count; i++)
+      {
+         if (g_runner.results[i].skipped)
+         {
+            if (g_runner.results[i].error_message)
+            {
+               mctf_logf("  - %s (%s:%d) [SKIP] - %s\n",
+                         g_runner.results[i].test_name,
+                         g_runner.results[i].file,
+                         g_runner.results[i].error_code,
+                         g_runner.results[i].error_message);
+            }
+            else
+            {
+               mctf_logf("  - %s (%s:%d) [SKIP]\n",
+                         g_runner.results[i].test_name,
+                         g_runner.results[i].file,
+                         g_runner.results[i].error_code);
+            }
+         }
+      }
+   }
+
+   if (g_runner.failed_count > 0)
+   {
+      mctf_logf("\nFailed tests:\n");
+      for (size_t i = 0; i < g_runner.result_count; i++)
+      {
+         if (!g_runner.results[i].passed && !g_runner.results[i].skipped)
+         {
+            if (g_runner.results[i].error_message)
+            {
+               mctf_logf("  - %s (%s:%d) - %s\n",
+                         g_runner.results[i].test_name,
+                         g_runner.results[i].file,
+                         g_runner.results[i].error_code,
+                         g_runner.results[i].error_message);
+            }
+            else
+            {
+               mctf_logf("  - %s (%s:%d)\n",
+                         g_runner.results[i].test_name,
+                         g_runner.results[i].file,
+                         g_runner.results[i].error_code);
+            }
+         }
+      }
+   }
+
+   mctf_logf("\n");
+}
+
+const mctf_result_t*
+mctf_get_results(size_t* count)
+{
+   if (count)
+   {
+      *count = g_runner.result_count;
+   }
+   return g_runner.results;
+}

--- a/test/runner.c
+++ b/test/runner.c
@@ -26,38 +26,359 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
+#include <mctf.h>
+#include <html_report.h>
 #include <tscommon.h>
-#include <tssuite.h>
+
+#include <errno.h>
+#include <getopt.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "logging.h"
+#include "utils.h"
+
+static struct sigaction old_sa_abrt;
+static struct sigaction old_sa_segv;
+
+static siginfo_t saved_siginfo_abrt;
+static siginfo_t saved_siginfo_segv;
+static ucontext_t saved_ucontext_abrt;
+static ucontext_t saved_ucontext_segv;
+
+static void
+usage(const char* progname)
+{
+   printf("Usage: %s [OPTIONS]\n", progname);
+   printf("Options:\n");
+   printf("  -t, --test NAME    Run only tests matching NAME (test name pattern)\n");
+   printf("  -m, --module NAME Run all tests in module NAME\n");
+   printf("  -h, --help         Show this help message\n");
+   printf("\n");
+   printf("Examples:\n");
+   printf("  %s                 Run full test suite\n", progname);
+   printf("  %s -m cli          Run all tests in 'cli' module\n", progname);
+   printf("  %s -t test_cli_ping Run test matching 'test_cli_ping'\n", progname);
+   printf("\n");
+}
+
+static void
+sigabrt_handler_siginfo(int sig, siginfo_t* info, void* context)
+{
+   if (info != NULL)
+   {
+      saved_siginfo_abrt = *info;
+   }
+   if (context != NULL)
+   {
+      saved_ucontext_abrt = *(ucontext_t*)context;
+   }
+
+   char* bt = NULL;
+   char* os = NULL;
+   int kernel_major = 0, kernel_minor = 0, kernel_patch = 0;
+
+   fprintf(stderr, "\n========================================\n");
+   fprintf(stderr, "FATAL: Received SIGABRT (assertion failure)\n");
+   fprintf(stderr, "========================================\n\n");
+
+   if (pgexporter_os_kernel_version(&os, &kernel_major, &kernel_minor, &kernel_patch) == 0)
+   {
+      fprintf(stderr, "System: %s %d.%d.%d\n\n", os ? os : "Unknown",
+              kernel_major, kernel_minor, kernel_patch);
+      if (os)
+      {
+         free(os);
+      }
+   }
+
+   if (pgexporter_backtrace_string(&bt) == 0 && bt != NULL)
+   {
+      fprintf(stderr, "%s\n", bt);
+
+      if (pgexporter_log_is_enabled(PGEXPORTER_LOGGING_LEVEL_DEBUG1))
+      {
+         pgexporter_backtrace();
+      }
+
+      free(bt);
+   }
+   else
+   {
+      fprintf(stderr, "Failed to generate backtrace\n");
+   }
+
+   fprintf(stderr, "\n========================================\n");
+   fflush(stderr);
+
+   if (old_sa_abrt.sa_flags & SA_SIGINFO)
+   {
+      if (getenv("PGEXPORTER_TEST_DEBUG_SIGNALS") != NULL)
+      {
+         fprintf(stderr, "DEBUG: Chaining to previous SIGABRT handler (SA_SIGINFO) at %p\n", (void*)old_sa_abrt.sa_sigaction);
+      }
+      old_sa_abrt.sa_sigaction(sig, &saved_siginfo_abrt, &saved_ucontext_abrt);
+   }
+   else if (old_sa_abrt.sa_handler == SIG_IGN)
+   {
+      return;
+   }
+   else if (old_sa_abrt.sa_handler == SIG_DFL)
+   {
+      signal(SIGABRT, SIG_DFL);
+      abort();
+   }
+   else
+   {
+      if (getenv("PGEXPORTER_TEST_DEBUG_SIGNALS") != NULL)
+      {
+         fprintf(stderr, "DEBUG: Chaining to previous SIGABRT handler (simple) at %p\n", (void*)old_sa_abrt.sa_handler);
+      }
+      old_sa_abrt.sa_handler(sig);
+   }
+}
+
+static void
+sigsegv_handler_siginfo(int sig, siginfo_t* info, void* context)
+{
+   if (info != NULL)
+   {
+      saved_siginfo_segv = *info;
+   }
+   if (context != NULL)
+   {
+      saved_ucontext_segv = *(ucontext_t*)context;
+   }
+
+   char* bt = NULL;
+   char* os = NULL;
+   int kernel_major = 0, kernel_minor = 0, kernel_patch = 0;
+
+   fprintf(stderr, "\n========================================\n");
+   fprintf(stderr, "FATAL: Received SIGSEGV (segmentation fault)\n");
+   fprintf(stderr, "========================================\n\n");
+
+   if (pgexporter_os_kernel_version(&os, &kernel_major, &kernel_minor, &kernel_patch) == 0)
+   {
+      fprintf(stderr, "System: %s %d.%d.%d\n\n", os ? os : "Unknown",
+              kernel_major, kernel_minor, kernel_patch);
+      if (os)
+      {
+         free(os);
+      }
+   }
+
+   if (pgexporter_backtrace_string(&bt) == 0 && bt != NULL)
+   {
+      fprintf(stderr, "%s\n", bt);
+
+      if (pgexporter_log_is_enabled(PGEXPORTER_LOGGING_LEVEL_DEBUG1))
+      {
+         pgexporter_backtrace();
+      }
+
+      free(bt);
+   }
+   else
+   {
+      fprintf(stderr, "Failed to generate backtrace\n");
+   }
+
+   fprintf(stderr, "\n========================================\n");
+   fflush(stderr);
+
+   if (old_sa_segv.sa_flags & SA_SIGINFO)
+   {
+      if (getenv("PGEXPORTER_TEST_DEBUG_SIGNALS") != NULL)
+      {
+         fprintf(stderr, "DEBUG: Chaining to previous SIGSEGV handler (SA_SIGINFO) at %p\n", (void*)old_sa_segv.sa_sigaction);
+         fprintf(stderr, "DEBUG: Fault address: %p\n", (void*)saved_siginfo_segv.si_addr);
+         fflush(stderr);
+      }
+      old_sa_segv.sa_sigaction(sig, &saved_siginfo_segv, &saved_ucontext_segv);
+   }
+   else if (old_sa_segv.sa_handler == SIG_IGN)
+   {
+      return;
+   }
+   else if (old_sa_segv.sa_handler == SIG_DFL)
+   {
+      signal(SIGSEGV, SIG_DFL);
+      raise(SIGSEGV);
+   }
+   else
+   {
+      if (getenv("PGEXPORTER_TEST_DEBUG_SIGNALS") != NULL)
+      {
+         fprintf(stderr, "DEBUG: Chaining to previous SIGSEGV handler (simple) at %p\n", (void*)old_sa_segv.sa_handler);
+      }
+      old_sa_segv.sa_handler(sig);
+   }
+}
+
+static void
+setup_signal_handlers(void)
+{
+   struct sigaction sa_abrt, sa_segv;
+
+   memset(&sa_abrt, 0, sizeof(sa_abrt));
+   sa_abrt.sa_sigaction = sigabrt_handler_siginfo;
+   sigemptyset(&sa_abrt.sa_mask);
+   sa_abrt.sa_flags = SA_SIGINFO;
+   if (sigaction(SIGABRT, &sa_abrt, &old_sa_abrt) != 0)
+   {
+      fprintf(stderr, "Warning: Failed to setup SIGABRT handler: %s\n", strerror(errno));
+   }
+
+   memset(&sa_segv, 0, sizeof(sa_segv));
+   sa_segv.sa_sigaction = sigsegv_handler_siginfo;
+   sigemptyset(&sa_segv.sa_mask);
+   sa_segv.sa_flags = SA_SIGINFO;
+   if (sigaction(SIGSEGV, &sa_segv, &old_sa_segv) != 0)
+   {
+      fprintf(stderr, "Warning: Failed to setup SIGSEGV handler: %s\n", strerror(errno));
+   }
+   else if (getenv("PGEXPORTER_TEST_DEBUG_SIGNALS") != NULL)
+   {
+      if (old_sa_segv.sa_handler == SIG_DFL)
+      {
+         fprintf(stderr, "DEBUG: Previous SIGSEGV handler was SIG_DFL\n");
+      }
+      else if (old_sa_segv.sa_handler == SIG_IGN)
+      {
+         fprintf(stderr, "DEBUG: Previous SIGSEGV handler was SIG_IGN\n");
+      }
+      else if (old_sa_segv.sa_flags & SA_SIGINFO)
+      {
+         fprintf(stderr, "DEBUG: Previous SIGSEGV handler was custom (SA_SIGINFO): %p\n", (void*)old_sa_segv.sa_sigaction);
+      }
+      else
+      {
+         fprintf(stderr, "DEBUG: Previous SIGSEGV handler was custom: %p\n", (void*)old_sa_segv.sa_handler);
+      }
+   }
+}
+
+static int
+build_mctf_log_path(char* path, size_t size)
+{
+   char base[MAX_PATH];
+   char* slash = NULL;
+   int n;
+
+   if (path == NULL || size == 0)
+   {
+      return 1;
+   }
+
+   memset(base, 0, sizeof(base));
+
+   if (TEST_BASE_DIR[0] == '\0')
+   {
+      return 1;
+   }
+
+   memcpy(base, TEST_BASE_DIR, sizeof(base) - 1);
+   base[sizeof(base) - 1] = '\0';
+
+   slash = strrchr(base, '/');
+   if (slash == NULL)
+   {
+      return 1;
+   }
+
+   *slash = '\0';
+
+   n = snprintf(path, size, "%s/log/pgexporter-test.log", base);
+   if (n <= 0 || (size_t)n >= size)
+   {
+      return 1;
+   }
+
+   return 0;
+}
 
 int
 main(int argc, char* argv[])
 {
    int number_failed = 0;
-   Suite* cli_suite;
-   Suite* database_suite;
-   Suite* http_suite;
-   Suite* configuration_suite;
-   SRunner* sr;
+   const char* filter = NULL;
+   mctf_filter_type_t filter_type = MCTF_FILTER_NONE;
+   int c;
+   bool env_created = false;
+   char mctf_log_path[MAX_PATH];
+   char html_report_path[MAX_PATH];
 
-   pgexporter_test_environment_create();
+   static struct option long_options[] = {
+      {"test", required_argument, 0, 't'},
+      {"module", required_argument, 0, 'm'},
+      {"help", no_argument, 0, 'h'},
+      {0, 0, 0, 0}};
 
-   cli_suite = pgexporter_test_cli_suite();
-   database_suite = pgexporter_test_database_suite();
-   http_suite = pgexporter_test_http_suite();
-   configuration_suite = pgexporter_test_configuration_suite();
+   while ((c = getopt_long(argc, argv, "t:m:h", long_options, NULL)) != -1)
+   {
+      switch (c)
+      {
+         case 't':
+         case 'm':
+            if (filter_type != MCTF_FILTER_NONE)
+            {
+               fprintf(stderr, "Error: Cannot specify both -t and -m options\n");
+               usage(argv[0]);
+               return EXIT_FAILURE;
+            }
+            filter = optarg;
+            filter_type = (c == 't') ? MCTF_FILTER_TEST : MCTF_FILTER_MODULE;
+            break;
+         case 'h':
+            usage(argv[0]);
+            return EXIT_SUCCESS;
+         default:
+            usage(argv[0]);
+            return EXIT_FAILURE;
+      }
+   }
 
-   sr = srunner_create(cli_suite);
-   srunner_add_suite(sr, database_suite);
-   srunner_add_suite(sr, configuration_suite);
-   srunner_add_suite(sr, http_suite);
-   srunner_set_log(sr, "-");
-   srunner_set_fork_status(sr, CK_NOFORK);
-   srunner_run(sr, NULL, NULL, CK_VERBOSE);
-   number_failed = srunner_ntests_failed(sr);
-   srunner_free(sr);
-   pgexporter_test_environment_destroy();
+   setup_signal_handlers();
+
+   if (getenv("PGEXPORTER_TEST_CONF") != NULL)
+   {
+      pgexporter_test_environment_create();
+      env_created = true;
+   }
+
+   if (build_mctf_log_path(mctf_log_path, sizeof(mctf_log_path)) == 0)
+   {
+      if (mctf_open_log(mctf_log_path) != 0)
+      {
+         fprintf(stderr, "Warning: Failed to open MCTF log file at '%s'\n", mctf_log_path);
+      }
+   }
+
+   mctf_log_environment();
+
+   memset(html_report_path, 0, sizeof(html_report_path));
+   bool html_report_available = (html_report_build_path(html_report_path, sizeof(html_report_path)) == 0);
+
+   number_failed = mctf_run_tests(filter_type, filter);
+   if (html_report_available)
+   {
+      html_report_generate(html_report_path, filter_type, filter);
+   }
+   mctf_print_summary();
+   mctf_cleanup();
+
+   mctf_close_log();
+
+   if (env_created)
+   {
+      pgexporter_test_environment_destroy();
+   }
 
    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/test/testcases/test_cli.c
+++ b/test/testcases/test_cli.c
@@ -34,62 +34,55 @@
 #include <network.h>
 #include <shmem.h>
 #include <tsclient.h>
-#include <tssuite.h>
 
-// Test CLI ping command
-START_TEST(test_cli_ping)
+#include <mctf.h>
+
+MCTF_TEST(test_cli_ping)
 {
    int socket = -1;
    int ret;
 
    socket = pgexporter_tsclient_get_connection();
-   ck_assert_msg(pgexporter_socket_isvalid(socket), "Failed to get connection to pgexporter");
+   MCTF_ASSERT(pgexporter_socket_isvalid(socket), cleanup, "Failed to get connection to pgexporter");
 
    ret = pgexporter_management_request_ping(NULL, socket, MANAGEMENT_COMPRESSION_NONE,
                                             MANAGEMENT_ENCRYPTION_NONE, MANAGEMENT_OUTPUT_FORMAT_JSON);
-   ck_assert_msg(ret == 0, "Failed to send ping request");
+   MCTF_ASSERT(ret == 0, cleanup, "Failed to send ping request");
 
    ret = pgexporter_tsclient_check_outcome(socket);
-   ck_assert_msg(ret == 0, "Ping command returned unsuccessful outcome");
+   MCTF_ASSERT(ret == 0, cleanup, "Ping command returned unsuccessful outcome");
 
    pgexporter_disconnect(socket);
+   socket = -1;
+cleanup:
+   if (socket >= 0)
+   {
+      pgexporter_disconnect(socket);
+   }
+   MCTF_FINISH();
 }
-END_TEST
 
-// Test CLI status command
-START_TEST(test_cli_status)
+MCTF_TEST(test_cli_status)
 {
    int socket = -1;
    int ret;
 
    socket = pgexporter_tsclient_get_connection();
-   ck_assert_msg(pgexporter_socket_isvalid(socket), "Failed to get connection to pgexporter");
+   MCTF_ASSERT(pgexporter_socket_isvalid(socket), cleanup, "Failed to get connection to pgexporter");
 
    ret = pgexporter_management_request_status(NULL, socket, MANAGEMENT_COMPRESSION_NONE,
                                               MANAGEMENT_ENCRYPTION_NONE, MANAGEMENT_OUTPUT_FORMAT_JSON);
-   ck_assert_msg(ret == 0, "Failed to send status request");
+   MCTF_ASSERT(ret == 0, cleanup, "Failed to send status request");
 
    ret = pgexporter_tsclient_check_outcome(socket);
-   ck_assert_msg(ret == 0, "Status command returned unsuccessful outcome");
+   MCTF_ASSERT(ret == 0, cleanup, "Status command returned unsuccessful outcome");
 
    pgexporter_disconnect(socket);
-}
-END_TEST
-
-Suite*
-pgexporter_test_cli_suite()
-{
-   Suite* s;
-   TCase* tc_cli;
-
-   s = suite_create("pgexporter_test_cli");
-
-   tc_cli = tcase_create("CLI");
-
-   tcase_set_timeout(tc_cli, 60);
-   tcase_add_test(tc_cli, test_cli_ping);
-   tcase_add_test(tc_cli, test_cli_status);
-   suite_add_tcase(s, tc_cli);
-
-   return s;
+   socket = -1;
+cleanup:
+   if (socket >= 0)
+   {
+      pgexporter_disconnect(socket);
+   }
+   MCTF_FINISH();
 }


### PR DESCRIPTION
- closes #415

#### Implementation Status

- [x] Create MCTF framework (`test/include/mctf.h` and `test/libpgexportertest/mctf.c`)
- [x] Implement test auto-registration, filtering, timing, and error handling
- [x] Remove Check dependency from build system (`test/CMakeLists.txt`, root `CMakeLists.txt`)
- [x] Rewrite test runner (`test/runner.c`) with MCTF API and signal handlers
- [x] Migrate test files to MCTF
- [x] Remove `test/include/tssuite.h`; add HTML report support
- [x] Add test filters - command-line options (`-t`, `-m`, `-h`)
- [x] Implement log file support (`/tmp/pgexporter-test/log/pgexporter-test.log`)
- [x] Display env before running test cases
- [x] Signal handlers and signal chaining 
- [x] Update documentation for MCTF usage
