### PR TITLE
[#515] Add per-server tls option to disable backend TLS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,5 @@ Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
 Frank Heikens <frank@elevarq.com>
 Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
+Vaibhav Bhembre <vbhembre@coreweave.com>
+

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -77,6 +77,7 @@ See a [sample](./etc/pgexporter.conf) configuration for running `pgexporter` on 
 | user | | String | Conditional | PostgreSQL | The user name. Required for `postgresql` type |
 | data_dir | | String | No | PostgreSQL | The location of the data directory |
 | wal_dir | | String | No | PostgreSQL | The location of the WAL directory |
+| tls | `try` | String | No | PostgreSQL | TLS negotiation policy for this server. `off` skips the PostgreSQL `SSLRequest` and connects without TLS. `try` sends the `SSLRequest` and upgrades if the server offers TLS, otherwise proceeds without TLS (preserves previous behavior). `on` sends the `SSLRequest` and fails the connection if the server declines; `on` also requires `tls_ca_file` to be set so the server certificate can be verified |
 | tls_cert_file | | String | No | All | Certificate file for TLS. This file must be owned by either the user running pgexporter or root. Can interpolate environment variables (e.g., `$HOME`) |
 | tls_key_file | | String | No | All | Private key file for TLS. This file must be owned by either the user running pgexporter or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. Can interpolate environment variables (e.g., `$HOME`) |
 | tls_ca_file | | String | No | All | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgexporter or root. Can interpolate environment variables (e.g., `$HOME`) |

--- a/doc/manual/en/04-configuration.md
+++ b/doc/manual/en/04-configuration.md
@@ -76,6 +76,7 @@ See a [sample][sample] configuration for running [**pgexporter**][pgexporter] on
 | user | | String | Conditional | PostgreSQL | The user name. Required for `postgresql` type |
 | data_dir | | String | No | PostgreSQL | The location of the data directory |
 | wal_dir | | String | No | PostgreSQL | The location of the WAL directory |
+| tls | `try` | String | No | PostgreSQL | TLS negotiation policy for this server. `off` skips the PostgreSQL `SSLRequest` and connects without TLS. `try` sends the `SSLRequest` and upgrades if the server offers TLS, otherwise proceeds without TLS (preserves previous behavior). `on` sends the `SSLRequest` and fails the connection if the server declines; `on` also requires `tls_ca_file` to be set so the server certificate can be verified |
 | tls_cert_file | | String | No | All | Certificate file for TLS. This file must be owned by either the user running pgexporter or root. |
 | tls_key_file | | String | No | All | Private key file for TLS. This file must be owned by either the user running pgexporter or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. |
 | tls_ca_file | | String | No | All | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgexporter or root.  |

--- a/doc/manual/en/13-tls.md
+++ b/doc/manual/en/13-tls.md
@@ -112,10 +112,16 @@ In `pgexporter.conf` add the paths to the server in question, like
 host=...
 port=...
 user=pgexporter
+tls=on
 tls_cert_file=/path/to/home/.postgresql/postgresql.crt
 tls_key_file=/path/to/home/.postgresql/postgresql.key
 tls_ca_file=/path/to/home/.postgresql/ca.crt
 ```
+
+Setting `tls=on` makes [**pgexporter**][pgexporter] require TLS for this server and fail the
+connection if the PostgreSQL server declines the `SSLRequest`. Use `tls=try` if you want the
+previous behavior of attempting TLS first and then proceeding without TLS when the server does
+not offer it.
 
 ## Server certificate
 

--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -93,6 +93,10 @@ extern "C" {
 #define SERVER_FIPS_DISABLED         0
 #define SERVER_FIPS_ENABLED          1
 
+#define SERVER_TLS_OFF               0
+#define SERVER_TLS_TRY               1
+#define SERVER_TLS_ON                2
+
 #define AUTH_SUCCESS                 0
 #define AUTH_BAD_PASSWORD            1
 #define AUTH_ERROR                   2
@@ -307,6 +311,7 @@ struct server
    int minor_version;                                      /**< The minor version of the server*/
    int number_of_databases;                                /**< The number of databases */
    int number_of_extensions;                               /**< The number of extensions */
+   int tls_mode;                                           /**< TLS negotiation mode */
    char tls_cert_file[MAX_PATH];                           /**< TLS certificate path */
    char tls_key_file[MAX_PATH];                            /**< TLS key path */
    char tls_ca_file[MAX_PATH];                             /**< TLS CA certificate path */

--- a/src/libpgexporter/configuration.c
+++ b/src/libpgexporter/configuration.c
@@ -102,6 +102,7 @@ static void add_servers_configuration_response(struct json* res);
 static int to_log_type(char* where, int value);
 static int to_log_level(char* where, int value);
 static int to_log_mode(char* where, int value);
+static int to_server_tls_mode(char* where, int value);
 static int to_hugepage(char* where, int value);
 static int to_update_process_title(char* where, int value);
 static bool pgexporter_is_binary_file(const char* path);
@@ -275,6 +276,7 @@ pgexporter_read_configuration(void* shm, char* filename)
                   srv.type = SERVER_TYPE_POSTGRESQL;
                   srv.version = SERVER_UNDERTERMINED_VERSION;
                   srv.fips_enabled = SERVER_FIPS_UNKNOWN;
+                  srv.tls_mode = SERVER_TLS_TRY;
 
                   idx_server++;
                }
@@ -627,7 +629,22 @@ pgexporter_read_configuration(void* shm, char* filename)
                   }
                   else
                   {
-                     unknown = true;
+                     if (!strcmp(value, "off"))
+                     {
+                        srv.tls_mode = SERVER_TLS_OFF;
+                     }
+                     else if (!strcmp(value, "try"))
+                     {
+                        srv.tls_mode = SERVER_TLS_TRY;
+                     }
+                     else if (!strcmp(value, "on"))
+                     {
+                        srv.tls_mode = SERVER_TLS_ON;
+                     }
+                     else
+                     {
+                        unknown = true;
+                     }
                   }
                }
                else if (!strcmp(key, "tls_ca_file"))
@@ -2279,11 +2296,39 @@ pgexporter_conf_set(SSL* ssl __attribute__((unused)), int client_fd, uint8_t com
       }
       else if (!strcmp(key, "tls"))
       {
-         if (as_bool(config_value, &config->tls))
+         if (strlen(section) > 0)
          {
-            unknown = true;
+            if (!strcmp(config_value, "off"))
+            {
+               config->servers[server_index].tls_mode = SERVER_TLS_OFF;
+            }
+            else if (!strcmp(config_value, "try"))
+            {
+               config->servers[server_index].tls_mode = SERVER_TLS_TRY;
+            }
+            else if (!strcmp(config_value, "on"))
+            {
+               config->servers[server_index].tls_mode = SERVER_TLS_ON;
+            }
+            else
+            {
+               unknown = true;
+            }
+
+            if (!unknown)
+            {
+               pgexporter_json_put_enum_value(server_j, key, config->servers[server_index].tls_mode, to_server_tls_mode);
+               pgexporter_json_put(response, config->servers[server_index].name, (uintptr_t)server_j, ValueJSON);
+            }
          }
-         pgexporter_json_put(response, key, (uintptr_t)config->tls, ValueBool);
+         else
+         {
+            if (as_bool(config_value, &config->tls))
+            {
+               unknown = true;
+            }
+            pgexporter_json_put(response, key, (uintptr_t)config->tls, ValueBool);
+         }
       }
       else if (!strcmp(key, "tls_ca_file"))
       {
@@ -2702,6 +2747,7 @@ add_servers_configuration_response(struct json* res)
 
       pgexporter_json_put(server_conf, CONFIGURATION_ARGUMENT_HOST, (uintptr_t)config->servers[i].host, ValueString);
       pgexporter_json_put(server_conf, CONFIGURATION_ARGUMENT_PORT, (uintptr_t)config->servers[i].port, ValueInt64);
+      pgexporter_json_put_enum_value(server_conf, CONFIGURATION_ARGUMENT_TLS, config->servers[i].tls_mode, to_server_tls_mode);
       pgexporter_json_put(server_conf, CONFIGURATION_ARGUMENT_TLS_CERT_FILE, (uintptr_t)config->servers[i].tls_cert_file, ValueString);
       pgexporter_json_put(server_conf, CONFIGURATION_ARGUMENT_TLS_KEY_FILE, (uintptr_t)config->servers[i].tls_key_file, ValueString);
       pgexporter_json_put(server_conf, CONFIGURATION_ARGUMENT_TLS_CA_FILE, (uintptr_t)config->servers[i].tls_ca_file, ValueString);
@@ -3832,6 +3878,7 @@ copy_server(struct server* dst, struct server* src)
    memcpy(&dst->name[0], &src->name[0], MISC_LENGTH);
    memcpy(&dst->host[0], &src->host[0], MISC_LENGTH);
    dst->port = src->port;
+   dst->tls_mode = src->tls_mode;
    memcpy(&dst->username[0], &src->username[0], MAX_USERNAME_LENGTH);
    memcpy(&dst->data[0], &src->data[0], MISC_LENGTH);
    memcpy(&dst->wal[0], &src->wal[0], MISC_LENGTH);
@@ -3897,6 +3944,8 @@ restart_string(char* name, char* e, char* n)
 static bool
 is_same_tls(struct server* src, struct server* dst)
 {
+   if (src->tls_mode != dst->tls_mode)
+      return false;
    if (strcmp(src->tls_cert_file, dst->tls_cert_file))
       return false;
    if (strcmp(src->tls_key_file, dst->tls_key_file))
@@ -4072,6 +4121,32 @@ to_log_mode(char* where, int value)
       default:
          return 1;
    }
+   return 0;
+}
+
+static int
+to_server_tls_mode(char* where, int value)
+{
+   if (!where)
+   {
+      return 1;
+   }
+
+   switch (value)
+   {
+      case SERVER_TLS_OFF:
+         snprintf(where, MISC_LENGTH, "%s", "off");
+         break;
+      case SERVER_TLS_TRY:
+         snprintf(where, MISC_LENGTH, "%s", "try");
+         break;
+      case SERVER_TLS_ON:
+         snprintf(where, MISC_LENGTH, "%s", "on");
+         break;
+      default:
+         return 1;
+   }
+
    return 0;
 }
 

--- a/src/libpgexporter/security.c
+++ b/src/libpgexporter/security.c
@@ -1053,81 +1053,97 @@ pgexporter_server_authenticate(int server, char* database, char* username, char*
       goto error;
    }
 
-   ret = pgexporter_create_ssl_message(&ssl_msg);
-   if (ret != MESSAGE_STATUS_OK)
+   if (config->servers[server].tls_mode == SERVER_TLS_ON &&
+       strlen(config->servers[server].tls_ca_file) == 0)
    {
+      pgexporter_log_error("%s: tls=on requires tls_ca_file to be set", config->servers[server].name);
       goto error;
    }
 
-   ret = pgexporter_write_message(NULL, server_fd, ssl_msg);
-   if (ret != MESSAGE_STATUS_OK)
+   if (config->servers[server].tls_mode != SERVER_TLS_OFF)
    {
-      goto error;
-   }
-
-   ret = pgexporter_read_block_message(NULL, server_fd, &msg);
-   if (ret != MESSAGE_STATUS_OK)
-   {
-      goto error;
-   }
-
-   if (msg->kind == 'S')
-   {
-      SSL_CTX* ctx = NULL;
-
-      if (pgexporter_create_ssl_ctx(true, &ctx))
+      ret = pgexporter_create_ssl_message(&ssl_msg);
+      if (ret != MESSAGE_STATUS_OK)
       {
          goto error;
       }
 
-      pgexporter_log_trace("%s: Key file @ %s", config->servers[server].name, config->servers[server].tls_key_file);
-      pgexporter_log_trace("%s: Certificate file @ %s", config->servers[server].name, config->servers[server].tls_cert_file);
-      pgexporter_log_trace("%s: CA file @ %s", config->servers[server].name, config->servers[server].tls_ca_file);
-
-      if (create_ssl_client(ctx, config->servers[server].tls_key_file, config->servers[server].tls_cert_file, config->servers[server].tls_ca_file, server_fd, &c_ssl))
+      ret = pgexporter_write_message(NULL, server_fd, ssl_msg);
+      if (ret != MESSAGE_STATUS_OK)
       {
          goto error;
       }
 
-      do
+      ret = pgexporter_read_block_message(NULL, server_fd, &msg);
+      if (ret != MESSAGE_STATUS_OK)
       {
-         connect = SSL_connect(c_ssl);
+         goto error;
+      }
 
-         if (connect != 1)
+      if (msg->kind != 'S' && config->servers[server].tls_mode == SERVER_TLS_ON)
+      {
+         pgexporter_log_error("%s: tls=on requested but server declined TLS", config->servers[server].name);
+         goto error;
+      }
+
+      if (msg->kind == 'S')
+      {
+         SSL_CTX* ctx = NULL;
+
+         if (pgexporter_create_ssl_ctx(true, &ctx))
          {
-            int err = SSL_get_error(c_ssl, connect);
-            switch (err)
-            {
-               case SSL_ERROR_ZERO_RETURN:
-               case SSL_ERROR_WANT_READ:
-               case SSL_ERROR_WANT_WRITE:
-               case SSL_ERROR_WANT_CONNECT:
-               case SSL_ERROR_WANT_ACCEPT:
-               case SSL_ERROR_WANT_X509_LOOKUP:
-#ifndef HAVE_OPENBSD
-               case SSL_ERROR_WANT_ASYNC:
-               case SSL_ERROR_WANT_ASYNC_JOB:
-               case SSL_ERROR_WANT_CLIENT_HELLO_CB:
-#endif
-                  break;
-               case SSL_ERROR_SYSCALL:
-                  pgexporter_log_error("SSL_ERROR_SYSCALL: %s (%d)", strerror(errno), server_fd);
-                  errno = 0;
-                  goto error;
-                  break;
-               case SSL_ERROR_SSL:
-                  pgexporter_log_error("SSL_ERROR_SSL: %s (%d)", strerror(errno), server_fd);
-                  pgexporter_log_error("%s", ERR_error_string(err, NULL));
-                  pgexporter_log_error("%s", ERR_lib_error_string(err));
-                  pgexporter_log_error("%s", ERR_reason_error_string(err));
-                  errno = 0;
-                  goto error;
-                  break;
-            }
-            ERR_clear_error();
+            goto error;
          }
+
+         pgexporter_log_trace("%s: Key file @ %s", config->servers[server].name, config->servers[server].tls_key_file);
+         pgexporter_log_trace("%s: Certificate file @ %s", config->servers[server].name, config->servers[server].tls_cert_file);
+         pgexporter_log_trace("%s: CA file @ %s", config->servers[server].name, config->servers[server].tls_ca_file);
+
+         if (create_ssl_client(ctx, config->servers[server].tls_key_file, config->servers[server].tls_cert_file, config->servers[server].tls_ca_file, server_fd, &c_ssl))
+         {
+            goto error;
+         }
+
+         do
+         {
+            connect = SSL_connect(c_ssl);
+
+            if (connect != 1)
+            {
+               int err = SSL_get_error(c_ssl, connect);
+               switch (err)
+               {
+                  case SSL_ERROR_ZERO_RETURN:
+                  case SSL_ERROR_WANT_READ:
+                  case SSL_ERROR_WANT_WRITE:
+                  case SSL_ERROR_WANT_CONNECT:
+                  case SSL_ERROR_WANT_ACCEPT:
+                  case SSL_ERROR_WANT_X509_LOOKUP:
+#ifndef HAVE_OPENBSD
+                  case SSL_ERROR_WANT_ASYNC:
+                  case SSL_ERROR_WANT_ASYNC_JOB:
+                  case SSL_ERROR_WANT_CLIENT_HELLO_CB:
+#endif
+                     break;
+                  case SSL_ERROR_SYSCALL:
+                     pgexporter_log_error("SSL_ERROR_SYSCALL: %s (%d)", strerror(errno), server_fd);
+                     errno = 0;
+                     goto error;
+                     break;
+                  case SSL_ERROR_SSL:
+                     pgexporter_log_error("SSL_ERROR_SSL: %s (%d)", strerror(errno), server_fd);
+                     pgexporter_log_error("%s", ERR_error_string(err, NULL));
+                     pgexporter_log_error("%s", ERR_lib_error_string(err));
+                     pgexporter_log_error("%s", ERR_reason_error_string(err));
+                     errno = 0;
+                     goto error;
+                     break;
+               }
+               ERR_clear_error();
+            }
+         }
+         while (connect != 1);
       }
-      while (connect != 1);
    }
 
    ret = pgexporter_create_startup_message(username, database, &startup_msg);

--- a/test/testcases/test_configuration.c
+++ b/test/testcases/test_configuration.c
@@ -30,7 +30,10 @@
 #include <pgexporter.h>
 #include <configuration.h>
 #include <json.h>
+#include <management.h>
+#include <network.h>
 #include <shmem.h>
+#include <tsclient.h>
 #include <tscommon.h>
 #include <utils.h>
 
@@ -242,6 +245,137 @@ test_enum_to_str(char* where, int value)
    return 0;
 }
 
+static int
+assert_server_tls_mode(char* key, char* value, int expected_mode, char* expected_string)
+{
+   int socket = -1;
+   struct json* read = NULL;
+   struct json* outcome = NULL;
+   struct json* response = NULL;
+   struct json* server = NULL;
+   struct json* tls = NULL;
+
+   socket = pgexporter_tsclient_get_connection();
+   if (!pgexporter_socket_isvalid(socket))
+   {
+      goto fail;
+   }
+
+   if (pgexporter_management_request_conf_set(NULL, socket, key, value,
+                                              MANAGEMENT_COMPRESSION_NONE, MANAGEMENT_ENCRYPTION_NONE,
+                                              MANAGEMENT_OUTPUT_FORMAT_JSON) != 0)
+   {
+      goto fail;
+   }
+
+   if (pgexporter_management_read_json(NULL, socket, NULL, NULL, &read) != 0)
+   {
+      goto fail;
+   }
+
+   outcome = (struct json*)pgexporter_json_get(read, MANAGEMENT_CATEGORY_OUTCOME);
+   if (!(bool)pgexporter_json_get(outcome, MANAGEMENT_ARGUMENT_STATUS))
+   {
+      goto fail;
+   }
+
+   response = (struct json*)pgexporter_json_get(read, MANAGEMENT_CATEGORY_RESPONSE);
+   server = (struct json*)pgexporter_json_get(response, "primary");
+   if (server == NULL)
+   {
+      goto fail;
+   }
+
+   tls = (struct json*)pgexporter_json_get(server, CONFIGURATION_ARGUMENT_TLS);
+   if (tls == NULL)
+   {
+      goto fail;
+   }
+
+   if ((int)pgexporter_json_get(tls, "value") != expected_mode)
+   {
+      goto fail;
+   }
+
+   if (strcmp((char*)pgexporter_json_get(tls, "string_value"), expected_string))
+   {
+      goto fail;
+   }
+
+   pgexporter_json_destroy(read);
+   pgexporter_disconnect(socket);
+   socket = -1;
+   read = NULL;
+
+   socket = pgexporter_tsclient_get_connection();
+   if (!pgexporter_socket_isvalid(socket))
+   {
+      goto fail;
+   }
+
+   if (pgexporter_management_request_conf_get(NULL, socket,
+                                              MANAGEMENT_COMPRESSION_NONE, MANAGEMENT_ENCRYPTION_NONE,
+                                              MANAGEMENT_OUTPUT_FORMAT_JSON) != 0)
+   {
+      goto fail;
+   }
+
+   if (pgexporter_management_read_json(NULL, socket, NULL, NULL, &read) != 0)
+   {
+      goto fail;
+   }
+
+   outcome = (struct json*)pgexporter_json_get(read, MANAGEMENT_CATEGORY_OUTCOME);
+   if (!(bool)pgexporter_json_get(outcome, MANAGEMENT_ARGUMENT_STATUS))
+   {
+      goto fail;
+   }
+
+   response = (struct json*)pgexporter_json_get(read, MANAGEMENT_CATEGORY_RESPONSE);
+   response = (struct json*)pgexporter_json_get(response, "server");
+   if (response == NULL)
+   {
+      goto fail;
+   }
+
+   server = (struct json*)pgexporter_json_get(response, "primary");
+   if (server == NULL)
+   {
+      goto fail;
+   }
+
+   tls = (struct json*)pgexporter_json_get(server, CONFIGURATION_ARGUMENT_TLS);
+   if (tls == NULL)
+   {
+      goto fail;
+   }
+
+   if ((int)pgexporter_json_get(tls, "value") != expected_mode)
+   {
+      goto fail;
+   }
+
+   if (strcmp((char*)pgexporter_json_get(tls, "string_value"), expected_string))
+   {
+      goto fail;
+   }
+
+   pgexporter_json_destroy(read);
+   pgexporter_disconnect(socket);
+   return 0;
+
+fail:
+   if (read)
+   {
+      pgexporter_json_destroy(read);
+   }
+   if (socket >= 0)
+   {
+      pgexporter_disconnect(socket);
+   }
+   return -1;
+}
+
 MCTF_TEST(test_configuration_json_put_enum_value)
 {
    struct json* res = NULL;
@@ -260,6 +394,40 @@ MCTF_TEST(test_configuration_json_put_enum_value)
 
 cleanup:
    pgexporter_json_destroy(res);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_configuration_server_tls_mode_roundtrip)
+{
+   pgexporter_test_setup();
+   pgexporter_test_config_save();
+
+   MCTF_ASSERT(assert_server_tls_mode("primary.tls", "off", SERVER_TLS_OFF, "off") == 0,
+               cleanup, "server tls mode roundtrip failed for off");
+   MCTF_ASSERT(assert_server_tls_mode("primary.tls", "try", SERVER_TLS_TRY, "try") == 0,
+               cleanup, "server tls mode roundtrip failed for try");
+   MCTF_ASSERT(assert_server_tls_mode("primary.tls", "on", SERVER_TLS_ON, "on") == 0,
+               cleanup, "server tls mode roundtrip failed for on");
+
+cleanup:
+   /* pgexporter_test_config_restore only reverts the test's local shmem copy; the daemon's
+    * in-memory config is unaffected by that call. Push the default back over the management
+    * API so subsequent tests don't inherit tls_mode=on (which would fail auth without a CA). */
+   (void)assert_server_tls_mode("primary.tls", "try", SERVER_TLS_TRY, "try");
+   pgexporter_test_config_restore();
+   pgexporter_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST_NEGATIVE(test_configuration_server_tls_mode_reject_invalid)
+{
+   pgexporter_test_setup();
+
+   MCTF_ASSERT(pgexporter_test_assert_conf_set_fail("primary.tls", "invalid") == 0,
+               cleanup, "expected server tls mode to reject invalid value");
+
+cleanup:
+   pgexporter_test_teardown();
    MCTF_FINISH();
 }
 


### PR DESCRIPTION
## Summary

Fixes #515. Adds an explicit per-server `tls` option (default `true`) so that `pgexporter` can connect to a PostgreSQL backend without negotiating TLS.

Before this change, `pgexporter_server_authenticate()` unconditionally sent the PostgreSQL `SSLRequest` packet and upgraded the connection whenever the server responded with `'S'`, and a `tls = off` line under a server section was silently logged as `Unknown`. Operators had no way to opt out of backend TLS which is painful when the server advertises SSL but the deployment doesn't require it, and when bugs in the SSL path (e.g. double-free on reconnect after a TCP reset) need to be worked around while they're being investigated upstream.

## Default behavior

Default is `tls = on`, so existing deployments are unaffected. Every backend still gets an `SSLRequest` and upgrades to TLS when the server advertises it. Operators explicitly add `tls = off` to opt out.