### PR TITLE
[#464] Fix memory leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ __pycache__/
 *.pyo
 *.pyd
 .Python
+
+.idea/

--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
 Zeyad Daowd <zeyaddaowd@yahoo.com>
+Ahmed Mordi <ahmed.m.hamada2003@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -35,6 +35,7 @@ Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
 Zeyad Daowd <zeyaddaowd@yahoo.com>
+Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
 ```
 
 ## Committers

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -414,6 +414,15 @@ pgexporter_base64_decode(char* encoded, size_t encoded_length, void** raw, size_
 void
 pgexporter_set_proc_title(int argc, char** argv, char* s1, char* s2);
 
+#ifdef HAVE_LINUX
+/**
+ * Free the process title environment copy.
+ * Should be called during shutdown on Linux.
+ */
+void
+pgexporter_free_proc_title(void);
+#endif
+
 /**
  * Create directories
  * @param dir The directory

--- a/src/libpgexporter/configuration.c
+++ b/src/libpgexporter/configuration.c
@@ -1800,6 +1800,9 @@ pgexporter_conf_get(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
 
    pgexporter_log_info("Conf Get (Elapsed: %s)", elapsed);
 
+   free(elapsed);
+   elapsed = NULL;
+
    pgexporter_json_destroy(payload);
 
    pgexporter_disconnect(client_fd);
@@ -2435,6 +2438,9 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
    elapsed = pgexporter_get_timestamp_string(start_time, end_time, &total_seconds);
 
    pgexporter_log_info("Conf Set (Elapsed: %s)", elapsed);
+
+   free(elapsed);
+   elapsed = NULL;
 
    pgexporter_json_destroy(payload);
 

--- a/src/libpgexporter/status.c
+++ b/src/libpgexporter/status.c
@@ -91,6 +91,9 @@ pgexporter_status(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compr
 
    pgexporter_log_info("Status (Elapsed: %s)", elapsed);
 
+   free(elapsed);
+   elapsed = NULL;
+
    pgexporter_json_destroy(payload);
 
    pgexporter_disconnect(client_fd);
@@ -166,6 +169,9 @@ pgexporter_status_details(SSL* ssl __attribute__((unused)), int client_fd, uint8
    elapsed = pgexporter_get_timestamp_string(start_time, end_time, &total_seconds);
 
    pgexporter_log_info("Status details (Elapsed: %s)", elapsed);
+
+   free(elapsed);
+   elapsed = NULL;
 
    pgexporter_json_destroy(payload);
 

--- a/src/libpgexporter/utils.c
+++ b/src/libpgexporter/utils.c
@@ -71,6 +71,8 @@ extern char** environ;
 #ifdef HAVE_LINUX
 static bool env_changed = false;
 static int max_process_title_size = 0;
+static char** proc_title_environ = NULL;
+static int proc_title_environ_size = 0;
 #endif
 
 static int string_compare(const void* a, const void* b);
@@ -853,11 +855,14 @@ pgexporter_set_proc_title(int argc, char** argv, char* s1, char* s2)
          es++;
       }
 
-      environ = (char**)malloc(sizeof(char*) * (es + 1));
-      if (environ == NULL)
+      proc_title_environ = (char**)malloc(sizeof(char*) * (es + 1));
+      if (proc_title_environ == NULL)
       {
+         proc_title_environ_size = 0;
          return;
       }
+      proc_title_environ_size = es;
+      environ = proc_title_environ;
 
       for (int i = 0; env[i] != NULL; i++)
       {
@@ -3505,3 +3510,21 @@ pgexporter_time_format(pgexporter_time_t t, enum pgexporter_time_format_t fmt, c
    *output = str;
    return 0;
 }
+
+#ifdef HAVE_LINUX
+void
+pgexporter_free_proc_title(void)
+{
+   if (proc_title_environ == NULL)
+   {
+      return;
+   }
+   for (int i = 0; i < proc_title_environ_size; i++)
+   {
+      free(proc_title_environ[i]);
+   }
+   free(proc_title_environ);
+   proc_title_environ = NULL;
+   proc_title_environ_size = 0;
+}
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -1317,6 +1317,9 @@ main(int argc, char** argv)
    pgexporter_destroy_shared_memory(prometheus_cache_shmem,
                                     prometheus_cache_shmem_size);
 
+#ifdef HAVE_LINUX
+   pgexporter_free_proc_title();
+#endif
    pgexporter_memory_destroy();
 
    OPENSSL_cleanup();
@@ -1469,6 +1472,11 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
 
          pgexporter_json_clone(payload, &pyl);
 
+         free(str);
+         str = NULL;
+         pgexporter_json_destroy(payload);
+         payload = NULL;
+
          pgexporter_set_proc_title(1, ai->argv, "status", NULL);
          pgexporter_status(NULL, client_fd, compression, encryption, pyl);
       }
@@ -1489,6 +1497,11 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
          shutdown_ports();
 
          pgexporter_json_clone(payload, &pyl);
+
+         free(str);
+         str = NULL;
+         pgexporter_json_destroy(payload);
+         payload = NULL;
 
          pgexporter_set_proc_title(1, ai->argv, "details", NULL);
          pgexporter_status_details(NULL, client_fd, compression, encryption, pyl);
@@ -1527,6 +1540,11 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
 
          pgexporter_json_clone(payload, &pyl);
 
+         free(str);
+         str = NULL;
+         pgexporter_json_destroy(payload);
+         payload = NULL;
+
          pgexporter_set_proc_title(1, ai->argv, "conf get", NULL);
          pgexporter_conf_get(NULL, client_fd, compression, encryption, pyl);
       }
@@ -1547,6 +1565,11 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
          shutdown_ports();
 
          pgexporter_json_clone(payload, &pyl);
+
+         free(str);
+         str = NULL;
+         pgexporter_json_destroy(payload);
+         payload = NULL;
 
          pgexporter_set_proc_title(1, ai->argv, "conf set", NULL);
          pgexporter_conf_set(NULL, client_fd, compression, encryption, pyl);


### PR DESCRIPTION
Fixes #464

<img width="697" height="251" alt="Screenshot from 2026-03-03 16-23-44" src="https://github.com/user-attachments/assets/e1b398fd-4fd9-4377-a87b-2f179b3d4b9e" />

1. `pgexporter_set_proc_title` replaced `environ` with a heap-allocated copy on Linux but never freed it on shutdown. Added `pgexporter_free_proc_title()` and called it in the shutdown sequence

2. `pgexporter_get_timestamp_string` returns a `malloc`'d string that four callers discarded without freeing. Added `free(elapsed)` after each log call

3. Child processes in `accept_mgt_cb` exited through the handler without destroying the original `payload` and `str`. Freed both after cloning into `pyl`, before calling the handler
