### PR TITLE
[#451] Cross-porting Optimization of salted password generation by reusing HMAC context from pgagroal

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Amr Shams (NightBird) <amr.shams2015.a@gmail.com>
 Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
+Zeyad Daowd <zeyaddaowd@yahoo.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -34,6 +34,7 @@ Amr Shams (NightBird) <amr.shams2015.a@gmail.com>
 Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
+Zeyad Daowd <zeyaddaowd@yahoo.com>
 ```
 
 ## Committers

--- a/src/libpgexporter/security.c
+++ b/src/libpgexporter/security.c
@@ -2194,12 +2194,8 @@ salted_password(char* password, char* salt, int salt_length, int iterations, uns
 
    for (int i = 2; i <= iterations; i++)
    {
-      if (HMAC_CTX_reset(ctx) != 1)
-      {
-         goto error;
-      }
-
-      if (HMAC_Init_ex(ctx, password, password_length, EVP_sha256(), NULL) != 1)
+      /* passing nulls cause function to reuse the same key / password in the context */
+      if (HMAC_Init_ex(ctx, NULL, 0, NULL, NULL) != 1)
       {
          goto error;
       }


### PR DESCRIPTION
This PR is a cross-port of the performance optimization merged in pgagroal #738.
Link of the PR: https://github.com/pgagroal/pgagroal/pull/738
I have isolated pgexporter's salting function in a separate file to replicate the testing and achieved the same ~5 speedup.
before:<img width="1418" height="174" alt="image" src="https://github.com/user-attachments/assets/30db6711-2c21-46cd-8a4b-6bcc63459771" />
after:<img width="1496" height="160" alt="image" src="https://github.com/user-attachments/assets/ae9c04bf-0c9e-4d70-90ff-fe7cc3ecfd05" />
closes #451 
