### PR TITLE
[#550] Added pruning support to sqlite history

### DIFF
--- a/doc/HISTORY.md
+++ b/doc/HISTORY.md
@@ -72,6 +72,33 @@ for bridge history). The currently supported backends are:
 |---------|----------|-------------|
 | SQLite  | `sqlite` | Default. Local file-based storage. |
 
+### SQLite
+
+The SQLite backend stores history in the file pointed to by `history_path`
+(`bridge_history_path` for bridge history). The database is opened with the
+following hardcoded settings:
+
+- `journal_mode = WAL` — write-ahead logging, so a scrape can read the history
+  while a snapshot is being written without blocking.
+- `busy_timeout = 5000` — when the database is momentarily locked (for example a
+  snapshot insert racing an in-flight prune), the writer waits and retries for up
+  to 5 seconds instead of failing immediately.
+- `auto_vacuum = INCREMENTAL` — pages freed by pruning are placed on a free list.
+  After each prune, up to 1000 free pages are returned to the operating system
+  with `PRAGMA incremental_vacuum`, keeping the database file from growing
+  unbounded while never holding the write lock for long.
+
+### Retention and pruning
+
+`history_retention` (and `bridge_history_retention`) set how long records are
+kept. Records older than the retention period are deleted by a pruning task that
+runs on a fixed **hourly** tick, independent of the snapshot interval. A prune is
+also run once at startup so a daemon that was down longer than its retention
+period catches up immediately rather than waiting a full hour.
+
+If `history_retention` is unset (disabled), records are kept forever and no
+pruning is scheduled.
+
 
 ## Access
 

--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -444,6 +444,8 @@ struct configuration
    atomic_bool history_worker_running;           /**< State of the history ticker */
    atomic_int_least64_t history_last_store_time; /**< Timestamp of last store */
    atomic_int history_worker_pid;                /**< PID of the forked history ticker worker (0 if none) */
+   atomic_bool history_retention_worker_running; /**< State of the retention pruner */
+   atomic_int history_retention_worker_pid;      /**< PID of the forked retention worker (0 if none) */
 
    int bridge;                                 /**< The bridge port */
    pgexporter_time_t bridge_cache_max_age;     /**< Cache duration for bridge response */

--- a/src/libpgexporter/history.c
+++ b/src/libpgexporter/history.c
@@ -436,9 +436,65 @@ pgexporter_history_tick_cb(void)
    history_tick_worker();
 }
 
+/**
+ * Child-process worker that opens its own database connection and prunes
+ * records older than the configured retention. Called after fork(); exit(0)s.
+ */
+static void
+history_retention_worker(void)
+{
+   struct configuration* config = (struct configuration*)shmem;
+
+   if (pgexporter_history_init() != 0)
+   {
+      pgexporter_log_error("history: failed to init history db for retention");
+      goto child_done;
+   }
+
+   if (pgexporter_history_prune() != 0)
+   {
+      pgexporter_log_error("history: prune failed");
+   }
+
+child_done:
+   pgexporter_history_shutdown();
+   atomic_store(&config->history_retention_worker_pid, 0);
+   atomic_store(&config->history_retention_worker_running, false);
+   exit(0);
+}
+
 void
 pgexporter_history_retention_tick_cb(void)
 {
-   /* TODO: fork retention worker */
-   pgexporter_log_debug("history: retention tick (not yet implemented)");
+   struct configuration* config = (struct configuration*)shmem;
+   pid_t pid;
+   bool expected = false;
+
+   if (config == NULL || config->history == 0)
+   {
+      return;
+   }
+
+   if (!atomic_compare_exchange_strong(&config->history_retention_worker_running, &expected, true))
+   {
+      /* Previous retention worker still running */
+      return;
+   }
+
+   pid = fork();
+   if (pid < 0)
+   {
+      pgexporter_log_error("history: failed to fork retention worker");
+      atomic_store(&config->history_retention_worker_running, false);
+      return;
+   }
+   else if (pid > 0)
+   {
+      /* Record worker pid so sigchld_cb can clear the running flag
+       * if the worker dies before resetting it itself. */
+      atomic_store(&config->history_retention_worker_pid, (int)pid);
+      return;
+   }
+
+   history_retention_worker();
 }

--- a/src/libpgexporter/history_sqlite.c
+++ b/src/libpgexporter/history_sqlite.c
@@ -53,12 +53,18 @@
 
 static sqlite3* db = NULL;
 
+/* Maximum free pages reclaimed per prune via PRAGMA incremental_vacuum */
+#define HISTORY_SQLITE_VACUUM_PAGES 1000
+
 int
 pgexporter_history_sqlite_init(void)
 {
    struct configuration* config;
    char* err_msg = NULL;
-   const char* sql = "CREATE TABLE IF NOT EXISTS history ("
+   const char* sql = "PRAGMA auto_vacuum=INCREMENTAL;"
+                     "PRAGMA journal_mode=WAL;"
+                     "PRAGMA busy_timeout=5000;"
+                     "CREATE TABLE IF NOT EXISTS history ("
                      "ts INTEGER, "
                      "server TEXT, "
                      "metric TEXT, "
@@ -297,6 +303,7 @@ pgexporter_history_sqlite_prune(void)
    struct configuration* config;
    sqlite3_stmt* stmt = NULL;
    const char* sql = "DELETE FROM history WHERE ts < ?;";
+   char vacuum_sql[48];
    time_t cutoff;
    int64_t retention_s;
 
@@ -330,6 +337,14 @@ pgexporter_history_sqlite_prune(void)
 
    sqlite3_finalize(stmt);
    stmt = NULL;
+
+   /* Hand reclaimed pages back to the OS. Bounded so the write lock is held
+    * only briefly; a no-op when auto_vacuum freed nothing. */
+   pgexporter_snprintf(vacuum_sql, sizeof(vacuum_sql), "PRAGMA incremental_vacuum(%d);", HISTORY_SQLITE_VACUUM_PAGES);
+   if (sqlite3_exec(db, vacuum_sql, NULL, NULL, NULL) != SQLITE_OK)
+   {
+      pgexporter_log_warn("history_sqlite: incremental_vacuum failed: %s", sqlite3_errmsg(db));
+   }
 
    return 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -426,8 +426,13 @@ usage(void)
    printf("Report bugs: %s\n", PGEXPORTER_ISSUES);
 }
 
+/* Fixed interval for the history retention pruning tick (1 hour, in ms) */
+#define HISTORY_RETENTION_PRUNE_INTERVAL_MS (60 * 60 * 1000)
+
 static struct periodic_watcher history_watcher;
+static struct periodic_watcher history_retention_watcher;
 static bool history_started = false;
+static bool history_retention_started = false;
 
 int
 main(int argc, char** argv)
@@ -1366,6 +1371,24 @@ main(int argc, char** argv)
             pgexporter_log_error("History: failed to initialize the periodic tick watcher; history snapshots disabled");
          }
       }
+
+      /* Retention pruning runs on a fixed hourly tick, independent of the
+       * snapshot interval */
+      if (pgexporter_time_is_valid(config->history_retention))
+      {
+         if (pgexporter_periodic_init(&history_retention_watcher, pgexporter_history_retention_tick_cb, HISTORY_RETENTION_PRUNE_INTERVAL_MS) == 0)
+         {
+            pgexporter_periodic_start(&history_retention_watcher);
+            history_retention_started = true;
+
+            /* Prune once at startup */
+            pgexporter_history_retention_tick_cb();
+         }
+         else
+         {
+            pgexporter_log_error("History: failed to initialize the retention tick watcher; pruning disabled");
+         }
+      }
    }
    pgexporter_log_debug("Management: %d", unix_management_socket);
    pgexporter_log_debug("Transfer: %d", unix_transfer_socket);
@@ -1468,6 +1491,11 @@ main(int argc, char** argv)
       {
          shutdown_bridge_json(true);
       }
+   }
+
+   if (history_retention_started)
+   {
+      pgexporter_periodic_stop(&history_retention_watcher);
    }
 
    if (history_started)
@@ -2453,6 +2481,13 @@ sigchld_cb(void)
       {
          atomic_store(&config->history_worker_pid, 0);
          atomic_store(&config->history_worker_running, false);
+      }
+
+      /* Same safeguard for the retention pruner worker. */
+      if (config != NULL && pid == (pid_t)atomic_load(&config->history_retention_worker_pid))
+      {
+         atomic_store(&config->history_retention_worker_pid, 0);
+         atomic_store(&config->history_retention_worker_running, false);
       }
    }
 }

--- a/test/testcases/test_history.c
+++ b/test/testcases/test_history.c
@@ -440,3 +440,163 @@ cleanup:
    unlink_db("test_edge_cases.db");
    MCTF_FINISH();
 }
+
+MCTF_TEST(test_history_prune_deletes_old_keeps_new)
+{
+   struct configuration* config = (struct configuration*)shmem;
+   struct history_record in[4];
+   struct history_record* out = NULL;
+   int count = 0;
+   time_t now = time(NULL);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   config->history_retention = PGEXPORTER_TIME_SEC(3600); /* keep 1 hour */
+
+   make_record(&in[0], now - 7200, "s", "m", "", 1.0); /* 2h old  -> pruned */
+   make_record(&in[1], now - 3700, "s", "m", "", 2.0); /* >1h old -> pruned */
+   make_record(&in[2], now - 60, "s", "m", "", 3.0);   /* recent  -> kept   */
+   make_record(&in[3], now, "s", "m", "", 4.0);        /* now     -> kept   */
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 4), 0, cleanup, "write failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_prune(), 0, cleanup, "prune failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("m", 0, now + 10, &out, &count), 0,
+                      cleanup, "query failed");
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "expected 2 rows after prune, got %d", count);
+   MCTF_ASSERT(out[0].ts == now - 60, cleanup, "kept row0 ts wrong");
+   MCTF_ASSERT(out[1].ts == now, cleanup, "kept row1 ts wrong");
+
+cleanup:
+   pgexporter_history_records_free(out, count);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_prune_disabled_keeps_all)
+{
+   struct configuration* config = (struct configuration*)shmem;
+   struct history_record in[3];
+   int count = -1;
+   time_t now = time(NULL);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   config->history_retention = PGEXPORTER_TIME_DISABLED; /* keep forever */
+
+   make_record(&in[0], now - 100000, "s", "m", "", 1.0);
+   make_record(&in[1], now - 50000, "s", "m", "", 2.0);
+   make_record(&in[2], now, "s", "m", "", 3.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 3), 0, cleanup, "write failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_prune(), 0, cleanup,
+                      "prune with disabled retention should succeed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("m", 0, now + 10, NULL, &count), 0,
+                      cleanup, "query failed");
+   MCTF_ASSERT_INT_EQ(count, 3, cleanup, "disabled retention should keep all 3, got %d", count);
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_prune_removes_all_when_all_old)
+{
+   struct configuration* config = (struct configuration*)shmem;
+   struct history_record in[3];
+   int count = -1;
+   time_t now = time(NULL);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   config->history_retention = PGEXPORTER_TIME_SEC(60);
+
+   make_record(&in[0], now - 3600, "s", "m", "", 1.0);
+   make_record(&in[1], now - 1800, "s", "m", "", 2.0);
+   make_record(&in[2], now - 600, "s", "m", "", 3.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 3), 0, cleanup, "write failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_prune(), 0, cleanup, "prune failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("m", 0, now + 10, NULL, &count), 0,
+                      cleanup, "query failed");
+   MCTF_ASSERT_INT_EQ(count, 0, cleanup,
+                      "all records older than retention should be pruned, got %d", count);
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_prune_empty_db_succeeds)
+{
+   struct configuration* config = (struct configuration*)shmem;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   config->history_retention = PGEXPORTER_TIME_SEC(60);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_prune(), 0, cleanup, "prune on empty db should succeed");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_prune_idempotent)
+{
+   struct configuration* config = (struct configuration*)shmem;
+   struct history_record in[3];
+   int count = -1;
+   time_t now = time(NULL);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   config->history_retention = PGEXPORTER_TIME_SEC(3600);
+
+   make_record(&in[0], now - 7200, "s", "m", "", 1.0); /* pruned */
+   make_record(&in[1], now - 30, "s", "m", "", 2.0);   /* kept   */
+   make_record(&in[2], now, "s", "m", "", 3.0);        /* kept   */
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 3), 0, cleanup, "write failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_prune(), 0, cleanup, "first prune failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("m", 0, now + 10, NULL, &count), 0,
+                      cleanup, "query failed");
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "expected 2 after first prune, got %d", count);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_prune(), 0, cleanup, "second prune failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("m", 0, now + 10, NULL, &count), 0,
+                      cleanup, "query failed");
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "second prune should be a no-op, got %d", count);
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_prune_spans_all_metrics)
+{
+   struct configuration* config = (struct configuration*)shmem;
+   struct history_record in[4];
+   int count = -1;
+   time_t now = time(NULL);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   config->history_retention = PGEXPORTER_TIME_SEC(3600);
+
+   make_record(&in[0], now - 7200, "s", "metric_a", "", 1.0); /* pruned */
+   make_record(&in[1], now - 30, "s", "metric_a", "", 2.0);   /* kept   */
+   make_record(&in[2], now - 7200, "s", "metric_b", "", 3.0); /* pruned */
+   make_record(&in[3], now - 30, "s", "metric_b", "", 4.0);   /* kept   */
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 4), 0, cleanup, "write failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_prune(), 0, cleanup, "prune failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("metric_a", 0, now + 10, NULL, &count), 0,
+                      cleanup, "query metric_a failed");
+   MCTF_ASSERT_INT_EQ(count, 1, cleanup, "metric_a should have 1 row after prune, got %d", count);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("metric_b", 0, now + 10, NULL, &count), 0,
+                      cleanup, "query metric_b failed");
+   MCTF_ASSERT_INT_EQ(count, 1, cleanup, "metric_b should have 1 row after prune, got %d", count);
+
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
Resolves #550 

Implemented pruning strategy in accordance with https://github.com/pgexporter/pgexporter/discussions/534#discussioncomment-17426438

Ran manual tests for checking and the worker successfully ran and deleted old records