### PR TITLE
Remove PostgreSQL server from container runtime images

### DIFF
--- a/contrib/docker/Dockerfile.alpine
+++ b/contrib/docker/Dockerfile.alpine
@@ -64,19 +64,12 @@ RUN cd build && \
 
 FROM alpine:latest
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-    echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk update && \
-    apk add --no-cache \
-    postgresql17 \
-    postgresql17-client \
+RUN apk add --no-cache \
     bash \
     ca-certificates \
     libev \
     yaml \
     bzip2 \
-    bzip2-dev \
-    libpq \
     libatomic \
     zstd \
     lz4-libs

--- a/contrib/docker/Dockerfile.rocky9
+++ b/contrib/docker/Dockerfile.rocky9
@@ -73,13 +73,15 @@ RUN cd build && \
 
 FROM rockylinux:9
 
-RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm && \
-    dnf -y update && \
-    dnf install -y postgresql17-server \
-        postgresql17-contrib \
-        libpq5 \
+RUN dnf -y update && \
+    dnf install -y \
         libev \
-        libatomic && \
+        libatomic \
+        libyaml \
+        zlib \
+        zstd \
+        lz4 \
+        bzip2 && \
     dnf clean all
 
 RUN useradd --create-home --shell /bin/bash pgexporter


### PR DESCRIPTION
pgexporter implements its own PostgreSQL wire protocol and does not depend
on libpq or any PostgreSQL packages at runtime. The runtime stages currently
install full PostgreSQL server and client packages that are never used.

Remove all PostgreSQL packages from both Alpine and Rocky 9 runtime images.
Remove the PGDG repository from Rocky 9 and the Alpine edge repositories,
which were only present for the PostgreSQL packages. Add explicit runtime
library dependencies (libyaml, zlib, zstd, lz4, bzip2) for Rocky 9 that
were previously pulled as transitive dependencies of the server package.
Remove bzip2-dev from Alpine (dev headers not needed at runtime).

Builder stages are unchanged. No change to runtime behavior.