### PR TITLE
[#490] Fix long string truncation in value serialization

### DIFF
--- a/src/libpgexporter/value.c
+++ b/src/libpgexporter/value.c
@@ -550,27 +550,25 @@ string_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char
 {
    char* ret = NULL;
    char* str = (char*)data;
-   char buf[MISC_LENGTH];
    char* translated_string = NULL;
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
    if (str == NULL)
    {
       if (format == FORMAT_JSON || format == FORMAT_JSON_COMPACT)
       {
-         snprintf(buf, MISC_LENGTH, "null");
+         ret = pgexporter_append(ret, "null");
       }
    }
    else if (strlen(str) == 0)
    {
       if (format == FORMAT_JSON || format == FORMAT_JSON_COMPACT)
       {
-         snprintf(buf, MISC_LENGTH, "\"%s\"", str);
+         ret = pgexporter_append(ret, "\"\"");
       }
       else if (format == FORMAT_TEXT)
       {
-         snprintf(buf, MISC_LENGTH, "''");
+         ret = pgexporter_append(ret, "''");
       }
    }
    else
@@ -578,15 +576,17 @@ string_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char
       if (format == FORMAT_JSON || format == FORMAT_JSON_COMPACT)
       {
          translated_string = pgexporter_escape_string(str);
-         snprintf(buf, MISC_LENGTH, "\"%s\"", translated_string);
+         ret = pgexporter_append(ret, "\"");
+         ret = pgexporter_append(ret, translated_string);
+         ret = pgexporter_append(ret, "\"");
          free(translated_string);
       }
       else if (format == FORMAT_TEXT)
       {
-         snprintf(buf, MISC_LENGTH, "%s", str);
+         ret = pgexporter_append(ret, str);
       }
    }
-   ret = pgexporter_append(ret, buf);
+
    return ret;
 }
 


### PR DESCRIPTION
Fixes - [#490]

Long string values could be truncated in `src/libpgexporter/value.c `because string serialization used a fixed-size `MISC_LENGTH` buffer. 
This change appends string content directly so long values, including SHA512-length strings, are serialized correctly.


