### PR TITLE
Add HEALTHCHECK to container Dockerfiles

### DIFF
--- a/contrib/docker/Dockerfile.alpine
+++ b/contrib/docker/Dockerfile.alpine
@@ -100,5 +100,7 @@ USER pgexporter
 RUN echo "pgexporter" | /usr/local/bin/pgexporter-admin master-key && \
     printf "pgexporter\npgexporter\npgexporter\n" | /usr/local/bin/pgexporter-admin -f /etc/pgexporter/pgexporter_users.conf user add
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
+    CMD pgexporter-cli -c /etc/pgexporter/pgexporter.conf ping || exit 1
 
 CMD ["/usr/local/bin/pgexporter", "-c", "/etc/pgexporter/pgexporter.conf", "-u","/etc/pgexporter/pgexporter_users.conf"]

--- a/contrib/docker/Dockerfile.rocky9
+++ b/contrib/docker/Dockerfile.rocky9
@@ -101,4 +101,7 @@ USER pgexporter
 RUN echo "pgexporter" | /usr/local/bin/pgexporter-admin master-key && \
     printf "pgexporter\npgexporter\npgexporter\n" | /usr/local/bin/pgexporter-admin -f /etc/pgexporter/pgexporter_users.conf user add
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
+    CMD pgexporter-cli -c /etc/pgexporter/pgexporter.conf ping || exit 1
+
 CMD ["/usr/local/bin/pgexporter", "-c", "/etc/pgexporter/pgexporter.conf", "-u", "/etc/pgexporter/pgexporter_users.conf"]


### PR DESCRIPTION
The container Dockerfiles in contrib/docker/ have no HEALTHCHECK instruction.
This means Docker and Podman cannot report whether the pgexporter daemon inside
the container is actually running.

Add a HEALTHCHECK using pgexporter-cli ping, which checks daemon liveness via
the Unix socket. The check runs as the pgexporter user with the container's own
configuration file.

Parameters: interval 10s, timeout 5s, start-period 5s, retries 3.

pgexporter-cli ping checks the daemon process only, not PostgreSQL backend
connectivity or metrics endpoint availability. This is intentional: the
container is healthy when its daemon is running, regardless of backend state.

No change to runtime behavior. Both Alpine and Rocky 9 variants are updated
identically.