### PR TITLE
[#467] Add pg_stat_get_backend_io metric for PostgreSQL 18+

### DIFF
--- a/contrib/grafana/README.md
+++ b/contrib/grafana/README.md
@@ -45,7 +45,7 @@ Dashboards are automatically provisioned - no manual import needed.
 | `postgresql_dashboard_pg15.json` | 15.x | + Memory contexts |
 | `postgresql_dashboard_pg16.json` | 16.x | + pg_stat_io metrics |
 | `postgresql_dashboard_pg17.json` | 17.x | + Wait events |
-| `postgresql_dashboard_pg18.json` | 18.x | + Wait events |
+| `postgresql_dashboard_pg18.json` | 18.x | + Wait events, pg_stat_backend_io metrics |
 
 ### Panels Included in All Dashboards
 

--- a/contrib/grafana/postgresql_dashboard.json
+++ b/contrib/grafana/postgresql_dashboard.json
@@ -2948,6 +2948,329 @@
       ],
       "title": "Long Running Transactions Details",
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "I/O operations per second grouped by user, application and database (PostgreSQL 18+)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*time.*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*bytes.*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 201
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_reads[5m])",
+          "legendFormat": "Reads - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_writes[5m])",
+          "legendFormat": "Writes - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_hits[5m])",
+          "legendFormat": "Hits - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_extends[5m])",
+          "legendFormat": "Extends - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_evictions[5m])",
+          "legendFormat": "Evictions - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_fsyncs[5m])",
+          "legendFormat": "Fsyncs - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "F"
+        }
+      ],
+      "title": "Backend I/O Operations (pg_stat_get_backend_io)",
+      "type": "timeseries",
+      "version": 18
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "I/O timing per second grouped by user, application and database (PostgreSQL 18+)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*time.*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*bytes.*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 201
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_read_time[5m])",
+          "legendFormat": "Read Time - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_write_time[5m])",
+          "legendFormat": "Write Time - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_fsync_time[5m])",
+          "legendFormat": "Fsync Time - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_writeback_time[5m])",
+          "legendFormat": "Writeback Time - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_extend_time[5m])",
+          "legendFormat": "Extend Time - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "E"
+        }
+      ],
+      "title": "Backend I/O Timing (pg_stat_get_backend_io)",
+      "type": "timeseries",
+      "version": 18
     }
   ],
   "refresh": "30s",

--- a/contrib/grafana/postgresql_dashboard_pg18.json
+++ b/contrib/grafana/postgresql_dashboard_pg18.json
@@ -2943,6 +2943,327 @@
       ],
       "title": "Long Running Transactions Details",
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "I/O operations per second grouped by user, application and database (PostgreSQL 18+)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*time.*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*bytes.*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 201
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_reads[5m])",
+          "legendFormat": "Reads - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_writes[5m])",
+          "legendFormat": "Writes - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_hits[5m])",
+          "legendFormat": "Hits - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_extends[5m])",
+          "legendFormat": "Extends - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_evictions[5m])",
+          "legendFormat": "Evictions - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_fsyncs[5m])",
+          "legendFormat": "Fsyncs - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "F"
+        }
+      ],
+      "title": "Backend I/O Operations (pg_stat_get_backend_io)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "I/O timing per second grouped by user, application and database (PostgreSQL 18+)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*time.*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*bytes.*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 201
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_read_time[5m])",
+          "legendFormat": "Read Time - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_write_time[5m])",
+          "legendFormat": "Write Time - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_fsync_time[5m])",
+          "legendFormat": "Fsync Time - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_writeback_time[5m])",
+          "legendFormat": "Writeback Time - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(pgexporter_pg_stat_backend_io_extend_time[5m])",
+          "legendFormat": "Extend Time - {{usename}} / {{application_name}} / {{datname}}",
+          "refId": "E"
+        }
+      ],
+      "title": "Backend I/O Timing (pg_stat_get_backend_io)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/contrib/json/postgresql-18.json
+++ b/contrib/json/postgresql-18.json
@@ -1731,6 +1731,111 @@
       ]
     },
     {
+      "tag": "pg_stat_backend_io",
+      "collector": "stat_backend_io",
+      "sort": "data",
+      "queries": [
+        {
+          "query": "SELECT a.usename, a.application_name, a.datname, SUM(COALESCE(i.reads, 0)) AS reads, SUM(COALESCE(i.read_bytes, 0)) AS read_bytes, SUM(COALESCE(i.read_time, 0)) AS read_time, SUM(COALESCE(i.writes, 0)) AS writes, SUM(COALESCE(i.write_bytes, 0)) AS write_bytes, SUM(COALESCE(i.write_time, 0)) AS write_time, SUM(COALESCE(i.writebacks, 0)) AS writebacks, SUM(COALESCE(i.writeback_time, 0)) AS writeback_time, SUM(COALESCE(i.extends, 0)) AS extends, SUM(COALESCE(i.extend_bytes, 0)) AS extend_bytes, SUM(COALESCE(i.extend_time, 0)) AS extend_time, SUM(COALESCE(i.hits, 0)) AS hits, SUM(COALESCE(i.evictions, 0)) AS evictions, SUM(COALESCE(i.reuses, 0)) AS reuses, SUM(COALESCE(i.fsyncs, 0)) AS fsyncs, SUM(COALESCE(i.fsync_time, 0)) AS fsync_time FROM pg_stat_activity a, pg_stat_get_backend_io(a.pid) i WHERE a.datname IS NOT NULL GROUP BY a.usename, a.application_name, a.datname;",
+          "version": 18,
+          "columns": [
+            {
+              "name": "usename",
+              "type": "label"
+            },
+            {
+              "name": "application_name",
+              "type": "label"
+            },
+            {
+              "name": "datname",
+              "type": "label"
+            },
+            {
+              "name": "reads",
+              "type": "counter",
+              "description": "Number of read operations."
+            },
+            {
+              "name": "read_bytes",
+              "type": "counter",
+              "description": "Total bytes read."
+            },
+            {
+              "name": "read_time",
+              "type": "counter",
+              "description": "Total time spent on read operations in milliseconds."
+            },
+            {
+              "name": "writes",
+              "type": "counter",
+              "description": "Number of write operations."
+            },
+            {
+              "name": "write_bytes",
+              "type": "counter",
+              "description": "Total bytes written."
+            },
+            {
+              "name": "write_time",
+              "type": "counter",
+              "description": "Total time spent on write operations in milliseconds."
+            },
+            {
+              "name": "writebacks",
+              "type": "counter",
+              "description": "Number of writeback to permanent storage requests sent to kernel."
+            },
+            {
+              "name": "writeback_time",
+              "type": "counter",
+              "description": "Total time spent on writeback operations in milliseconds."
+            },
+            {
+              "name": "extends",
+              "type": "counter",
+              "description": "Number of relation extend operations."
+            },
+            {
+              "name": "extend_bytes",
+              "type": "counter",
+              "description": "Total bytes extended."
+            },
+            {
+              "name": "extend_time",
+              "type": "counter",
+              "description": "Total time spent on relation extend operations in milliseconds."
+            },
+            {
+              "name": "hits",
+              "type": "counter",
+              "description": "The number of times a desired block was found in shared buffer."
+            },
+            {
+              "name": "evictions",
+              "type": "counter",
+              "description": "The number of times a block has been written out from shared or local buffer in order to make it available for another use."
+            },
+            {
+              "name": "reuses",
+              "type": "counter",
+              "description": "The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation."
+            },
+            {
+              "name": "fsyncs",
+              "type": "counter",
+              "description": "Number of fsync calls."
+            },
+            {
+              "name": "fsync_time",
+              "type": "counter",
+              "description": "Total time spent on fsync operations in milliseconds."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "tag": "pg_stat_database_conflicts",
       "collector": "stat_conflicts",
       "sort": "data",

--- a/contrib/prometheus_scrape/extra.info
+++ b/contrib/prometheus_scrape/extra.info
@@ -6422,3 +6422,131 @@ pgexporter_pg_long_running_transactions_age_seconds
 * usename: User name.
 * query: The SQL query text being executed.
 Version: 10+
+
+pgexporter_pg_stat_backend_io_reads
++ Total read operations performed by each backend, from pg_stat_get_backend_io(pid) joined with pg_stat_activity. Grouped by user, application, and database.
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_read_bytes
++ Total bytes read by each backend, from pg_stat_get_backend_io(pid) joined with pg_stat_activity.
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_read_time
++ Total time (milliseconds) spent on read operations by each backend (requires track_io_timing), from pg_stat_get_backend_io(pid).
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_writes
++ Total write operations performed by each backend, from pg_stat_get_backend_io(pid) joined with pg_stat_activity.
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_write_bytes
++ Total bytes written by each backend, from pg_stat_get_backend_io(pid) joined with pg_stat_activity.
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_write_time
++ Total time (milliseconds) spent on write operations by each backend (requires track_io_timing), from pg_stat_get_backend_io(pid).
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_writebacks
++ Total OS-level writeback requests initiated by each backend, from pg_stat_get_backend_io(pid) joined with pg_stat_activity.
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_writeback_time
++ Total time (milliseconds) spent on writeback operations by each backend (requires track_io_timing), from pg_stat_get_backend_io(pid).
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_extends
++ Total relation file extension operations performed by each backend, from pg_stat_get_backend_io(pid) joined with pg_stat_activity.
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_extend_bytes
++ Total bytes extended (relation file growth) by each backend, from pg_stat_get_backend_io(pid) joined with pg_stat_activity.
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_extend_time
++ Total time (milliseconds) spent on relation extension operations by each backend (requires track_io_timing), from pg_stat_get_backend_io(pid).
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_hits
++ Total shared buffer cache hits by each backend, from pg_stat_get_backend_io(pid) joined with pg_stat_activity.
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_evictions
++ Total buffer blocks evicted from cache by each backend, from pg_stat_get_backend_io(pid) joined with pg_stat_activity.
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_reuses
++ Total times I/O ring buffers were reused by each backend, from pg_stat_get_backend_io(pid) joined with pg_stat_activity.
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_fsyncs
++ Total fsync calls made by each backend, from pg_stat_get_backend_io(pid) joined with pg_stat_activity.
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+
+
+pgexporter_pg_stat_backend_io_fsync_time
++ Total time (milliseconds) spent on fsync operations by each backend (requires track_io_timing), from pg_stat_get_backend_io(pid).
+* server: The configured name/identifier for the PostgreSQL server.
+* usename: The username of the backend.
+* application_name: The application name reported by the backend.
+* datname: The database the backend is connected to.
+Version: 18+

--- a/contrib/yaml/postgresql-18.yaml
+++ b/contrib/yaml/postgresql-18.yaml
@@ -973,6 +973,67 @@ metrics:
     - name: fsync_time
       type: counter
       description: Total time spent on fsync operations in milliseconds.
+- tag: pg_stat_backend_io
+  collector: stat_backend_io
+  sort: data
+  queries:
+  - query: SELECT a.usename, a.application_name, a.datname, SUM(COALESCE(i.reads, 0)) AS reads, SUM(COALESCE(i.read_bytes, 0)) AS read_bytes, SUM(COALESCE(i.read_time, 0)) AS read_time, SUM(COALESCE(i.writes, 0)) AS writes, SUM(COALESCE(i.write_bytes, 0)) AS write_bytes, SUM(COALESCE(i.write_time, 0)) AS write_time, SUM(COALESCE(i.writebacks, 0)) AS writebacks, SUM(COALESCE(i.writeback_time, 0)) AS writeback_time, SUM(COALESCE(i.extends, 0)) AS extends, SUM(COALESCE(i.extend_bytes, 0)) AS extend_bytes, SUM(COALESCE(i.extend_time, 0)) AS extend_time, SUM(COALESCE(i.hits, 0)) AS hits, SUM(COALESCE(i.evictions, 0)) AS evictions, SUM(COALESCE(i.reuses, 0)) AS reuses, SUM(COALESCE(i.fsyncs, 0)) AS fsyncs, SUM(COALESCE(i.fsync_time, 0)) AS fsync_time FROM pg_stat_activity a, pg_stat_get_backend_io(a.pid) i WHERE a.datname IS NOT NULL GROUP BY a.usename, a.application_name, a.datname;
+    version: 18
+    columns:
+    - name: usename
+      type: label
+    - name: application_name
+      type: label
+    - name: datname
+      type: label
+    - name: reads
+      type: counter
+      description: Number of read operations.
+    - name: read_bytes
+      type: counter
+      description: Total bytes read.
+    - name: read_time
+      type: counter
+      description: Total time spent on read operations in milliseconds.
+    - name: writes
+      type: counter
+      description: Number of write operations.
+    - name: write_bytes
+      type: counter
+      description: Total bytes written.
+    - name: write_time
+      type: counter
+      description: Total time spent on write operations in milliseconds.
+    - name: writebacks
+      type: counter
+      description: Number of writeback to permanent storage requests sent to kernel.
+    - name: writeback_time
+      type: counter
+      description: Total time spent on writeback operations in milliseconds.
+    - name: extends
+      type: counter
+      description: Number of relation extend operations.
+    - name: extend_bytes
+      type: counter
+      description: Total bytes extended.
+    - name: extend_time
+      type: counter
+      description: Total time spent on relation extend operations in milliseconds.
+    - name: hits
+      type: counter
+      description: The number of times a desired block was found in shared buffer.
+    - name: evictions
+      type: counter
+      description: The number of times a block has been written out from shared or local buffer in order to make it available for another use.
+    - name: reuses
+      type: counter
+      description: The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation.
+    - name: fsyncs
+      type: counter
+      description: Number of fsync calls.
+    - name: fsync_time
+      type: counter
+      description: Total time spent on fsync operations in milliseconds.
 - tag: pg_stat_database_conflicts
   collector: stat_conflicts
   sort: data

--- a/doc/manual/en/06-prometheus.md
+++ b/doc/manual/en/06-prometheus.md
@@ -5244,6 +5244,182 @@ Total bytes extended (relation file growth) across all I/O operations, sourced f
 | server | The configured name/identifier for the PostgreSQL server. |
 | backend_type | Type of backend process. |
 
+## pgexporter_pg_stat_backend_io_reads
+
+Counts the total read operations performed by each backend, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_read_bytes
+
+Total bytes read by each backend, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_read_time
+
+Aggregates total time (ms) spent by each backend performing read I/O operations, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+, requires `track_io_timing`).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_writes
+
+Counts the total write operations performed by each backend, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_write_bytes
+
+Total bytes written by each backend, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_write_time
+
+Aggregates total time (ms) spent by each backend performing write I/O operations, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+, requires `track_io_timing`).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_writebacks
+
+Counts the total number of writeback to permanent storage requests sent to the kernel by each backend, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_writeback_time
+
+Aggregates total time (ms) spent by each backend performing writeback operations, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+, requires `track_io_timing`).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_extends
+
+Counts the total relation extend operations performed by each backend, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_extend_bytes
+
+Total bytes extended by each backend, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_extend_time
+
+Aggregates total time (ms) spent by each backend performing relation extend operations, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+, requires `track_io_timing`).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_hits
+
+Counts the total number of times a desired block was found in shared buffer by each backend, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_evictions
+
+Counts the total number of times a block was written out from shared or local buffer to make it available for another use, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_reuses
+
+Counts the total number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_fsyncs
+
+Counts the total number of fsync calls made by each backend, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
+## pgexporter_pg_stat_backend_io_fsync_time
+
+Aggregates total time (ms) spent by each backend performing fsync operations, sourced from `pg_stat_get_backend_io` joined with `pg_stat_activity` (PostgreSQL 18+, requires `track_io_timing`).
+
+| Attribute | Description |
+| :-------- | :---------- |
+| server | The configured name/identifier for the PostgreSQL server. |
+| usename | The name of the user running the backend. |
+| application_name | The name of the application connected to this backend. |
+| datname | The name of the database this backend is connected to. |
+
 ## pgexporter_pg_stat_user_tables_total_vacuum_time
 
 Total time (milliseconds) spent vacuuming this table since statistics reset, from `pg_stat_user_tables`.

--- a/doc/manual/en/09-grafana.md
+++ b/doc/manual/en/09-grafana.md
@@ -143,7 +143,7 @@ We provide 6 version-specific dashboards to support the unique features of each 
 *   `postgresql_dashboard_pg15.json` (+ Memory Contexts)
 *   `postgresql_dashboard_pg16.json` (+ pg_stat_io)
 *   `postgresql_dashboard_pg17.json` (+ Wait Events)
-*   `postgresql_dashboard_pg18.json` (+ Wait Events)
+*   `postgresql_dashboard_pg18.json` (+ Wait Events, pg_stat_backend_io)
 
 Select **"Upload dashboard as JSON file"**, choose the file matching your PostgreSQL version from the [contrib/grafana](../../../contrib/grafana/) directory, select your Prometheus datasource, and click **"Import"**.
 

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -2445,6 +2445,92 @@ extern "C" {
                       "    tag: pg_stat_io\n"                                                                                                                                           \
                       "    collector: stat_io\n"                                                                                                                                        \
                       "\n"                                                                                                                                                              \
+                      "# pg_stat_get_backend_io\n"                                                                                                                                      \
+                      "  - queries:\n"                                                                                                                                                  \
+                      "    - query: SELECT\n"                                                                                                                                           \
+                      "                a.usename,\n"                                                                                                                                    \
+                      "                a.application_name,\n"                                                                                                                           \
+                      "                a.datname,\n"                                                                                                                                    \
+                      "                SUM(COALESCE(i.reads, 0)) AS reads,\n"                                                                                                           \
+                      "                SUM(COALESCE(i.read_bytes, 0)) AS read_bytes,\n"                                                                                                 \
+                      "                SUM(COALESCE(i.read_time, 0)) AS read_time,\n"                                                                                                   \
+                      "                SUM(COALESCE(i.writes, 0)) AS writes,\n"                                                                                                         \
+                      "                SUM(COALESCE(i.write_bytes, 0)) AS write_bytes,\n"                                                                                               \
+                      "                SUM(COALESCE(i.write_time, 0)) AS write_time,\n"                                                                                                 \
+                      "                SUM(COALESCE(i.writebacks, 0)) AS writebacks,\n"                                                                                                 \
+                      "                SUM(COALESCE(i.writeback_time, 0)) AS writeback_time,\n"                                                                                         \
+                      "                SUM(COALESCE(i.extends, 0)) AS extends,\n"                                                                                                       \
+                      "                SUM(COALESCE(i.extend_bytes, 0)) AS extend_bytes,\n"                                                                                             \
+                      "                SUM(COALESCE(i.extend_time, 0)) AS extend_time,\n"                                                                                               \
+                      "                SUM(COALESCE(i.hits, 0)) AS hits,\n"                                                                                                             \
+                      "                SUM(COALESCE(i.evictions, 0)) AS evictions,\n"                                                                                                   \
+                      "                SUM(COALESCE(i.reuses, 0)) AS reuses,\n"                                                                                                         \
+                      "                SUM(COALESCE(i.fsyncs, 0)) AS fsyncs,\n"                                                                                                         \
+                      "                SUM(COALESCE(i.fsync_time, 0)) AS fsync_time\n"                                                                                                  \
+                      "              FROM pg_stat_activity a,\n"                                                                                                                        \
+                      "                   pg_stat_get_backend_io(a.pid) i\n"                                                                                                            \
+                      "              WHERE a.datname IS NOT NULL\n"                                                                                                                     \
+                      "              GROUP BY a.usename, a.application_name, a.datname;\n"                                                                                              \
+                      "      version: 18\n"                                                                                                                                             \
+                      "      columns:\n"                                                                                                                                                \
+                      "        - name: usename\n"                                                                                                                                       \
+                      "          type: label\n"                                                                                                                                         \
+                      "        - name: application_name\n"                                                                                                                              \
+                      "          type: label\n"                                                                                                                                         \
+                      "        - name: datname\n"                                                                                                                                       \
+                      "          type: label\n"                                                                                                                                         \
+                      "        - name: reads\n"                                                                                                                                         \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Number of read operations.\n"                                                                                                             \
+                      "        - name: read_bytes\n"                                                                                                                                    \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Total bytes read.\n"                                                                                                                      \
+                      "        - name: read_time\n"                                                                                                                                     \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Total time spent on read operations in milliseconds.\n"                                                                                   \
+                      "        - name: writes\n"                                                                                                                                        \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Number of write operations.\n"                                                                                                            \
+                      "        - name: write_bytes\n"                                                                                                                                   \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Total bytes written.\n"                                                                                                                   \
+                      "        - name: write_time\n"                                                                                                                                    \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Total time spent on write operations in milliseconds.\n"                                                                                  \
+                      "        - name: writebacks\n"                                                                                                                                    \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Number of writeback to permanent storage requests sent to kernel.\n"                                                                      \
+                      "        - name: writeback_time\n"                                                                                                                                \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Total time spent on writeback operations in milliseconds.\n"                                                                              \
+                      "        - name: extends\n"                                                                                                                                       \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Number of relation extend operations.\n"                                                                                                  \
+                      "        - name: extend_bytes\n"                                                                                                                                  \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Total bytes extended.\n"                                                                                                                  \
+                      "        - name: extend_time\n"                                                                                                                                   \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Total time spent on relation extend operations in milliseconds.\n"                                                                        \
+                      "        - name: hits\n"                                                                                                                                          \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: The number of times a desired block was found in shared buffer.\n"                                                                        \
+                      "        - name: evictions\n"                                                                                                                                     \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: The number of times a block has been written out from shared or local buffer in order to make it available for another use.\n"            \
+                      "        - name: reuses\n"                                                                                                                                        \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: The number of times an existing buffer in a size-limited ring buffer outside of shared buffers was reused as part of an I/O operation.\n" \
+                      "        - name: fsyncs\n"                                                                                                                                        \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Number of fsync calls.\n"                                                                                                                 \
+                      "        - name: fsync_time\n"                                                                                                                                    \
+                      "          type: counter\n"                                                                                                                                       \
+                      "          description: Total time spent on fsync operations in milliseconds.\n"                                                                                  \
+                      "    tag: pg_stat_backend_io\n"                                                                                                                                   \
+                      "    sort: data\n"                                                                                                                                                \
+                      "    collector: stat_backend_io\n"                                                                                                                                \
+                      "\n"                                                                                                                                                              \
                       "# stat_database_conflicts_information()\n"                                                                                                                       \
                       "  - queries:\n"                                                                                                                                                  \
                       "    - query: SELECT datname,\n"                                                                                                                                  \


### PR DESCRIPTION
## What is added
- New metric `pg_stat_backend_io` (16 counters) using `pg_stat_get_backend_io(pid)` joined with `pg_stat_activity`, available on PostgreSQL 18+ only
- Labels: `usename`, `application_name`, `datname`
- Two new Grafana panels in the PG18 dashboard (operations and timing)
- Note: data reflects currently active backends only, statistics are not persisted after session termination

## Testing
Tested on Fedora with PostgreSQL 18. Multiple backends across different databases tracked correctly, with non-zero reads and read_time confirmed via `pgbench` after cache flush.

<img width="1904" height="732" alt="image" src="https://github.com/user-attachments/assets/163b5c05-dfdc-4204-aac9-c250fd3ccb87" />


Closes #467
