### PR TITLE
[#527 ] Handle ErrorResponse during SCRAM authentication

### DIFF
--- a/src/libpgexporter/security.c
+++ b/src/libpgexporter/security.c
@@ -488,6 +488,10 @@ pgexporter_remote_management_scram_sha256(char* username, char* password, int se
    }
 
    sasl_continue = pgexporter_copy_message(msg);
+   if (((char*)sasl_continue->data)[0] == 'E')
+   {
+      goto error;
+   }
 
    get_scram_attribute('r', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &combined_nounce);
    get_scram_attribute('s', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &base64_salt);
@@ -878,6 +882,10 @@ retry:
    }
 
    sasl_continue = pgexporter_copy_message(msg);
+   if (((char*)sasl_continue->data)[0] == 'E')
+   {
+      goto error;
+   }
 
    pgexporter_free_message(msg);
    msg = NULL;
@@ -1550,6 +1558,10 @@ server_scram256(char* username, char* password, SSL* ssl, int server_fd)
    }
 
    sasl_continue = pgexporter_copy_message(msg);
+   if (((char*)sasl_continue->data)[0] == 'E')
+   {
+      goto error;
+   }
 
    security_lengths[auth_index] = sasl_continue->length;
    memcpy(&security_messages[auth_index], sasl_continue->data, sasl_continue->length);


### PR DESCRIPTION
fixed #527 Avoid parsing SCRAM attributes when server returns 'E', which could lead to NULL values (e.g. base64_salt) and segfaults.