### PR TITLE
fix: lock file cleanup in error paths (#424)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,5 +27,4 @@ Amr Shams (NightBird) <amr.shams2015.a@gmail.com>
 Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
-Zeyad Daowd <zeyaddaowd@yahoo.com>
-Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
+Praful <prafuldkasamalagi2353@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -34,8 +34,7 @@ Amr Shams (NightBird) <amr.shams2015.a@gmail.com>
 Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
-Zeyad Daowd <zeyaddaowd@yahoo.com>
-Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
+Praful <prafuldkasamalagi2353@gmail.com>
 ```
 
 ## Committers

--- a/src/main.c
+++ b/src/main.c
@@ -958,7 +958,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
       sd_notify(0, "STATUS=Both YAML and JSON paths cannot be specified at the same time");
 #endif
-      exit(1);
+      goto error;
    }
 
    if (yaml_path != NULL)
@@ -970,7 +970,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
          sd_notify(0, "STATUS=Invalid metrics YAML");
 #endif
-         exit(1);
+         goto error;
       }
    }
    else if (json_path != NULL)
@@ -982,7 +982,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
          sd_notify(0, "STATUS=Invalid metrics JSON");
 #endif
-         exit(1);
+         goto error;
       }
    }
    if (yaml_path != NULL || json_path != NULL)
@@ -997,7 +997,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
       sd_notify(0, "STATUS=Failed to setup extensions path");
 #endif
-      exit(1);
+      goto error;
    }
 
    if (daemon)
@@ -1008,7 +1008,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
          sd_notify(0, "STATUS=Daemon mode can't be used with console logging");
 #endif
-         exit(1);
+         goto error;
       }
 
       pid = fork();
@@ -1019,7 +1019,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
          sd_notify(0, "STATUS=Daemon mode failed");
 #endif
-         exit(1);
+         goto error;
       }
 
       if (pid > 0)
@@ -1033,7 +1033,7 @@ main(int argc, char** argv)
 
       if (sid < 0)
       {
-         exit(1);
+         goto error;
       }
    }
 
@@ -1076,7 +1076,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
       sd_notifyf(0, "STATUS=Could not bind to %s/%s", config->unix_socket_dir, MAIN_UDS);
 #endif
-      exit(1);
+      goto error;
    }
 
    /* Bind Unix Domain Socket: Transfer */
@@ -1086,7 +1086,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
       sd_notifyf(0, "STATUS=Could not bind to %s/%s", config->unix_socket_dir, TRANSFER_UDS);
 #endif
-      exit(1);
+      goto error;
    }
 
    /* libev */
@@ -1098,7 +1098,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
       sd_notifyf(0, "STATUS=No loop implementation (%x) (%x)", pgexporter_libev(config->libev), ev_supported_backends());
 #endif
-      exit(1);
+      goto error;
    }
 
    ev_signal_init((struct ev_signal*)&signal_watcher[0], shutdown_cb, SIGTERM);
@@ -1120,7 +1120,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
       sd_notify(0, "STATUS=Invalid TLS configuration");
 #endif
-      exit(1);
+      goto error;
    }
 
    if (config->metrics > 0)
@@ -1135,7 +1135,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
          sd_notifyf(0, "STATUS=Could not bind to %s:%d", config->host, config->metrics);
 #endif
-         exit(1);
+         goto error;
       }
 
       if (metrics_fds_length > MAX_FDS)
@@ -1144,7 +1144,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
          sd_notifyf(0, "STATUS=Too many descriptors %d", metrics_fds_length);
 #endif
-         exit(1);
+         goto error;
       }
 
       start_metrics();
@@ -1183,7 +1183,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
          sd_notifyf(0, "STATUS=Could not bind to %s:%d", config->host, config->bridge);
 #endif
-         exit(1);
+         goto error;
       }
 
       if (bridge_fds_length > MAX_FDS)
@@ -1192,7 +1192,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
          sd_notifyf(0, "STATUS=Too many descriptors %d", bridge_fds_length);
 #endif
-         exit(1);
+         goto error;
       }
 
       start_bridge();
@@ -1206,7 +1206,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
             sd_notifyf(0, "STATUS=Could not bind to %s:%d", config->host, config->bridge_json);
 #endif
-            exit(1);
+            goto error;
          }
 
          if (bridge_json_fds_length > MAX_FDS)
@@ -1215,7 +1215,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
             sd_notifyf(0, "STATUS=Too many descriptors %d", bridge_json_fds_length);
 #endif
-            exit(1);
+            goto error;
          }
 
          start_bridge_json();
@@ -1231,7 +1231,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
          sd_notifyf(0, "STATUS=Could not bind to %s:%d", config->host, config->management);
 #endif
-         exit(1);
+         goto error;
       }
 
       if (management_fds_length > MAX_FDS)
@@ -1240,7 +1240,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
          sd_notifyf(0, "STATUS=Too many descriptors %d", management_fds_length);
 #endif
-         exit(1);
+         goto error;
       }
 
       start_management();
@@ -1306,7 +1306,7 @@ main(int argc, char** argv)
 #ifdef HAVE_SYSTEMD
       sd_notify(0, "STATUS=Failed to load extension YAMLs");
 #endif
-      exit(1);
+      goto error;
    }
 
    /* Close connections after validation  and loading extensions - child processes will create their own.
@@ -1386,8 +1386,71 @@ main(int argc, char** argv)
    {
       kill(0, SIGTERM);
    }
-
    return 0;
+}
+
+error :
+#ifdef HAVE_SYSTEMD
+    sd_notify(0, "STATUS=Error");
+#endif
+
+pgexporter_close_connections();
+
+shutdown_management();
+
+if (config->metrics != -1)
+{
+   shutdown_metrics();
+   shutdown_mgt();
+   shutdown_transfer();
+}
+
+if (config->bridge != -1)
+{
+   shutdown_bridge();
+
+   if (config->bridge_json != -1)
+   {
+      shutdown_bridge_json();
+   }
+}
+
+if (main_loop)
+{
+   for (int i = 0; i < 6; i++)
+   {
+      ev_signal_stop(main_loop, (struct ev_signal*)&signal_watcher[i]);
+   }
+
+   ev_loop_destroy(main_loop);
+}
+
+free(metrics_fds);
+free(bridge_fds);
+free(bridge_json_fds);
+free(management_fds);
+
+free(bin_path);
+
+remove_pidfile();
+remove_lockfile(config->metrics);
+remove_lockfile(config->bridge);
+remove_lockfile(config->bridge_json);
+
+pgexporter_stop_logging();
+
+pgexporter_free_pg_query_alts(config);
+pgexporter_free_extension_query_alts(config);
+
+pgexporter_destroy_shared_memory(shmem, shmem_size);
+pgexporter_destroy_shared_memory(prometheus_cache_shmem,
+                                 prometheus_cache_shmem_size);
+
+pgexporter_memory_destroy();
+
+OPENSSL_cleanup();
+
+return 1;
 }
 
 static void


### PR DESCRIPTION
Always cleanup the lock file when an error occurs.

Replaced all exit(1) calls after lock file creation with goto error
in src/main.c. Added error: label that calls remove_lockfile() for
all three lock files (metrics, bridge, bridge_json) before exiting.

Fixes #424