### PR TITLE
[#517] Cross-port ART prefix search

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Zeyad Daowd <zeyaddaowd@yahoo.com>
 Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
 Frank Heikens <frank@elevarq.com>
+Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -38,6 +38,7 @@ Zeyad Daowd <zeyaddaowd@yahoo.com>
 Ahmed Mordi <ahmed.m.hamada2003@gmail.com>
 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
 Frank Heikens <frank@elevarq.com>
+Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 ```
 
 ## Committers

--- a/src/include/art.h
+++ b/src/include/art.h
@@ -105,6 +105,17 @@ bool
 pgexporter_art_contains_key(struct art* t, char* key);
 
 /**
+ * Prefix search for a string in the ART tree
+ * @param t The tree
+ * @param prefix The prefix to search for
+ * @param matches [out] Array of matching strings
+ * @param max_matches Maximum number of matches to return
+ * @return Number of matches (-1 on error)
+ */
+int
+pgexporter_art_prefix_search(struct art* t, char* prefix, char*** matches, int max_matches);
+
+/**
  * Searches for a value in the ART tree
  * @param t The tree
  * @param key The key

--- a/src/libpgexporter/art.c
+++ b/src/libpgexporter/art.c
@@ -368,6 +368,107 @@ pgexporter_art_contains_key(struct art* t, char* key)
    return val != NULL;
 }
 
+struct prefix_search_state
+{
+   char*** matches;
+   int max_matches;
+   int current_count;
+   uint32_t key_len;
+   char* prefix;
+};
+
+static int
+prefix_search_cb(void* param, const char* key, struct value* value)
+{
+   struct prefix_search_state* state = (struct prefix_search_state*)param;
+   (void)value;
+
+   if (state->current_count >= state->max_matches)
+   {
+      return 1;
+   }
+
+   (*state->matches)[state->current_count] = pgexporter_append(NULL, (char*)key);
+   state->current_count++;
+
+   return 0;
+}
+
+int
+pgexporter_art_prefix_search(struct art* t, char* prefix, char*** matches, int max_matches)
+{
+   struct art_node* node = NULL;
+   struct art_node** child = NULL;
+   uint32_t depth = 0;
+   uint32_t key_len = 0;
+   unsigned char* key = (unsigned char*)prefix;
+   struct prefix_search_state state;
+   struct art_leaf* min_leaf = NULL;
+
+   if (t == NULL || t->root == NULL || matches == NULL || max_matches <= 0)
+   {
+      return -1;
+   }
+
+   *matches = malloc((max_matches + 1) * sizeof(char*));
+   if (*matches == NULL)
+   {
+      return -1;
+   }
+   memset(*matches, 0, (max_matches + 1) * sizeof(char*));
+
+   state.matches = matches;
+   state.max_matches = max_matches;
+   state.current_count = 0;
+   state.prefix = prefix;
+
+   if (prefix == NULL || strlen(prefix) == 0)
+   {
+      art_node_iterate(t->root, prefix_search_cb, &state);
+      return state.current_count;
+   }
+
+   key_len = strlen(prefix);
+   state.key_len = key_len;
+   node = t->root;
+
+   while (node != NULL)
+   {
+      if (IS_LEAF(node))
+      {
+         struct art_leaf* leaf = GET_LEAF(node);
+         if (leaf->key_len >= key_len && strncmp((char*)leaf->key, prefix, key_len) == 0)
+         {
+            prefix_search_cb(&state, (char*)leaf->key, leaf->value);
+         }
+         return state.current_count;
+      }
+
+      uint32_t cpl = check_prefix_partial(node, key, depth, key_len);
+      if (cpl < min(node->prefix_len, MAX_PREFIX_LEN) && depth + cpl < key_len)
+      {
+         return state.current_count;
+      }
+
+      depth += node->prefix_len;
+      if (depth >= key_len)
+      {
+         min_leaf = node_get_minimum(node);
+         if (min_leaf != NULL && min_leaf->key_len >= key_len && strncmp((char*)min_leaf->key, prefix, key_len) == 0)
+         {
+            art_node_iterate(node, prefix_search_cb, &state);
+         }
+         return state.current_count;
+      }
+
+      child = node_get_child(node, key[depth]);
+      node = child != NULL ? *child : NULL;
+      depth++;
+   }
+
+   return state.current_count;
+}
+
 int
 pgexporter_art_insert(struct art* t, char* key, uintptr_t value, enum value_type type)
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TESTCASE_FILES
   testcases/test_aes.c
   testcases/test_http.c
   testcases/test_alert.c
+  testcases/test_art.c
 )
 set(SOURCE_FILES ${LIB_SOURCE_FILES} ${TESTCASE_FILES} ${HEADER_FILES})
 

--- a/test/testcases/test_art.c
+++ b/test/testcases/test_art.c
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <pgexporter.h>
+#include <art.h>
+#include <value.h>
+
+#include <mctf.h>
+#include <stdlib.h>
+#include <string.h>
+
+MCTF_TEST(test_art_prefix_search)
+{
+   struct art* t = NULL;
+   char** matches = NULL;
+   int count = 0;
+
+   pgexporter_art_create(&t);
+   MCTF_ASSERT_PTR_NONNULL(t, cleanup, "ART creation failed");
+
+   MCTF_ASSERT(!pgexporter_art_insert(t, "apple", 1, ValueInt32), cleanup, "Insert apple failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "applet", 2, ValueInt32), cleanup, "Insert applet failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "apply", 3, ValueInt32), cleanup, "Insert apply failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "ball", 4, ValueInt32), cleanup, "Insert ball failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "bat", 5, ValueInt32), cleanup, "Insert bat failed");
+
+   count = pgexporter_art_prefix_search(t, "app", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 3, cleanup, "Prefix search 'app' should return 3 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "apple", cleanup, "First match mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "applet", cleanup, "Second match mismatch");
+   MCTF_ASSERT_STR_EQ(matches[2], "apply", cleanup, "Third match mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgexporter_art_prefix_search(t, "cat", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 0, cleanup, "Prefix search 'cat' should return 0 matches");
+   free(matches);
+   matches = NULL;
+
+   count = pgexporter_art_prefix_search(t, "apple", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "Prefix search 'apple' should return 2 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "apple", cleanup, "First match mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "applet", cleanup, "Second match mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgexporter_art_prefix_search(t, "", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 5, cleanup, "Empty prefix should return all matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "apple", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "applet", cleanup, "Match 1 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[2], "apply", cleanup, "Match 2 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[3], "ball", cleanup, "Match 3 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[4], "bat", cleanup, "Match 4 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgexporter_art_prefix_search(t, "app", &matches, 2);
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "Max matches should limit results to 2");
+   MCTF_ASSERT_STR_EQ(matches[0], "apple", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "applet", cleanup, "Match 1 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgexporter_art_prefix_search(t, "applet", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 1, cleanup, "Prefix search 'applet' should return exactly 1 match");
+   MCTF_ASSERT_STR_EQ(matches[0], "applet", cleanup, "Exact match mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   MCTF_ASSERT(!pgexporter_art_delete(t, "applet"), cleanup, "Delete applet failed");
+   count = pgexporter_art_prefix_search(t, "app", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "Prefix search 'app' after delete should return 2 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "apple", cleanup, "Match 0 mismatch after delete");
+   MCTF_ASSERT_STR_EQ(matches[1], "apply", cleanup, "Match 1 mismatch after delete");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgexporter_art_prefix_search(NULL, "app", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, -1, cleanup, "Prefix search with NULL tree should return -1");
+
+   count = pgexporter_art_prefix_search(t, "app", NULL, 10);
+   MCTF_ASSERT_INT_EQ(count, -1, cleanup, "Prefix search with NULL matches pointer should return -1");
+
+   count = pgexporter_art_prefix_search(t, "app", &matches, 0);
+   MCTF_ASSERT_INT_EQ(count, -1, cleanup, "Prefix search with 0 max_matches should return -1");
+
+cleanup:
+   if (matches)
+   {
+      for (int i = 0; i < count; i++)
+      {
+         free(matches[i]);
+      }
+      free(matches);
+   }
+   pgexporter_art_destroy(t);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_art_prefix_search_nested)
+{
+   struct art* t = NULL;
+   char** matches = NULL;
+   int count = 0;
+
+   pgexporter_art_create(&t);
+   MCTF_ASSERT_PTR_NONNULL(t, cleanup, "ART creation failed");
+
+   MCTF_ASSERT(!pgexporter_art_insert(t, "api.foo.bar", 1, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "api.foo.baz", 2, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "api.foe.fum", 3, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "abc.123.456", 4, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "api.foo", 5, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "api", 6, ValueInt32), cleanup, "Insert failed");
+
+   count = pgexporter_art_prefix_search(t, "api", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 5, cleanup, "Prefix 'api' should return 5 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "api", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "api.foe.fum", cleanup, "Match 1 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[2], "api.foo", cleanup, "Match 2 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[3], "api.foo.bar", cleanup, "Match 3 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[4], "api.foo.baz", cleanup, "Match 4 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgexporter_art_prefix_search(t, "a", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 6, cleanup, "Prefix 'a' should return 6 matches");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgexporter_art_prefix_search(t, "b", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 0, cleanup, "Prefix 'b' should return 0 matches");
+   free(matches);
+   matches = NULL;
+
+   count = pgexporter_art_prefix_search(t, "api.", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 4, cleanup, "Prefix 'api.' should return 4 matches");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgexporter_art_prefix_search(t, "api.foo.ba", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "Prefix 'api.foo.ba' should return 2 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "api.foo.bar", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "api.foo.baz", cleanup, "Match 1 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgexporter_art_prefix_search(t, "api.end", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 0, cleanup, "Prefix 'api.end' should return 0 matches");
+   free(matches);
+   matches = NULL;
+
+cleanup:
+   if (matches)
+   {
+      for (int i = 0; i < count; i++)
+      {
+         free(matches[i]);
+      }
+      free(matches);
+   }
+   pgexporter_art_destroy(t);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_art_prefix_search_long_prefix)
+{
+   struct art* t = NULL;
+   char** matches = NULL;
+   int count = 0;
+
+   pgexporter_art_create(&t);
+   MCTF_ASSERT_PTR_NONNULL(t, cleanup, "ART creation failed");
+
+   MCTF_ASSERT(!pgexporter_art_insert(t, "this:key:has:a:long:prefix:3", 3, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "this:key:has:a:long:common:prefix:2", 2, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "this:key:has:a:long:common:prefix:1", 1, ValueInt32), cleanup, "Insert failed");
+
+   count = pgexporter_art_prefix_search(t, "this:key:has", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 3, cleanup, "Prefix 'this:key:has' should return 3 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "this:key:has:a:long:common:prefix:1", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "this:key:has:a:long:common:prefix:2", cleanup, "Match 1 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[2], "this:key:has:a:long:prefix:3", cleanup, "Match 2 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+cleanup:
+   if (matches)
+   {
+      for (int i = 0; i < count; i++)
+      {
+         free(matches[i]);
+      }
+      free(matches);
+   }
+   pgexporter_art_destroy(t);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_art_prefix_search_max_prefix_len)
+{
+   struct art* t = NULL;
+   char** matches = NULL;
+   int count = 0;
+
+   pgexporter_art_create(&t);
+   MCTF_ASSERT_PTR_NONNULL(t, cleanup, "ART creation failed");
+
+   MCTF_ASSERT(!pgexporter_art_insert(t, "foobarbaz1-test1-foo", 1, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "foobarbaz1-test1-bar", 2, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgexporter_art_insert(t, "foobarbaz1-test2-foo", 3, ValueInt32), cleanup, "Insert failed");
+
+   count = pgexporter_art_prefix_search(t, "foobarbaz1-test1", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "Prefix 'foobarbaz1-test1' should return 2 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "foobarbaz1-test1-bar", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "foobarbaz1-test1-foo", cleanup, "Match 1 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+cleanup:
+   if (matches)
+   {
+      for (int i = 0; i < count; i++)
+      {
+         free(matches[i]);
+      }
+      free(matches);
+   }
+   pgexporter_art_destroy(t);
+   MCTF_FINISH();
+}


### PR DESCRIPTION
Cross-port the ART prefix search functionality alongside its associated unit tests.
Closes #517.