### PR TITLE
[#481] Fix environ pointer seg fault

### DIFF
--- a/src/libpgexporter/utils.c
+++ b/src/libpgexporter/utils.c
@@ -3533,11 +3533,6 @@ pgexporter_free_proc_title(void)
    {
       return;
    }
-   for (int i = 0; i < proc_title_environ_size; i++)
-   {
-      free(proc_title_environ[i]);
-   }
-   free(proc_title_environ);
    proc_title_environ = NULL;
    proc_title_environ_size = 0;
 }


### PR DESCRIPTION
pgexporter_free_proc_title() was freeing the heap copy of environ while the global environ pointer still referenced it. Any getenv() call after that point (such as from atexit handlers, i think by LLVM or ASAN injections)  would dereference freed memory, causing a segfault on shutdown.                                                                                                                           

Fix by not freeing the heap copy to remove the error- environ remains valid for the lifetime of the process and the OS reclaims the memory on exit anyway. Addresses #481 
