### PR TITLE
[#536] Remove md5

### DIFF
--- a/contrib/json/postgresql-13.json
+++ b/contrib/json/postgresql-13.json
@@ -330,7 +330,7 @@
       "optional": true,
       "queries": [
         {
-          "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
+          "query": "SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-14.json
+++ b/contrib/json/postgresql-14.json
@@ -330,7 +330,7 @@
       "optional": true,
       "queries": [
         {
-          "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
+          "query": "SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-15.json
+++ b/contrib/json/postgresql-15.json
@@ -330,7 +330,7 @@
       "optional": true,
       "queries": [
         {
-          "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
+          "query": "SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-16.json
+++ b/contrib/json/postgresql-16.json
@@ -330,7 +330,7 @@
       "optional": true,
       "queries": [
         {
-          "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
+          "query": "SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-17.json
+++ b/contrib/json/postgresql-17.json
@@ -295,7 +295,7 @@
       "optional": true,
       "queries": [
         {
-          "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
+          "query": "SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
           "version": 10,
           "columns": [
             {

--- a/contrib/json/postgresql-18.json
+++ b/contrib/json/postgresql-18.json
@@ -330,7 +330,7 @@
       "optional": true,
       "queries": [
         {
-          "query": "SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
+          "query": "SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;",
           "version": 10,
           "columns": [
             {

--- a/contrib/prometheus_scrape/extra.info
+++ b/contrib/prometheus_scrape/extra.info
@@ -3149,9 +3149,9 @@ pgexporter_pg_matviews
 Version: 10+
 
 pgexporter_pg_shadow
-+ Counts user accounts (excluding 'postgres') based on their password encryption method (MD5, SCRAM, or none).
++ Counts user accounts (excluding 'postgres') based on their password encryption method (SCRAM, or none).
 * server: The configured name/identifier for the PostgreSQL server.
-* encryption_type: The type of password encryption (e.g., MD5, SCRAM-SHA-256, UNENCRYPTED).
+* encryption_type: The type of password encryption (e.g., SCRAM-SHA-256, UNENCRYPTED).
 Version: 10+
 
 pgexporter_pg_usr_evt_trigger

--- a/contrib/yaml/postgresql-13.yaml
+++ b/contrib/yaml/postgresql-13.yaml
@@ -177,7 +177,7 @@ metrics:
   sort: data
   optional: true
   queries:
-  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
     columns:
     - name: encryption_type

--- a/contrib/yaml/postgresql-14.yaml
+++ b/contrib/yaml/postgresql-14.yaml
@@ -177,7 +177,7 @@ metrics:
   sort: data
   optional: true
   queries:
-  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
     columns:
     - name: encryption_type

--- a/contrib/yaml/postgresql-15.yaml
+++ b/contrib/yaml/postgresql-15.yaml
@@ -177,7 +177,7 @@ metrics:
   sort: data
   optional: true
   queries:
-  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
     columns:
     - name: encryption_type

--- a/contrib/yaml/postgresql-16.yaml
+++ b/contrib/yaml/postgresql-16.yaml
@@ -177,7 +177,7 @@ metrics:
   sort: data
   optional: true
   queries:
-  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
     columns:
     - name: encryption_type

--- a/contrib/yaml/postgresql-17.yaml
+++ b/contrib/yaml/postgresql-17.yaml
@@ -156,7 +156,7 @@ metrics:
   sort: data
   optional: true
   queries:
-  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
     columns:
     - name: encryption_type

--- a/contrib/yaml/postgresql-18.yaml
+++ b/contrib/yaml/postgresql-18.yaml
@@ -177,7 +177,7 @@ metrics:
   sort: data
   optional: true
   queries:
-  - query: SELECT ( CASE WHEN rolpassword LIKE 'md5%' THEN 'MD5' WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
+  - query: SELECT ( CASE WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256' ELSE 'UNENCRYPTED' END ) AS encryption_type, COUNT(*) FROM pg_authid WHERE rolname != 'postgres' GROUP BY encryption_type;
     version: 10
     columns:
     - name: encryption_type

--- a/doc/DEVELOPERS.md
+++ b/doc/DEVELOPERS.md
@@ -192,7 +192,7 @@ Set `password_encryption` value in `/tmp/pgsql/postgresql.conf` to be `scram-sha
 password_encryption = scram-sha-256
 ```
 
-For version 13, the default is `md5`, while for version 14 and above, it is `scram-sha-256`. Therefore, you should ensure that the value in `/tmp/pgsql/postgresql.conf` matches the value in `/tmp/pgsql/pg_hba.conf`.
+For version 13, the default `password_encryption` is `md5`, while for version 14 and above, it is `scram-sha-256`. **Note:** pgexporter no longer supports MD5 authentication. You **must** set `password_encryption = scram-sha-256` in `postgresql.conf` and use `scram-sha-256` in `pg_hba.conf` for all PostgreSQL versions.
 
 #### Start PostgreSQL
 

--- a/doc/MIGRATION.md
+++ b/doc/MIGRATION.md
@@ -1,5 +1,22 @@
 # Migration
 
+## From 0.8.x to 0.9.x
+
+### MD5 Authentication Removal
+
+Legacy MD5 authentication has been completely removed from pgexporter for improved security. This is a **breaking change** for any deployment still relying on MD5.
+
+**Action required:**
+
+1. **PostgreSQL Server**:
+   - Ensure `password_encryption = scram-sha-256` is set in `postgresql.conf`.
+   - Update `pg_hba.conf` to use `scram-sha-256` instead of `md5`.
+   - For existing users with MD5 passwords, you **must** reset their passwords while SCRAM encryption is active so that PostgreSQL generates SCRAM‑compatible verifiers.
+2. **pgexporter**:
+   - Ensure the user configured in `pgexporter.conf` uses `scram-sha-256` for database connectivity. MD5 is no longer a valid method.
+3. **Clients**:
+   - Ensure clients are compatible with `scram-sha-256` (standard for modern PostgreSQL drivers).
+
 ## From 0.7.x to 0.8.x
 
 ### Vault Encryption

--- a/doc/manual/en/03-quickstart.md
+++ b/doc/manual/en/03-quickstart.md
@@ -71,7 +71,7 @@ host   postgres  pgexporter  127.0.0.1/32  scram-sha-256
 host   postgres  pgexporter  ::1/128       scram-sha-256
 ```
 
-The authentication type should be based on `postgresql.conf`'s `password_encryption` value.
+The authentication type must be `scram-sha-256`. Note that `pgexporter` does not support MD5 authentication.
 
 We will need a user vault for the `pgexporter` account, so the following commands will add a master key, and the `pgexporter` password. The master key should be longer than 8 characters.
 

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -423,7 +423,6 @@ extern "C" {
                       "  - queries:\n"                                                                                                                                                  \
                       "    - query: SELECT (\n"                                                                                                                                         \
                       "                CASE\n"                                                                                                                                          \
-                      "                  WHEN rolpassword LIKE 'md5%' THEN 'MD5'\n"                                                                                                     \
                       "                  WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256'\n"                                                                                \
                       "                  ELSE 'UNENCRYPTED'\n"                                                                                                                          \
                       "                END\n"                                                                                                                                           \

--- a/src/include/message.h
+++ b/src/include/message.h
@@ -220,15 +220,6 @@ int
 pgexporter_create_auth_password_response(char* password, struct message** msg);
 
 /**
- * Create an auth MD5 response message
- * @param md5 The md5
- * @param msg The resulting message
- * @return 0 upon success, otherwise 1
- */
-int
-pgexporter_create_auth_md5_response(char* md5, struct message** msg);
-
-/**
  * Write an auth SCRAM-SHA-256 message
  * @param ssl The SSL struct
  * @param socket The socket descriptor

--- a/src/libpgexporter/message.c
+++ b/src/libpgexporter/message.c
@@ -381,31 +381,6 @@ pgexporter_create_auth_password_response(char* password, struct message** msg)
 }
 
 int
-pgexporter_create_auth_md5_response(char* md5, struct message** msg)
-{
-   struct message* m = NULL;
-   size_t size;
-
-   size = 1 + 4 + strlen(md5) + 1;
-
-   m = (struct message*)malloc(sizeof(struct message));
-   m->data = malloc(size);
-
-   memset(m->data, 0, size);
-
-   m->kind = 'p';
-   m->length = size;
-
-   pgexporter_write_byte(m->data, 'p');
-   pgexporter_write_int32(m->data + 1, size - 1);
-   pgexporter_write_string(m->data + 5, md5);
-
-   *msg = m;
-
-   return MESSAGE_STATUS_OK;
-}
-
-int
 pgexporter_write_auth_scram256(SSL* ssl, int socket)
 {
    char scram[24];

--- a/src/libpgexporter/security.c
+++ b/src/libpgexporter/security.c
@@ -54,7 +54,6 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
-#include <openssl/md5.h>
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
 #include <openssl/params.h>
@@ -68,7 +67,6 @@
 #define SECURITY_REJECT             -1
 #define SECURITY_TRUST              0
 #define SECURITY_PASSWORD           3
-#define SECURITY_MD5                5
 #define SECURITY_SCRAM256           10
 #define SECURITY_ALL                99
 
@@ -80,14 +78,11 @@ static ssize_t security_lengths[NUMBER_OF_SECURITY_MESSAGES];
 static char security_messages[NUMBER_OF_SECURITY_MESSAGES][SECURITY_BUFFER_SIZE];
 
 static int get_auth_type(struct message* msg, int* auth_type);
-static int get_salt(void* data, char** salt);
-static int generate_md5(char* str, int length, char** md5);
 
 static int client_scram256(SSL* c_ssl, int client_fd, char* username, char* password, int slot);
 
 static int server_trust(void);
 static int server_password(char* username, char* password, SSL* ssl, int server_fd);
-static int server_md5(char* username, char* password, SSL* ssl, int server_fd);
 static int server_scram256(char* username, char* password, SSL* ssl, int server_fd);
 
 static char* get_admin_password(char* username);
@@ -697,12 +692,7 @@ get_auth_type(struct message* msg, int* auth_type)
          pgexporter_log_trace("Backend: R - CleartextPassword");
          break;
       case 5:
-         pgexporter_log_trace("Backend: R - MD5Password");
-         pgexporter_log_trace("             Salt %02hhx%02hhx%02hhx%02hhx",
-                              (signed char)(pgexporter_read_byte(msg->data + 9) & 0xFF),
-                              (signed char)(pgexporter_read_byte(msg->data + 10) & 0xFF),
-                              (signed char)(pgexporter_read_byte(msg->data + 11) & 0xFF),
-                              (signed char)(pgexporter_read_byte(msg->data + 12) & 0xFF));
+         pgexporter_log_warn("MD5 is unsupported - use SCRAM-SHA-256 instead");
          break;
       case 6:
          pgexporter_log_trace("Backend: R - SCMCredential");
@@ -751,47 +741,6 @@ get_auth_type(struct message* msg, int* auth_type)
    }
 
    *auth_type = type;
-
-   return 0;
-}
-
-static int
-get_salt(void* data, char** salt)
-{
-   char* result;
-
-   result = malloc(4);
-   memset(result, 0, 4);
-
-   memcpy(result, data + 9, 4);
-
-   *salt = result;
-
-   return 0;
-}
-
-static int
-generate_md5(char* str, int length, char** md5)
-{
-   int n;
-   MD5_CTX c;
-   unsigned char digest[16];
-   char* out;
-
-   out = malloc(33);
-
-   memset(out, 0, 33);
-
-   MD5_Init(&c);
-   MD5_Update(&c, str, length);
-   MD5_Final(digest, &c);
-
-   for (n = 0; n < 16; ++n)
-   {
-      pgexporter_snprintf(&(out[n * 2]), 32, "%02x", (unsigned int)digest[n]);
-   }
-
-   *md5 = out;
 
    return 0;
 }
@@ -1178,7 +1127,7 @@ pgexporter_server_authenticate(int server, char* database, char* username, char*
    {
       goto error;
    }
-   else if (auth_type != SECURITY_TRUST && auth_type != SECURITY_PASSWORD && auth_type != SECURITY_MD5 && auth_type != SECURITY_SCRAM256)
+   else if (auth_type != SECURITY_TRUST && auth_type != SECURITY_PASSWORD && auth_type != SECURITY_SCRAM256)
    {
       goto error;
    }
@@ -1193,10 +1142,6 @@ pgexporter_server_authenticate(int server, char* database, char* username, char*
    else if (auth_type == SECURITY_PASSWORD)
    {
       status = server_password(username, password, c_ssl, server_fd);
-   }
-   else if (auth_type == SECURITY_MD5)
-   {
-      status = server_md5(username, password, c_ssl, server_fd);
    }
    else if (auth_type == SECURITY_SCRAM256)
    {
@@ -1353,139 +1298,6 @@ bad_password:
 error:
 
    pgexporter_free_message(password_msg);
-   pgexporter_clear_message();
-
-   return AUTH_ERROR;
-}
-
-static int
-server_md5(char* username, char* password, SSL* ssl, int server_fd)
-{
-   int status = MESSAGE_STATUS_ERROR;
-   int auth_index = 1;
-   int auth_response = -1;
-   size_t size;
-   char* pwdusr = NULL;
-   char* shadow = NULL;
-   char* md5_req = NULL;
-   char* md5 = NULL;
-   char md5str[36];
-   char* salt = NULL;
-   struct message* auth_msg = NULL;
-   struct message* md5_msg = NULL;
-
-   pgexporter_log_trace("server_md5");
-
-   if (get_salt(security_messages[0], &salt))
-   {
-      goto error;
-   }
-
-   size = strlen(username) + strlen(password) + 1;
-   pwdusr = malloc(size);
-   memset(pwdusr, 0, size);
-
-   pgexporter_snprintf(pwdusr, size, "%s%s", password, username);
-
-   if (generate_md5(pwdusr, strlen(pwdusr), &shadow))
-   {
-      goto error;
-   }
-
-   md5_req = malloc(36);
-   memset(md5_req, 0, 36);
-   memcpy(md5_req, shadow, 32);
-   memcpy(md5_req + 32, salt, 4);
-
-   if (generate_md5(md5_req, 36, &md5))
-   {
-      goto error;
-   }
-
-   memset(&md5str, 0, sizeof(md5str));
-   pgexporter_snprintf(&md5str[0], 36, "md5%s", md5);
-
-   status = pgexporter_create_auth_md5_response(md5str, &md5_msg);
-   if (status != MESSAGE_STATUS_OK)
-   {
-      goto error;
-   }
-
-   status = pgexporter_write_message(ssl, server_fd, md5_msg);
-   if (status != MESSAGE_STATUS_OK)
-   {
-      goto error;
-   }
-
-   security_lengths[auth_index] = md5_msg->length;
-   memcpy(&security_messages[auth_index], md5_msg->data, md5_msg->length);
-   auth_index++;
-
-   status = pgexporter_read_block_message(ssl, server_fd, &auth_msg);
-   if (auth_msg->length > SECURITY_BUFFER_SIZE)
-   {
-      pgexporter_log_message(auth_msg);
-      pgexporter_log_error("Security message too large: %ld", auth_msg->length);
-      goto error;
-   }
-
-   get_auth_type(auth_msg, &auth_response);
-   pgexporter_log_trace("authenticate: auth response %d", auth_response);
-
-   if (auth_response == 0)
-   {
-      if (auth_msg->length > SECURITY_BUFFER_SIZE)
-      {
-         pgexporter_log_message(auth_msg);
-         pgexporter_log_error("Security message too large: %ld", auth_msg->length);
-         goto error;
-      }
-
-      security_lengths[auth_index] = auth_msg->length;
-      memcpy(&security_messages[auth_index], auth_msg->data, auth_msg->length);
-
-      has_security = SECURITY_MD5;
-   }
-   else
-   {
-      goto bad_password;
-   }
-
-   free(pwdusr);
-   free(shadow);
-   free(md5_req);
-   free(md5);
-   free(salt);
-
-   pgexporter_free_message(md5_msg);
-   pgexporter_clear_message();
-
-   return AUTH_SUCCESS;
-
-bad_password:
-
-   pgexporter_log_warn("Wrong password for user: %s", username);
-
-   free(pwdusr);
-   free(shadow);
-   free(md5_req);
-   free(md5);
-   free(salt);
-
-   pgexporter_free_message(md5_msg);
-   pgexporter_clear_message();
-
-   return AUTH_BAD_PASSWORD;
-
-error:
-
-   free(pwdusr);
-   free(shadow);
-   free(md5_req);
-   free(md5);
-   free(salt);
-
-   pgexporter_free_message(md5_msg);
    pgexporter_clear_message();
 
    return AUTH_ERROR;


### PR DESCRIPTION
closes: #536 
performs a project wide removal of MD5 auth

MD5 is considered insecure and its removal enforces modern authentication standards across pgexporter.