### PR TITLE
[#552] Read complete SCRAM messages before parsing

### DIFF
--- a/src/include/message.h
+++ b/src/include/message.h
@@ -65,6 +65,21 @@ int
 pgexporter_read_block_message(SSL* ssl, int socket, struct message** msg);
 
 /**
+ * Read a complete typed message in blocking mode. The message must carry the
+ * standard header (1 byte kind + 4 byte length); the read continues until the
+ * number of bytes declared in the header has arrived, so a message split
+ * across multiple network segments is never returned partially. A message
+ * whose declared length is malformed (less than 4 bytes or larger than the
+ * read buffer) is an error.
+ * @param ssl The SSL struct
+ * @param socket The socket descriptor
+ * @param msg The resulting message
+ * @return One of MESSAGE_STATUS_ZERO, MESSAGE_STATUS_OK or MESSAGE_STATUS_ERROR
+ */
+int
+pgexporter_read_complete_message(SSL* ssl, int socket, struct message** msg);
+
+/**
  * Read a message with a timeout
  * @param ssl The SSL struct
  * @param socket The socket descriptor

--- a/src/libpgexporter/message.c
+++ b/src/libpgexporter/message.c
@@ -63,6 +63,105 @@ pgexporter_read_block_message(SSL* ssl, int socket, struct message** msg)
    return ssl_read_message(ssl, 0, msg);
 }
 
+static int
+read_append(SSL* ssl, int socket, struct message* m, size_t needed)
+{
+   ssize_t numbytes;
+
+   while ((size_t)m->length < needed)
+   {
+      if (ssl != NULL)
+      {
+         numbytes = SSL_read(ssl, (char*)m->data + m->length, DEFAULT_BUFFER_SIZE - m->length);
+
+         if (numbytes <= 0)
+         {
+            int err = SSL_get_error(ssl, numbytes);
+            ERR_clear_error();
+
+            switch (err)
+            {
+               case SSL_ERROR_WANT_READ:
+               case SSL_ERROR_WANT_WRITE:
+                  continue;
+               case SSL_ERROR_ZERO_RETURN:
+                  return MESSAGE_STATUS_ZERO;
+               default:
+                  return MESSAGE_STATUS_ERROR;
+            }
+         }
+      }
+      else
+      {
+         numbytes = read(socket, (char*)m->data + m->length, DEFAULT_BUFFER_SIZE - m->length);
+
+         if (numbytes == 0)
+         {
+            return MESSAGE_STATUS_ZERO;
+         }
+         else if (numbytes < 0)
+         {
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+            {
+               errno = 0;
+               continue;
+            }
+
+            pgexporter_log_error("read error: fd=%d errno=%d", socket, errno);
+            errno = 0;
+            return MESSAGE_STATUS_ERROR;
+         }
+      }
+
+      m->length += numbytes;
+   }
+
+   return MESSAGE_STATUS_OK;
+}
+
+int
+pgexporter_read_complete_message(SSL* ssl, int socket, struct message** msg)
+{
+   int status;
+   int32_t length;
+   size_t total;
+   struct message* m = NULL;
+
+   *msg = NULL;
+
+   status = pgexporter_read_block_message(ssl, socket, &m);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      return status;
+   }
+
+   /* kind (1 byte) + length (4 bytes, includes itself) */
+   status = read_append(ssl, socket, m, 5);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      return status;
+   }
+
+   length = pgexporter_read_int32((char*)m->data + 1);
+   if (length < 4 || (size_t)length + 1 > DEFAULT_BUFFER_SIZE)
+   {
+      pgexporter_log_error("Invalid message length: fd=%d kind=%c length=%d", socket, m->kind, length);
+      return MESSAGE_STATUS_ERROR;
+   }
+
+   total = (size_t)length + 1;
+
+   status = read_append(ssl, socket, m, total);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      return status;
+   }
+
+   *msg = m;
+
+   return MESSAGE_STATUS_OK;
+}
+
 int
 pgexporter_read_timeout_message(SSL* ssl, int socket, int timeout, struct message** msg)
 {

--- a/src/libpgexporter/security.c
+++ b/src/libpgexporter/security.c
@@ -450,7 +450,7 @@ pgexporter_remote_management_scram_sha256(char* username, char* password, int se
       goto error;
    }
 
-   status = pgexporter_read_block_message(ssl, server_fd, &msg);
+   status = pgexporter_read_complete_message(ssl, server_fd, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -481,7 +481,7 @@ pgexporter_remote_management_scram_sha256(char* username, char* password, int se
       goto error;
    }
 
-   status = pgexporter_read_block_message(ssl, server_fd, &msg);
+   status = pgexporter_read_complete_message(ssl, server_fd, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -489,12 +489,23 @@ pgexporter_remote_management_scram_sha256(char* username, char* password, int se
 
    sasl_continue = pgexporter_copy_message(msg);
 
+   /* 'R' + length + AuthenticationSASLContinue + payload */
+   if (sasl_continue->length <= 9)
+   {
+      goto error;
+   }
+
    get_scram_attribute('r', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &combined_nounce);
    get_scram_attribute('s', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &base64_salt);
    get_scram_attribute('i', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &iteration_string);
    get_scram_attribute('e', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &err);
 
    if (err != NULL)
+   {
+      goto error;
+   }
+
+   if (combined_nounce == NULL || base64_salt == NULL || iteration_string == NULL)
    {
       goto error;
    }
@@ -538,13 +549,19 @@ pgexporter_remote_management_scram_sha256(char* username, char* password, int se
       goto error;
    }
 
-   status = pgexporter_read_block_message(ssl, server_fd, &msg);
+   status = pgexporter_read_complete_message(ssl, server_fd, &msg);
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
    }
 
    if (pgexporter_extract_message('R', msg, &sasl_final))
+   {
+      goto error;
+   }
+
+   /* 'R' + length + AuthenticationSASLFinal + 'v' attribute */
+   if (sasl_final->length <= 11)
    {
       goto error;
    }
@@ -815,11 +832,23 @@ retry:
       pgexporter_socket_nonblocking(client_fd, false);
    }
 
+   /* 'p' + length + mechanism + "n,,n=,r=" + nounce */
+   if (msg->length <= 26)
+   {
+      goto error;
+   }
+
    client_first_message_bare = malloc(msg->length - 25);
    memset(client_first_message_bare, 0, msg->length - 25);
    memcpy(client_first_message_bare, msg->data + 26, msg->length - 26);
 
    get_scram_attribute('r', (char*)msg->data + 26, msg->length - 26, &client_nounce);
+
+   if (client_nounce == NULL)
+   {
+      goto error;
+   }
+
    generate_nounce(&server_nounce);
    generate_salt(&salt, &salt_length);
    pgexporter_base64_encode(salt, salt_length, &base64_salt, &base64_salt_length);
@@ -851,7 +880,19 @@ retry:
       goto error;
    }
 
+   /* 'p' + length + "c=biws,r=" + nounces (57 bytes) + ",p=" + proof */
+   if (msg->length < 62)
+   {
+      goto error;
+   }
+
    get_scram_attribute('p', (char*)msg->data + 5, msg->length - 5, &base64_client_proof);
+
+   if (base64_client_proof == NULL)
+   {
+      goto error;
+   }
+
    pgexporter_base64_decode(base64_client_proof, strlen(base64_client_proof), (void**)&client_proof_received, &client_proof_received_length);
 
    client_final_message_without_proof = malloc(58);
@@ -1361,7 +1402,12 @@ server_scram256(char* username, char* password, SSL* ssl, int server_fd)
       goto error;
    }
 
-   status = pgexporter_read_block_message(ssl, server_fd, &msg);
+   status = pgexporter_read_complete_message(ssl, server_fd, &msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
    if (msg->length > SECURITY_BUFFER_SIZE)
    {
       pgexporter_log_message(msg);
@@ -1375,6 +1421,12 @@ server_scram256(char* username, char* password, SSL* ssl, int server_fd)
    memcpy(&security_messages[auth_index], sasl_continue->data, sasl_continue->length);
    auth_index++;
 
+   /* 'R' + length + AuthenticationSASLContinue + payload */
+   if (sasl_continue->length <= 9)
+   {
+      goto error;
+   }
+
    get_scram_attribute('r', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &combined_nounce);
    get_scram_attribute('s', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &base64_salt);
    get_scram_attribute('i', (char*)(sasl_continue->data + 9), sasl_continue->length - 9, &iteration_string);
@@ -1383,6 +1435,11 @@ server_scram256(char* username, char* password, SSL* ssl, int server_fd)
    if (err != NULL)
    {
       pgexporter_log_error("SCRAM-SHA-256: %s", err);
+      goto error;
+   }
+
+   if (combined_nounce == NULL || base64_salt == NULL || iteration_string == NULL)
+   {
       goto error;
    }
 
@@ -1429,7 +1486,12 @@ server_scram256(char* username, char* password, SSL* ssl, int server_fd)
       goto error;
    }
 
-   status = pgexporter_read_block_message(ssl, server_fd, &msg);
+   status = pgexporter_read_complete_message(ssl, server_fd, &msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
    if (msg->length > SECURITY_BUFFER_SIZE)
    {
       pgexporter_log_message(msg);
@@ -1442,6 +1504,12 @@ server_scram256(char* username, char* password, SSL* ssl, int server_fd)
    auth_index++;
 
    if (pgexporter_extract_message('R', msg, &sasl_final))
+   {
+      goto error;
+   }
+
+   /* 'R' + length + AuthenticationSASLFinal + 'v' attribute */
+   if (sasl_final->length <= 11)
    {
       goto error;
    }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TESTCASE_FILES
   testcases/test_art.c
   testcases/test_deque.c
   testcases/test_history.c
+  testcases/test_message_complete.c
 )
 set(SOURCE_FILES ${LIB_SOURCE_FILES} ${TESTCASE_FILES} ${HEADER_FILES})
 

--- a/test/testcases/test_message_complete.c
+++ b/test/testcases/test_message_complete.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <pgexporter.h>
+#include <ev.h>
+#include <memory.h>
+#include <message.h>
+#include <utils.h>
+#include <mctf.h>
+
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/*
+ * Regression tests for the SCRAM split-message fix (pgagroal #834): an
+ * AuthenticationSASLContinue split across multiple network segments was parsed
+ * after the first read(), so sasl_continue->length - 9 underflowed (size_t)
+ * and reached the SCRAM parsers with a huge value.
+ *
+ * pgexporter_read_complete_message() must keep reading until the byte count
+ * declared in the message header has arrived, and must reject a header whose
+ * declared length is malformed.
+ */
+
+/* AuthenticationSASLContinue: 'R' + int32 length + int32 11 + SCRAM payload */
+static ssize_t
+build_sasl_continue(char* buffer, size_t size)
+{
+   const char* payload = "r=clientnonceservernonce,s=c2FsdA==,i=4096";
+   size_t total = 1 + 4 + 4 + strlen(payload);
+
+   if (size < total)
+   {
+      return -1;
+   }
+
+   pgexporter_write_byte(buffer, 'R');
+   pgexporter_write_int32(buffer + 1, (int32_t)(total - 1));
+   pgexporter_write_int32(buffer + 5, 11);
+   memcpy(buffer + 9, payload, strlen(payload));
+
+   return (ssize_t)total;
+}
+
+/* Baseline: a message arriving in a single segment is returned as-is. */
+MCTF_TEST(test_complete_message_single_segment)
+{
+   int sv[2] = {-1, -1};
+   char buffer[128];
+   ssize_t total;
+   int status;
+   struct message* msg = NULL;
+
+   pgexporter_memory_init();
+
+   total = build_sasl_continue(buffer, sizeof(buffer));
+   MCTF_ASSERT(total > 0, cleanup, "failed to build test message");
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair failed");
+
+   MCTF_ASSERT(write(sv[1], buffer, total) == total, cleanup, "write failed");
+
+   status = pgexporter_read_complete_message(NULL, sv[0], &msg);
+
+   MCTF_ASSERT_INT_EQ(status, MESSAGE_STATUS_OK, cleanup, "single segment should succeed");
+   MCTF_ASSERT(msg != NULL, cleanup, "message should be returned");
+   MCTF_ASSERT(msg->kind == 'R', cleanup, "kind should be R");
+   MCTF_ASSERT_INT_EQ((int)msg->length, (int)total, cleanup, "length should match the declared length");
+
+cleanup:
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   pgexporter_memory_destroy();
+   MCTF_FINISH();
+}
+
+/* Split message must be assembled before parsing. */
+MCTF_TEST(test_complete_message_split_segments)
+{
+   int sv[2] = {-1, -1};
+   char buffer[128];
+   ssize_t total;
+   int status;
+   pid_t pid = -1;
+   struct message* msg = NULL;
+
+   pgexporter_memory_init();
+
+   total = build_sasl_continue(buffer, sizeof(buffer));
+   MCTF_ASSERT(total > 0, cleanup, "failed to build test message");
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair failed");
+
+   pid = fork();
+   MCTF_ASSERT(pid >= 0, cleanup, "fork failed");
+
+   if (pid == 0)
+   {
+      /* writer: 3 bytes (shorter than the 5 byte header), pause, 4 more
+       * bytes, pause, the rest -- forces partial reads on the reader */
+      close(sv[0]);
+      write(sv[1], buffer, 3);
+      usleep(50 * 1000);
+      write(sv[1], buffer + 3, 4);
+      usleep(50 * 1000);
+      write(sv[1], buffer + 7, total - 7);
+      close(sv[1]);
+      _exit(0);
+   }
+
+   close(sv[1]);
+   sv[1] = -1;
+
+   status = pgexporter_read_complete_message(NULL, sv[0], &msg);
+
+   MCTF_ASSERT_INT_EQ(status, MESSAGE_STATUS_OK, cleanup, "split message should be assembled");
+   MCTF_ASSERT(msg != NULL, cleanup, "message should be returned");
+   MCTF_ASSERT(msg->kind == 'R', cleanup, "kind should be R");
+   MCTF_ASSERT_INT_EQ((int)msg->length, (int)total, cleanup, "all declared bytes should have been read");
+
+cleanup:
+   if (pid > 0)
+   {
+      waitpid(pid, NULL, 0);
+   }
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   pgexporter_memory_destroy();
+   MCTF_FINISH();
+}
+
+/* A peer that disappears mid-message is an error, not a partial message. */
+MCTF_TEST(test_complete_message_truncated_by_close)
+{
+   int sv[2] = {-1, -1};
+   char buffer[128];
+   ssize_t total;
+   int status;
+   struct message* msg = NULL;
+
+   pgexporter_memory_init();
+
+   total = build_sasl_continue(buffer, sizeof(buffer));
+   MCTF_ASSERT(total > 0, cleanup, "failed to build test message");
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair failed");
+
+   /* half the message, then close */
+   MCTF_ASSERT(write(sv[1], buffer, total / 2) == total / 2, cleanup, "write failed");
+   close(sv[1]);
+   sv[1] = -1;
+
+   status = pgexporter_read_complete_message(NULL, sv[0], &msg);
+
+   MCTF_ASSERT(status != MESSAGE_STATUS_OK, cleanup, "truncated message must not be returned as complete");
+   MCTF_ASSERT(msg == NULL, cleanup, "no message should be returned");
+
+cleanup:
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   pgexporter_memory_destroy();
+   MCTF_FINISH();
+}
+
+/* A header whose declared length cannot be valid is rejected. Negative: the
+ * rejection path deliberately logs an ERROR. */
+MCTF_TEST_NEGATIVE(test_complete_message_invalid_declared_length)
+{
+   int sv[2] = {-1, -1};
+   char buffer[8];
+   int status;
+   struct message* msg = NULL;
+
+   pgexporter_memory_init();
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair failed");
+
+   /* 'R' declaring a length of 3: less than the length field itself */
+   pgexporter_write_byte(buffer, 'R');
+   pgexporter_write_int32(buffer + 1, 3);
+
+   MCTF_ASSERT(write(sv[1], buffer, 5) == 5, cleanup, "write failed");
+
+   status = pgexporter_read_complete_message(NULL, sv[0], &msg);
+
+   MCTF_ASSERT_INT_EQ(status, MESSAGE_STATUS_ERROR, cleanup, "invalid declared length must be an error");
+   MCTF_ASSERT(msg == NULL, cleanup, "no message should be returned");
+
+cleanup:
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   pgexporter_memory_destroy();
+   MCTF_FINISH();
+}


### PR DESCRIPTION
## Problem

A SCRAM message that arrives split across multiple network segments is parsed after the first `read()` returns. `sasl_continue->length - 9` (and the other offset arithmetic) then underflows because `length` is unsigned, and the huge value reaches `get_scram_attribute()` / `pgexporter_base64_decode()`, risking a crash. The single-read assumption exists in every SCRAM exchange, server-side and client-side.

## Fix

Add `pgexporter_read_complete_message()`, which keeps reading until the byte count declared in the message header has arrived and rejects a header whose declared length is malformed. Use it for the SCRAM reads. Guard every SCRAM parse site against short messages and missing attributes so a malformed message fails authentication cleanly instead of crashing.

This is the pgexporter counterpart of pgagroal#834 / pgagroal#932.

## Testing

New MCTF regression tests (`test/testcases/test_message_complete.c`) over a `socketpair`:

- single segment is returned as-is
- a message split across segments is assembled before parsing
- a peer that closes mid-message is an error, not a partial message
- a header declaring an impossible length is rejected

All four pass locally; `clang-format` clean.

close #552
