### PR TITLE
Add .dockerignore for container builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Reduce Docker build context for container image builds.
+# The Dockerfiles in contrib/docker/ use COPY . . in the builder stage,
+# so only files needed by cmake and the runtime COPY are required.
+
+# Version control
+.git
+.gitignore
+
+# CI/CD
+.github
+
+# Tests (cmake skips test/ if absent)
+test
+
+# Monitoring and observability tooling
+contrib/grafana
+contrib/prometheus_scrape
+contrib/shell_comp
+contrib/views
+contrib/docker/rpm
+
+# Generated metric files (not needed for build)
+contrib/json
+contrib/yaml
+
+# Developer tools
+.clang-format
+clang-format.sh
+
+# Package specs
+pgexporter.spec
+
+# Documentation at root level
+README.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+AUTHORS
+
+# Build artifacts (if present locally)
+build
+CMakeCache.txt
+CMakeFiles
+
+# OS and editor artifacts
+.DS_Store
+*.log

--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Shashidhar B M <shashidhar.i.0119@gmail.com>
 Zeyad Daowd <zeyaddaowd@yahoo.com>
 Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
+Frank Heikens <frank@elevarq.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -37,6 +37,7 @@ Shashidhar B M <shashidhar.i.0119@gmail.com>
 Zeyad Daowd <zeyaddaowd@yahoo.com>
 Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
+Frank Heikens <frank@elevarq.com>
 ```
 
 ## Committers


### PR DESCRIPTION
The Dockerfiles in contrib/docker/ are built with the repository root as
context. Without a .dockerignore, the entire repository is sent to the Docker
daemon, including files not needed by the cmake build or the runtime image.

Add a .dockerignore that excludes version control, CI configuration, tests,
monitoring tooling, generated metric files, developer tools, and root-level
documentation.

All paths required by the build remain included:
- src/, cmake/, CMakeLists.txt (cmake build)
- doc/ (man page generation)
- extensions/ (YAML query definitions, installed by cmake)
- contrib/docker/pgexporter.conf (runtime config)

The test/ exclusion is safe because cmake already guards it:
if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test").

No change to build output or runtime behavior. Works with both Docker and Podman.