### PR TITLE
feat: add streaming callbacks to HTTP layer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,5 @@ Frank Heikens <frank@elevarq.com>
 Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 Vaibhav Bhembre <vbhembre@coreweave.com>
 Ameen Sakr <ameensakr623@gmail.com>
+
+Som Shegokar <akashshegokar2186@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -67,3 +67,5 @@ Please, consult our [Code of Conduct][conduct] policies for interacting in our
 community.
 
 Consider giving the project a [star][star] on [GitHub][pgexporter] if you find it useful.
+
+* Som Shegokar

--- a/src/include/http.h
+++ b/src/include/http.h
@@ -70,9 +70,11 @@ struct http_payload
  */
 struct http_request
 {
-   struct http_payload payload; /**< Request payload */
-   int method;                  /**< HTTP method */
-   char* path;                  /**< Request path */
+   struct http_payload payload;                                  /**< Request payload */
+   int method;                                                   /**< HTTP method */
+   char* path;                                                   /**< Request path */
+   size_t (*read_cb)(void* buffer, size_t size, void* userdata); /**< Read callback for streaming upload */
+   void* read_userdata;                                          /**< User data for read callback */
 };
 
 /** @struct http_response
@@ -80,8 +82,10 @@ struct http_request
  */
 struct http_response
 {
-   struct http_payload payload; /**< Response payload */
-   int status_code;             /**< HTTP status code */
+   struct http_payload payload;                                   /**< Response payload */
+   int status_code;                                               /**< HTTP status code */
+   size_t (*write_cb)(void* buffer, size_t size, void* userdata); /**< Write callback for streaming download */
+   void* write_userdata;                                          /**< User data for write callback */
 };
 
 /** @struct http

--- a/src/libpgexporter/http.c
+++ b/src/libpgexporter/http.c
@@ -377,15 +377,24 @@ pgexporter_http_invoke(struct http* connection, struct http_request* request, st
       goto error;
    }
 
+   bool response_owned = false;
    pgexporter_log_trace("Invoking HTTP request");
 
-   http_response = (struct http_response*)malloc(sizeof(struct http_response));
-   if (http_response == NULL)
+   if (*response != NULL)
    {
-      pgexporter_log_error("Failed to allocate HTTP response structure");
-      goto error;
+      http_response = *response;
    }
-   memset(http_response, 0, sizeof(struct http_response));
+   else
+   {
+      http_response = (struct http_response*)malloc(sizeof(struct http_response));
+      if (http_response == NULL)
+      {
+         pgexporter_log_error("Failed to allocate HTTP response structure");
+         goto error;
+      }
+      memset(http_response, 0, sizeof(struct http_response));
+      response_owned = true;
+   }
 
    if (http_build_request(connection, request, &full_request, &full_request_size))
    {
@@ -405,6 +414,30 @@ pgexporter_http_invoke(struct http* connection, struct http_request* request, st
    msg_request->length = full_request_size;
 
    error = 0;
+   if (request->read_cb != NULL)
+   {
+      char stream_buffer[8192];
+      struct message stream_msg;
+      ssize_t n;
+
+      memset(&stream_msg, 0, sizeof(struct message));
+      if (pgexporter_write_message(connection->ssl, connection->socket, msg_request) != MESSAGE_STATUS_OK)
+      {
+         pgexporter_log_error("Failed to send HTTP headers for streaming request");
+         goto error;
+      }
+      while ((n = (ssize_t)request->read_cb(stream_buffer, sizeof(stream_buffer), request->read_userdata)) > 0)
+      {
+         stream_msg.data = stream_buffer;
+         stream_msg.length = n;
+         if (pgexporter_write_message(connection->ssl, connection->socket, &stream_msg) != MESSAGE_STATUS_OK)
+         {
+            pgexporter_log_error("Failed to stream HTTP request body");
+            goto error;
+         }
+      }
+      goto response;
+   }
 req:
    if (error < 5)
    {
@@ -422,6 +455,7 @@ req:
       goto error;
    }
 
+response:
    status = http_read_response_header(connection->ssl, connection->socket, &header_text, http_response);
    if (status != MESSAGE_STATUS_OK)
    {
@@ -453,7 +487,7 @@ error:
    free(full_request);
    free(header_text);
    free(msg_request);
-   if (http_response != NULL)
+   if (http_response != NULL && response_owned)
    {
       pgexporter_http_response_destroy(http_response);
    }
@@ -705,9 +739,17 @@ http_read_chunked_body(SSL* ssl, int socket, struct http_response* http_response
          if (bytes_read <= 0)
             goto error;
 
-         buffer[bytes_read] = '\0';
-         http_response->payload.data = pgexporter_append(http_response->payload.data, buffer);
-         http_response->payload.data_size += bytes_read;
+         if (http_response->write_cb != NULL)
+         {
+            if (http_response->write_cb(buffer, bytes_read, http_response->write_userdata) != (size_t)bytes_read)
+               goto error;
+         }
+         else
+         {
+            buffer[bytes_read] = '\0';
+            http_response->payload.data = pgexporter_append(http_response->payload.data, buffer);
+            http_response->payload.data_size += bytes_read;
+         }
          chunk_read += bytes_read;
       }
       // the chunk size must match
@@ -754,7 +796,30 @@ http_read_content_length_body(SSL* ssl, int socket, struct http_response* http_r
 {
    char buffer[8192];
    ssize_t bytes_read;
-   size_t remaining = content_length - http_response->payload.data_size;
+   char* prefetched = (char*)http_response->payload.data;
+   size_t prefetched_size = http_response->payload.data_size;
+   size_t remaining;
+
+   if (prefetched_size > content_length)
+   {
+      goto error;
+   }
+
+   if (http_response->write_cb != NULL && prefetched_size > 0)
+   {
+      if (http_response->write_cb(prefetched, prefetched_size, http_response->write_userdata) != prefetched_size)
+      {
+         free(prefetched);
+         http_response->payload.data = NULL;
+         http_response->payload.data_size = 0;
+         goto error;
+      }
+      free(prefetched);
+      http_response->payload.data = NULL;
+      http_response->payload.data_size = 0;
+   }
+
+   remaining = content_length - prefetched_size;
 
    while (remaining > 0)
    {
@@ -764,9 +829,17 @@ http_read_content_length_body(SSL* ssl, int socket, struct http_response* http_r
       if (bytes_read <= 0)
          goto error;
 
-      buffer[bytes_read] = '\0';
-      http_response->payload.data = pgexporter_append(http_response->payload.data, buffer);
-      http_response->payload.data_size += bytes_read;
+      if (http_response->write_cb != NULL)
+      {
+         if (http_response->write_cb(buffer, bytes_read, http_response->write_userdata) != (size_t)bytes_read)
+            goto error;
+      }
+      else
+      {
+         buffer[bytes_read] = '\0';
+         http_response->payload.data = pgexporter_append(http_response->payload.data, buffer);
+         http_response->payload.data_size += bytes_read;
+      }
       remaining -= bytes_read;
    }
 
@@ -780,6 +853,20 @@ http_read_EOF_body(SSL* ssl, int socket, struct http_response* http_response)
    char buffer[8192];
    ssize_t bytes_read;
 
+   if (http_response->write_cb != NULL && http_response->payload.data_size > 0)
+   {
+      if (http_response->write_cb(http_response->payload.data, http_response->payload.data_size, http_response->write_userdata) != http_response->payload.data_size)
+      {
+         free(http_response->payload.data);
+         http_response->payload.data = NULL;
+         http_response->payload.data_size = 0;
+         goto error;
+      }
+      free(http_response->payload.data);
+      http_response->payload.data = NULL;
+      http_response->payload.data_size = 0;
+   }
+
    while (1)
    {
       size_t to_read = sizeof(buffer) - 1;
@@ -790,9 +877,17 @@ http_read_EOF_body(SSL* ssl, int socket, struct http_response* http_response)
       if (bytes_read == 0)
          break;
 
-      buffer[bytes_read] = '\0';
-      http_response->payload.data = pgexporter_append(http_response->payload.data, buffer);
-      http_response->payload.data_size += bytes_read;
+      if (http_response->write_cb != NULL)
+      {
+         if (http_response->write_cb(buffer, bytes_read, http_response->write_userdata) != (size_t)bytes_read)
+            goto error;
+      }
+      else
+      {
+         buffer[bytes_read] = '\0';
+         http_response->payload.data = pgexporter_append(http_response->payload.data, buffer);
+         http_response->payload.data_size += bytes_read;
+      }
    }
 
    return MESSAGE_STATUS_OK;
@@ -953,10 +1048,13 @@ http_build_request(struct http* connection, struct http_request* request, char**
 
    headers = pgexporter_append(headers, "Connection: close\r\n");
 
-   sprintf(content_length, "%zu", request->payload.data_size);
-   headers = pgexporter_append(headers, "Content-Length: ");
-   headers = pgexporter_append(headers, content_length);
-   headers = pgexporter_append(headers, "\r\n");
+   if (request->read_cb == NULL)
+   {
+      sprintf(content_length, "%zu", request->payload.data_size);
+      headers = pgexporter_append(headers, "Content-Length: ");
+      headers = pgexporter_append(headers, content_length);
+      headers = pgexporter_append(headers, "\r\n");
+   }
 
    if (request->payload.headers != NULL && !pgexporter_deque_empty(request->payload.headers))
    {
@@ -977,7 +1075,7 @@ http_build_request(struct http* connection, struct http_request* request, char**
    headers = pgexporter_append(headers, "\r\n");
 
    header_len = strlen(request_line) + strlen(headers);
-   total_len = header_len + request->payload.data_size;
+   total_len = header_len + (request->read_cb == NULL ? request->payload.data_size : 0);
 
    *full_request = malloc(total_len + 1);
    if (*full_request == NULL)
@@ -989,7 +1087,7 @@ http_build_request(struct http* connection, struct http_request* request, char**
    memcpy(*full_request, request_line, strlen(request_line));
    memcpy(*full_request + strlen(request_line), headers, strlen(headers));
 
-   if (request->payload.data_size > 0)
+   if (request->read_cb == NULL && request->payload.data_size > 0)
    {
       memcpy(*full_request + header_len, request->payload.data, request->payload.data_size);
    }

--- a/test/testcases/test_http.c
+++ b/test/testcases/test_http.c
@@ -39,9 +39,16 @@
 #include <utils.h>
 
 #include <mctf.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
 
 static int validate_metrics_response(char* response_body, const char* metric_pattern);
 
@@ -328,6 +335,257 @@ cleanup:
    if (connection)
       pgexporter_http_destroy(connection);
    pgexporter_test_teardown();
+   MCTF_FINISH();
+}
+
+struct echo_server
+{
+   int socket_fd;
+   int port;
+   pthread_t thread;
+   bool running;
+   char* response;
+   size_t response_len;
+};
+
+struct write_cb_context
+{
+   char data[64];
+   size_t data_size;
+};
+
+static struct echo_server* test_server = NULL;
+
+static size_t
+collect_write_cb(void* buffer, size_t size, void* userdata)
+{
+   struct write_cb_context* context = (struct write_cb_context*)userdata;
+
+   if (context == NULL || context->data_size + size > sizeof(context->data))
+   {
+      return 0;
+   }
+
+   memcpy(context->data + context->data_size, buffer, size);
+   context->data_size += size;
+
+   return size;
+}
+
+static void*
+echo_server_thread(void* arg)
+{
+   struct echo_server* server = (struct echo_server*)arg;
+
+   while (server->running)
+   {
+      fd_set read_fds;
+      struct timeval timeout;
+
+      FD_ZERO(&read_fds);
+      FD_SET(server->socket_fd, &read_fds);
+
+      timeout.tv_sec = 1;
+      timeout.tv_usec = 0;
+
+      int result = select(server->socket_fd + 1, &read_fds, NULL, NULL, &timeout);
+
+      if (result <= 0)
+      {
+         continue;
+      }
+
+      if (FD_ISSET(server->socket_fd, &read_fds))
+      {
+         struct sockaddr_in client_addr;
+         socklen_t client_len = sizeof(client_addr);
+         int client_fd = accept(server->socket_fd, (struct sockaddr*)&client_addr, &client_len);
+
+         if (client_fd < 0)
+         {
+            continue;
+         }
+
+         char buffer[4096];
+         ssize_t bytes_read = recv(client_fd, buffer, sizeof(buffer) - 1, 0);
+
+         if (bytes_read > 0)
+         {
+            send(client_fd, server->response, server->response_len, 0);
+         }
+
+         close(client_fd);
+      }
+   }
+
+   return NULL;
+}
+
+static int
+start_echo_server(int port, char* response)
+{
+   struct sockaddr_in addr;
+
+   test_server = malloc(sizeof(struct echo_server));
+   if (test_server == NULL)
+   {
+      return 1;
+   }
+
+   test_server->port = port;
+   test_server->running = false;
+   test_server->response = response;
+   test_server->response_len = strlen(response);
+
+   test_server->socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+   if (test_server->socket_fd < 0)
+   {
+      free(test_server);
+      test_server = NULL;
+      return 1;
+   }
+
+   int opt = 1;
+   setsockopt(test_server->socket_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+   memset(&addr, 0, sizeof(addr));
+   addr.sin_family = AF_INET;
+   addr.sin_addr.s_addr = INADDR_ANY;
+   addr.sin_port = htons(port);
+
+   if (bind(test_server->socket_fd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
+   {
+      close(test_server->socket_fd);
+      free(test_server);
+      test_server = NULL;
+      return 1;
+   }
+
+   if (listen(test_server->socket_fd, 5) < 0)
+   {
+      close(test_server->socket_fd);
+      free(test_server);
+      test_server = NULL;
+      return 1;
+   }
+
+   test_server->running = true;
+
+   if (pthread_create(&test_server->thread, NULL, echo_server_thread, test_server) != 0)
+   {
+      test_server->running = false;
+      close(test_server->socket_fd);
+      free(test_server);
+      test_server = NULL;
+      return 1;
+   }
+
+   usleep(100000);
+
+   return 0;
+}
+
+static void
+stop_echo_server(void)
+{
+   if (test_server == NULL)
+   {
+      return;
+   }
+
+   test_server->running = false;
+   usleep(1100000);
+
+   if (test_server->socket_fd >= 0)
+   {
+      close(test_server->socket_fd);
+   }
+
+   pthread_detach(test_server->thread);
+   free(test_server);
+   test_server = NULL;
+}
+
+MCTF_TEST(test_http_write_cb_content_length)
+{
+   int status;
+   struct http* connection = NULL;
+   struct http_request* request = NULL;
+   struct http_response* response = NULL;
+   struct write_cb_context write_context = {0};
+
+   char* response_text =
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Length: 13\r\n"
+      "\r\n"
+      "Hello, World!";
+
+   MCTF_ASSERT(start_echo_server(9999, response_text) == 0, cleanup, "failed to start echo server");
+
+   response = calloc(1, sizeof(struct http_response));
+   MCTF_ASSERT_PTR_NONNULL(response, cleanup, "failed to allocate response");
+
+   response->write_cb = collect_write_cb;
+   response->write_userdata = &write_context;
+
+   MCTF_ASSERT(pgexporter_http_create("localhost", 9999, false, &connection) == 0, cleanup, "failed to establish connection");
+   MCTF_ASSERT(pgexporter_http_request_create(PGEXPORTER_HTTP_GET, "/test", &request) == 0, cleanup, "failed to create request");
+
+   status = pgexporter_http_invoke(connection, request, &response);
+   MCTF_ASSERT(status == PGEXPORTER_HTTP_STATUS_OK, cleanup, "HTTP request failed");
+   MCTF_ASSERT(write_context.data_size == 13, cleanup, "write_cb should receive content-length body");
+   MCTF_ASSERT(strcmp(write_context.data, "Hello, World!") == 0, cleanup, "write_cb content-length body mismatch");
+   MCTF_ASSERT(response->payload.data_size == 0, cleanup, "write_cb should prevent buffering in payload");
+
+cleanup:
+   pgexporter_http_request_destroy(request);
+   pgexporter_http_response_destroy(response);
+   pgexporter_http_destroy(connection);
+   stop_echo_server();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_http_write_cb_chunked)
+{
+   int status;
+   struct http* connection = NULL;
+   struct http_request* request = NULL;
+   struct http_response* response = NULL;
+   struct write_cb_context write_context = {0};
+
+   char* response_text =
+      "HTTP/1.1 200 OK\r\n"
+      "Transfer-Encoding: chunked\r\n"
+      "\r\n"
+      "5\r\n"
+      "Hello\r\n"
+      "8\r\n"
+      ", World!\r\n"
+      "0\r\n"
+      "\r\n";
+
+   MCTF_ASSERT(start_echo_server(9999, response_text) == 0, cleanup, "failed to start echo server");
+
+   response = calloc(1, sizeof(struct http_response));
+   MCTF_ASSERT_PTR_NONNULL(response, cleanup, "failed to allocate response");
+
+   response->write_cb = collect_write_cb;
+   response->write_userdata = &write_context;
+
+   MCTF_ASSERT(pgexporter_http_create("localhost", 9999, false, &connection) == 0, cleanup, "failed to establish connection");
+   MCTF_ASSERT(pgexporter_http_request_create(PGEXPORTER_HTTP_GET, "/test", &request) == 0, cleanup, "failed to create request");
+
+   status = pgexporter_http_invoke(connection, request, &response);
+   MCTF_ASSERT(status == PGEXPORTER_HTTP_STATUS_OK, cleanup, "HTTP chunked request failed");
+   MCTF_ASSERT(write_context.data_size == 13, cleanup, "write_cb should receive chunked body");
+   MCTF_ASSERT(strcmp(write_context.data, "Hello, World!") == 0, cleanup, "write_cb chunked body mismatch");
+   MCTF_ASSERT(response->payload.data_size == 0, cleanup, "write_cb should prevent buffering for chunked response");
+
+cleanup:
+   pgexporter_http_request_destroy(request);
+   pgexporter_http_response_destroy(response);
+   pgexporter_http_destroy(connection);
+   stop_echo_server();
    MCTF_FINISH();
 }
 


### PR DESCRIPTION
Cross-port of pgmoneta/pgmoneta#1113 as requested by @jesperpedersen.

This adds streaming callback support to the HTTP layer:

- read_cb + read_userdata on http_request for streaming upload
- write_cb + write_userdata on http_response for streaming download
- write_cb support for Content-Length, chunked, and EOF-style responses
- tests for write_cb with Content-Length and chunked responses

Build verified locally with:

cmake --build build -j4