### PR TITLE
[#554] Refactored http server side logic

### DIFF
--- a/src/include/http_server.h
+++ b/src/include/http_server.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGEXPORTER_HTTP_SERVER_H
+#define PGEXPORTER_HTTP_SERVER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <openssl/ssl.h>
+#include <stddef.h>
+
+/** @struct http_server_request
+ * Parsed inbound HTTP request. Populated by pgexporter_http_server_parse().
+ */
+struct http_server_request
+{
+   char path[256]; /**< Request path extracted from the GET line (e.g. "/metrics") */
+};
+
+/**
+ * Handler function type for HTTP route handlers.
+ * @param ssl The SSL connection, or NULL for plain HTTP
+ * @param fd  The client socket file descriptor
+ * @return MESSAGE_STATUS_OK on success, otherwise MESSAGE_STATUS_ERROR
+ */
+typedef int (*http_handler_fn)(SSL* ssl, int fd);
+
+/** @struct http_route
+ * Maps a URL path to a handler function.
+ */
+struct http_route
+{
+   const char* path;        /**< Exact path to match (e.g. "/metrics") */
+   http_handler_fn handler; /**< Handler called when path matches */
+};
+
+/**
+ * Perform TLS detection and SSL_accept on an incoming connection.
+ *
+ * Returns MESSAGE_STATUS_OK when the TLS handshake completed successfully, or
+ * when @p ssl is NULL (no TLS configured — caller proceeds with plain HTTP).
+ * Returns MESSAGE_STATUS_ZERO when the connection is plain HTTP on a TLS
+ * socket — the caller decides what to do (e.g. redirect to HTTPS).
+ * Returns MESSAGE_STATUS_ERROR when SSL_accept() failed.
+ *
+ * @param ssl The SSL object created for this connection
+ * @param fd  The client socket file descriptor
+ * @return MESSAGE_STATUS_OK, MESSAGE_STATUS_ZERO, or MESSAGE_STATUS_ERROR
+ */
+int
+pgexporter_http_server_ssl_accept(SSL* ssl, int fd);
+
+/**
+ * Read and parse an inbound HTTP request from the socket.
+ *
+ * Calls pgexporter_read_timeout_message() using the configured authentication
+ * timeout, then extracts the request path into a newly allocated
+ * http_server_request. On failure (read error or malformed request) the
+ * function returns MESSAGE_STATUS_ERROR and @p *req is set to NULL.
+ *
+ * The caller must free the returned struct with
+ * pgexporter_http_server_request_destroy() when done.
+ *
+ * @param ssl The SSL connection, or NULL for plain HTTP
+ * @param fd  The client socket file descriptor
+ * @param req Output: pointer to the allocated request struct
+ * @return MESSAGE_STATUS_OK on success, otherwise MESSAGE_STATUS_ERROR
+ */
+int
+pgexporter_http_server_parse(SSL* ssl, int fd, struct http_server_request** req);
+
+/**
+ * Free an http_server_request allocated by pgexporter_http_server_parse().
+ * Safe to call with NULL.
+ * @param req The request to free
+ */
+void
+pgexporter_http_server_request_destroy(struct http_server_request* req);
+
+/**
+ * Dispatch a parsed request against a route table.
+ *
+ * Walks @p routes for an exact path match and calls the matching handler.
+ * Sends a 403 if no route matches. The dispatch always returns after the
+ * first matching route (or after sending the 403).
+ *
+ * @param ssl      The SSL connection, or NULL for plain HTTP
+ * @param fd       The client socket file descriptor
+ * @param req      The parsed request from pgexporter_http_server_parse()
+ * @param routes   Route table array
+ * @param n_routes Number of entries in @p routes
+ * @return MESSAGE_STATUS_OK on success, otherwise MESSAGE_STATUS_ERROR
+ */
+int
+pgexporter_http_server_dispatch(SSL* ssl, int fd, struct http_server_request* req,
+                                struct http_route* routes, int n_routes);
+
+/**
+ * Send an HTTP 200 OK response with a fixed-size body.
+ * @param ssl          The SSL connection, or NULL for plain HTTP
+ * @param fd           The client socket file descriptor
+ * @param content_type The Content-Type header value
+ * @param body         Response body data
+ * @param len          Length of @p body in bytes
+ * @return MESSAGE_STATUS_OK on success, otherwise MESSAGE_STATUS_ERROR
+ */
+int
+pgexporter_http_respond_ok(SSL* ssl, int fd, const char* content_type,
+                           const void* body, size_t len);
+
+/**
+ * Send an HTTP 400 Bad Request response.
+ * @param ssl The SSL connection, or NULL for plain HTTP
+ * @param fd  The client socket file descriptor
+ * @return MESSAGE_STATUS_OK on success, otherwise MESSAGE_STATUS_ERROR
+ */
+int
+pgexporter_http_respond_400(SSL* ssl, int fd);
+
+/**
+ * Send an HTTP 404 Not Found response.
+ * @param ssl The SSL connection, or NULL for plain HTTP
+ * @param fd  The client socket file descriptor
+ * @return MESSAGE_STATUS_OK on success, otherwise MESSAGE_STATUS_ERROR
+ */
+int
+pgexporter_http_respond_404(SSL* ssl, int fd);
+
+/**
+ * Send an HTTP 301 Moved Permanently redirect.
+ * @param ssl      The SSL connection, or NULL for plain HTTP
+ * @param fd       The client socket file descriptor
+ * @param location The target URL for the Location header
+ * @return MESSAGE_STATUS_OK on success, otherwise MESSAGE_STATUS_ERROR
+ */
+int
+pgexporter_http_respond_redirect(SSL* ssl, int fd, const char* location);
+
+/**
+ * Begin a chunked HTTP 200 OK response.
+ * Must be followed by one or more pgexporter_http_respond_chunked_write() calls
+ * and exactly one pgexporter_http_respond_chunked_end() call.
+ * @param ssl          The SSL connection, or NULL for plain HTTP
+ * @param fd           The client socket file descriptor
+ * @param content_type The Content-Type header value
+ * @return MESSAGE_STATUS_OK on success, otherwise MESSAGE_STATUS_ERROR
+ */
+int
+pgexporter_http_respond_chunked_start(SSL* ssl, int fd, const char* content_type);
+
+/**
+ * Write one chunk of data in a chunked response.
+ * Must be called after pgexporter_http_respond_chunked_start().
+ * @param ssl  The SSL connection, or NULL for plain HTTP
+ * @param fd   The client socket file descriptor
+ * @param data Null-terminated chunk data (must not be NULL)
+ * @return MESSAGE_STATUS_OK on success, otherwise MESSAGE_STATUS_ERROR
+ */
+int
+pgexporter_http_respond_chunked_write(SSL* ssl, int fd, const char* data);
+
+/**
+ * Finish a chunked response by sending the terminal zero-length chunk.
+ * Must be called exactly once after all pgexporter_http_respond_chunked_write() calls.
+ * @param ssl The SSL connection, or NULL for plain HTTP
+ * @param fd  The client socket file descriptor
+ * @return MESSAGE_STATUS_OK on success, otherwise MESSAGE_STATUS_ERROR
+ */
+int
+pgexporter_http_respond_chunked_end(SSL* ssl, int fd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libpgexporter/bridge.c
+++ b/src/libpgexporter/bridge.c
@@ -30,6 +30,7 @@
 #include <pgexporter.h>
 #include <art.h>
 #include <bridge.h>
+#include <http_server.h>
 #include <cache.h>
 #include <deque.h>
 #include <logging.h>
@@ -53,19 +54,8 @@
 #define CHUNK_SIZE                       32768
 #define DEFAULT_BLOCKING_TIMEOUT_SECONDS 30
 
-#define PAGE_UNKNOWN                     0
-#define PAGE_HOME                        1
-#define PAGE_METRICS                     2
-#define BAD_REQUEST                      3
-
-static int resolve_page(struct message* msg);
-static int badrequest_page(int client_fd);
-static int unknown_page(int client_fd);
-static int home_page(int client_fd);
-static int metrics_page(int client_fd);
-static int bad_request(int client_fd);
-
-static int send_chunk(int client_fd, char* data);
+static int home_page(SSL* ssl, int fd);
+static int metrics_page(SSL* ssl, int fd);
 
 static bool is_bridge_cache_configured(void);
 static bool is_bridge_cache_valid(void);
@@ -78,262 +68,86 @@ static bool is_bridge_json_cache_configured(void);
 static bool bridge_json_cache_set(char* data);
 static size_t bridge_json_cache_size_to_alloc(void);
 
-static void bridge_metrics(int client_fd);
-static void bridge_json_metrics(int client_fd);
+static void bridge_metrics(SSL* ssl, int client_fd);
+static int bridge_json_metrics(SSL* ssl, int fd);
+
+static struct http_route bridge_routes[] = {
+   {"/", home_page},
+   {"/index.html", home_page},
+   {"/metrics", metrics_page},
+};
+
+static struct http_route bridge_json_routes[] = {
+   {"/", bridge_json_metrics},
+   {"/index.html", bridge_json_metrics},
+   {"/metrics", bridge_json_metrics},
+};
 
 void
 pgexporter_bridge(int client_fd)
 {
-   int status;
-   int page;
-   struct message* msg = NULL;
-   struct configuration* config;
+   struct http_server_request* req = NULL;
 
    pgexporter_start_logging();
    pgexporter_memory_init();
 
-   config = (struct configuration*)shmem;
-
-   status = pgexporter_read_timeout_message(
-      NULL, client_fd, (int)pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S), &msg);
-
-   if (status != MESSAGE_STATUS_OK)
+   if (pgexporter_http_server_parse(NULL, client_fd, &req) != MESSAGE_STATUS_OK)
    {
-      goto error;
-   }
-
-   page = resolve_page(msg);
-
-   if (page == PAGE_HOME)
-   {
-      home_page(client_fd);
-   }
-   else if (page == PAGE_METRICS)
-   {
-      metrics_page(client_fd);
-   }
-   else if (page == PAGE_UNKNOWN)
-   {
-      unknown_page(client_fd);
+      pgexporter_http_respond_400(NULL, client_fd);
    }
    else
    {
-      bad_request(client_fd);
+      pgexporter_http_server_dispatch(NULL, client_fd, req,
+                                      bridge_routes,
+                                      sizeof(bridge_routes) / sizeof(bridge_routes[0]));
    }
 
+   pgexporter_http_server_request_destroy(req);
    pgexporter_disconnect(client_fd);
-
    pgexporter_memory_destroy();
    pgexporter_stop_logging();
 
    exit(0);
-
-error:
-
-   badrequest_page(client_fd);
-
-   pgexporter_disconnect(client_fd);
-
-   pgexporter_memory_destroy();
-   pgexporter_stop_logging();
-
-   exit(1);
 }
 
 void
 pgexporter_bridge_json(int client_fd)
 {
-   int status;
-   int page;
-   struct message* msg = NULL;
-   struct configuration* config;
+   struct http_server_request* req = NULL;
 
    pgexporter_start_logging();
    pgexporter_memory_init();
 
-   config = (struct configuration*)shmem;
-
-   status = pgexporter_read_timeout_message(NULL, client_fd, (int)pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S), &msg);
-
-   if (status != MESSAGE_STATUS_OK)
+   if (pgexporter_http_server_parse(NULL, client_fd, &req) != MESSAGE_STATUS_OK)
    {
-      goto error;
-   }
-
-   page = resolve_page(msg);
-
-   if (page == PAGE_HOME || page == PAGE_METRICS)
-   {
-      bridge_json_metrics(client_fd);
-   }
-   else if (page == PAGE_UNKNOWN)
-   {
-      unknown_page(client_fd);
+      pgexporter_http_respond_400(NULL, client_fd);
    }
    else
    {
-      bad_request(client_fd);
+      pgexporter_http_server_dispatch(NULL, client_fd, req,
+                                      bridge_json_routes,
+                                      sizeof(bridge_json_routes) / sizeof(bridge_json_routes[0]));
    }
 
+   pgexporter_http_server_request_destroy(req);
    pgexporter_disconnect(client_fd);
-
    pgexporter_memory_destroy();
    pgexporter_stop_logging();
 
    exit(0);
-
-error:
-
-   badrequest_page(client_fd);
-
-   pgexporter_disconnect(client_fd);
-
-   pgexporter_memory_destroy();
-   pgexporter_stop_logging();
-
-   exit(1);
 }
 
 static int
-resolve_page(struct message* msg)
-{
-   char* from = NULL;
-   int index;
-
-   if (msg->length < 3 || strncmp((char*)msg->data, "GET", 3) != 0)
-   {
-      pgexporter_log_debug("Bridge: Not a GET request");
-      return BAD_REQUEST;
-   }
-
-   index = 4;
-   from = (char*)msg->data + index;
-
-   while (pgexporter_read_byte(msg->data + index) != ' ')
-   {
-      index++;
-   }
-
-   pgexporter_write_byte(msg->data + index, '\0');
-
-   if (strcmp(from, "/") == 0 || strcmp(from, "/index.html") == 0)
-   {
-      return PAGE_HOME;
-   }
-   else if (strcmp(from, "/metrics") == 0)
-   {
-      return PAGE_METRICS;
-   }
-
-   return PAGE_UNKNOWN;
-}
-
-static int
-badrequest_page(int client_fd)
-{
-   char* data = NULL;
-   time_t now;
-   char time_buf[32];
-   int status;
-   struct message msg;
-
-   memset(&msg, 0, sizeof(struct message));
-   memset(&data, 0, sizeof(data));
-
-   now = time(NULL);
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&now, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
-
-   data = pgexporter_vappend(data, 4,
-                             "HTTP/1.1 400 Bad Request\r\n",
-                             "Date: ",
-                             &time_buf[0],
-                             "\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
-   status = pgexporter_write_message(NULL, client_fd, &msg);
-
-   free(data);
-
-   return status;
-}
-
-static int
-unknown_page(int client_fd)
-{
-   char* data = NULL;
-   time_t now;
-   char time_buf[32];
-   int status;
-   struct message msg;
-
-   memset(&msg, 0, sizeof(struct message));
-   memset(&data, 0, sizeof(data));
-
-   now = time(NULL);
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&now, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
-
-   data = pgexporter_vappend(data, 4,
-                             "HTTP/1.1 403 Forbidden\r\n",
-                             "Date: ",
-                             &time_buf[0],
-                             "\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
-   status = pgexporter_write_message(NULL, client_fd, &msg);
-
-   free(data);
-
-   return status;
-}
-
-static int
-home_page(int client_fd)
+home_page(SSL* ssl, int fd)
 {
    char* data = NULL;
    int status;
-   time_t now;
-   char time_buf[32];
-   struct message msg;
 
-   now = time(NULL);
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&now, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
-
-   data = pgexporter_vappend(data, 7,
-                             "HTTP/1.1 200 OK\r\n",
-                             "Content-Type: text/html; charset=utf-8\r\n",
-                             "Date: ",
-                             &time_buf[0],
-                             "\r\n",
-                             "Transfer-Encoding: chunked\r\n",
-                             "\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
-   status = pgexporter_write_message(NULL, client_fd, &msg);
+   status = pgexporter_http_respond_chunked_start(ssl, fd, "text/html; charset=utf-8");
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
    }
-
-   free(data);
-   data = NULL;
 
    data = pgexporter_vappend(data, 13,
                              "<html>\n", "<head>\n",
@@ -349,16 +163,11 @@ home_page(int client_fd)
                              "</body>\n",
                              "</html>\n");
 
-   send_chunk(client_fd, data);
+   pgexporter_http_respond_chunked_write(ssl, fd, data);
    free(data);
    data = NULL;
 
-   /* Footer */
-   data = pgexporter_append(data, "\r\n\r\n");
-
-   send_chunk(client_fd, data);
-   free(data);
-   data = NULL;
+   pgexporter_http_respond_chunked_end(ssl, fd);
 
    return 0;
 
@@ -370,14 +179,11 @@ error:
 }
 
 static int
-metrics_page(int client_fd)
+metrics_page(SSL* ssl, int fd)
 {
-   char* data = NULL;
    time_t start_time;
    int dt;
-   char time_buf[32];
    int status;
-   struct message msg;
    struct prometheus_cache* cache;
    signed char cache_is_free;
    struct configuration* config;
@@ -385,13 +191,7 @@ metrics_page(int client_fd)
    config = (struct configuration*)shmem;
    cache = (struct prometheus_cache*)bridge_cache_shmem;
 
-   memset(&msg, 0, sizeof(struct message));
-
    start_time = time(NULL);
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&start_time, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
 
 retry_cache_locking:
    cache_is_free = STATE_FREE;
@@ -402,48 +202,16 @@ retry_cache_locking:
       {
          // serve the message directly out of the cache
          pgexporter_log_debug("Serving bridge out of cache (%d/%d bytes valid until %lld)",
-                              strlen(cache->data),
-                              cache->size,
-                              cache->valid_until);
+                              strlen(cache->data), cache->size, cache->valid_until);
 
-         /* Header */
-         data = pgexporter_vappend(data, 7,
-                                   "HTTP/1.1 200 OK\r\n",
-                                   "Content-Type: text/plain; charset=utf-8\r\n",
-                                   "Date: ", &time_buf[0], "\r\n",
-                                   "Transfer-Encoding: chunked\r\n", "\r\n");
-
-         msg.kind = 0;
-         msg.length = strlen(data);
-         msg.data = data;
-
-         status = pgexporter_write_message(NULL, client_fd, &msg);
+         status = pgexporter_http_respond_chunked_start(ssl, fd, "text/plain; charset=utf-8");
          if (status != MESSAGE_STATUS_OK)
          {
             goto error;
          }
 
-         free(data);
-         data = NULL;
-
-         /* Cache */
-         send_chunk(client_fd, cache->data);
-
-         /* Footer */
-         data = pgexporter_append(data, "0\r\n\r\n");
-
-         msg.kind = 0;
-         msg.length = strlen(data);
-         msg.data = data;
-
-         status = pgexporter_write_message(NULL, client_fd, &msg);
-         if (status != MESSAGE_STATUS_OK)
-         {
-            goto error;
-         }
-
-         free(data);
-         data = NULL;
+         pgexporter_http_respond_chunked_write(ssl, fd, cache->data);
+         pgexporter_http_respond_chunked_end(ssl, fd);
       }
       else
       {
@@ -451,44 +219,17 @@ retry_cache_locking:
 
          bridge_cache_invalidate();
 
-         data = pgexporter_vappend(data, 7,
-                                   "HTTP/1.1 200 OK\r\n",
-                                   "Content-Type: text/plain; version=0.0.1; charset=utf-8\r\n",
-                                   "Date: ", &time_buf[0], "\r\n",
-                                   "Transfer-Encoding: chunked\r\n",
-                                   "\r\n");
-
-         msg.kind = 0;
-         msg.length = strlen(data);
-         msg.data = data;
-
-         status = pgexporter_write_message(NULL, client_fd, &msg);
+         status = pgexporter_http_respond_chunked_start(ssl, fd,
+                                                        "text/plain; version=0.0.1; charset=utf-8");
          if (status != MESSAGE_STATUS_OK)
          {
             goto error;
          }
 
-         free(data);
-         data = NULL;
-
-         /* Metrics */
-         bridge_metrics(client_fd);
-
-         /* Footer */
-         data = pgexporter_append(data, "0\r\n\r\n");
-
-         msg.kind = 0;
-         msg.length = strlen(data);
-         msg.data = data;
-
-         status = pgexporter_write_message(NULL, client_fd, &msg);
-         if (status != MESSAGE_STATUS_OK)
-         {
-            goto error;
-         }
+         bridge_metrics(ssl, fd);
+         pgexporter_http_respond_chunked_end(ssl, fd);
       }
 
-      // free the cache
       atomic_store(&cache->lock, STATE_FREE);
    }
    else
@@ -503,87 +244,11 @@ retry_cache_locking:
       SLEEP_AND_GOTO(10000000L, retry_cache_locking);
    }
 
-   free(data);
-
    return 0;
 
 error:
 
-   free(data);
-
    return 1;
-}
-
-static int
-bad_request(int client_fd)
-{
-   char* data = NULL;
-   time_t now;
-   char time_buf[32];
-   int status;
-   struct message msg;
-
-   memset(&msg, 0, sizeof(struct message));
-   memset(&data, 0, sizeof(data));
-
-   now = time(NULL);
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&now, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
-
-   data = pgexporter_vappend(data, 4,
-                             "HTTP/1.1 400 Bad Request\r\n",
-                             "Date: ",
-                             &time_buf[0],
-                             "\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
-   status = pgexporter_write_message(NULL, client_fd, &msg);
-
-   free(data);
-
-   return status;
-}
-
-static int
-send_chunk(int client_fd, char* data)
-{
-   int status;
-   char* m = NULL;
-   struct message msg;
-
-   memset(&msg, 0, sizeof(struct message));
-
-   m = malloc(20);
-
-   if (m == NULL)
-   {
-      goto error;
-   }
-
-   memset(m, 0, 20);
-
-   sprintf(m, "%zX\r\n", strlen(data));
-
-   m = pgexporter_vappend(m, 2, data, "\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(m);
-   msg.data = m;
-
-   status = pgexporter_write_message(NULL, client_fd, &msg);
-
-   free(m);
-
-   return status;
-
-error:
-
-   return MESSAGE_STATUS_ERROR;
 }
 
 /**
@@ -888,7 +553,7 @@ bridge_json_cache_set(char* data)
 }
 
 static void
-bridge_metrics(int client_fd)
+bridge_metrics(SSL* ssl, int client_fd)
 {
    time_t start_time;
    int dt;
@@ -1035,7 +700,7 @@ retry_cache_json_locking:
          bridge_cache_append(data);
       }
 
-      send_chunk(client_fd, data);
+      pgexporter_http_respond_chunked_write(ssl, client_fd, data);
 
       pgexporter_deque_iterator_destroy(definition_iterator);
 
@@ -1075,15 +740,12 @@ error:
    pgexporter_prometheus_client_destroy_bridge(bridge);
 }
 
-static void
-bridge_json_metrics(int client_fd)
+static int
+bridge_json_metrics(SSL* ssl, int fd)
 {
-   char* data = NULL;
    time_t start_time;
    int dt;
-   char time_buf[32];
    int status;
-   struct message msg;
    struct prometheus_cache* cache;
    signed char cache_is_free;
    struct configuration* config = NULL;
@@ -1092,15 +754,7 @@ bridge_json_metrics(int client_fd)
    cache = (struct prometheus_cache*)bridge_json_cache_shmem;
 
    cache_is_free = STATE_FREE;
-
    start_time = time(NULL);
-
-   memset(&msg, 0, sizeof(struct message));
-   memset(&data, 0, sizeof(data));
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&start_time, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
 
 retry_cache_locking:
    if (is_bridge_json_cache_configured())
@@ -1117,51 +771,22 @@ retry_cache_locking:
          SLEEP_AND_GOTO(10000000L, retry_cache_locking);
       }
 
-      /* Header */
-      data = pgexporter_vappend(data, 7,
-                                "HTTP/1.1 200 OK\r\n",
-                                "Content-Type: text/plain; charset=utf-8\r\n",
-                                "Date: ", &time_buf[0], "\r\n",
-                                "Transfer-Encoding: chunked\r\n", "\r\n");
-
-      msg.kind = 0;
-      msg.length = strlen(data);
-      msg.data = data;
-
-      status = pgexporter_write_message(NULL, client_fd, &msg);
+      status = pgexporter_http_respond_chunked_start(ssl, fd, "text/plain; charset=utf-8");
       if (status != MESSAGE_STATUS_OK)
       {
          goto error;
       }
 
-      free(data);
-      data = NULL;
-
-      /* Cache */
       if (strlen(cache->data) > 0)
       {
-         send_chunk(client_fd, cache->data);
+         pgexporter_http_respond_chunked_write(ssl, fd, cache->data);
       }
       else
       {
-         send_chunk(client_fd, "{\n}\n");
+         pgexporter_http_respond_chunked_write(ssl, fd, "{\n}\n");
       }
 
-      /* Footer */
-      data = pgexporter_append(data, "0\r\n\r\n");
-
-      msg.kind = 0;
-      msg.length = strlen(data);
-      msg.data = data;
-
-      status = pgexporter_write_message(NULL, client_fd, &msg);
-      if (status != MESSAGE_STATUS_OK)
-      {
-         goto error;
-      }
-
-      free(data);
-      data = NULL;
+      pgexporter_http_respond_chunked_end(ssl, fd);
 
       atomic_store(&cache->lock, STATE_FREE);
    }
@@ -1170,9 +795,10 @@ retry_cache_locking:
       goto error;
    }
 
-   return;
+   return MESSAGE_STATUS_OK;
 
 error:
 
-   pgexporter_log_error("bridge_json_metrics called");
+   pgexporter_log_error("bridge_json_metrics: failed to serve response");
+   return MESSAGE_STATUS_ERROR;
 }

--- a/src/libpgexporter/console.c
+++ b/src/libpgexporter/console.c
@@ -30,6 +30,7 @@
 #include <pgexporter.h>
 #include <console.h>
 #include <http.h>
+#include <http_server.h>
 #include <logging.h>
 #include <memory.h>
 #include <network.h>
@@ -138,20 +139,10 @@ struct category_candidate
 #define PREFIX_COUNT_INITIAL_CAP       32
 #define CATEGORY_CANDIDATE_INITIAL_CAP 16
 #define CATEGORY_SELECT_INITIAL_CAP    16
-#define TLS_PROBE_SIZE                 5
-#define TLS_HANDSHAKE_BYTE             0x16
-#define TLS_SSL2_BYTE                  0x80
-
-/* Page routing constants */
-#define PAGE_UNKNOWN 0
-#define PAGE_HOME    1
-#define PAGE_API     2
-#define BAD_REQUEST  3
 
 static int build_categories_from_bridge(struct prometheus_bridge* bridge, struct console_page* console);
 static int record_prefix_counts(const char* metric_name, struct prefix_count** counts, int* size, int* capacity);
 static int add_or_increment_prefix(struct prefix_count** counts, int* size, int* capacity, const char* prefix);
-static int send_http_response(SSL* client_ssl, int client_fd, const char* content_type, void* body, size_t body_len, const char* page_name);
 static int count_prefix_depth(const char* prefix);
 static int build_category_candidates(struct prefix_count* counts, int size, struct category_candidate** candidates, int* candidate_count);
 static int compare_candidates_by_score(const void* a, const void* b);
@@ -167,8 +158,6 @@ static int collect_simple_label_columns(struct console_category* category, char*
 static const char* find_metric_label_value(struct console_metric* metric, const char* key);
 static char* generate_metrics_table(struct console_category* category);
 static char* generate_category_tabs(struct console_page* console);
-static int resolve_page(struct message* msg);
-static int badrequest_page(SSL* client_ssl, int client_fd);
 static int home_page(SSL* client_ssl, int client_fd);
 static int api_page(SSL* client_ssl, int client_fd);
 static int console_init(int endpoint, const char* brand_name, const char* metric_prefix, struct console_page** result);
@@ -178,102 +167,12 @@ static int console_generate_html(struct console_page* console, char** html, size
 static int console_generate_json(struct console_page* console, char** json, size_t* json_size);
 static int console_destroy(struct console_page* console);
 
-static int
-resolve_page(struct message* msg)
-{
-   char* from = NULL;
-   int index;
-
-   if (msg->length < 3 || strncmp((char*)msg->data, "GET", 3) != 0)
-   {
-      return BAD_REQUEST;
-   }
-
-   index = 4;
-   from = (char*)msg->data + index;
-
-   while (pgexporter_read_byte(msg->data + index) != ' ')
-   {
-      index++;
-   }
-
-   pgexporter_write_byte(msg->data + index, '\0');
-
-   if (strcmp(from, "/") == 0 || strcmp(from, "/index.html") == 0)
-   {
-      return PAGE_HOME;
-   }
-   else if (strcmp(from, "/api") == 0 || strcmp(from, "/api/") == 0)
-   {
-      return PAGE_API;
-   }
-   return PAGE_UNKNOWN;
-}
-
-static int
-send_http_response(SSL* client_ssl, int client_fd, const char* content_type, void* body, size_t body_len, const char* page_name)
-{
-   struct message msg;
-   char response_header[512];
-   int header_len;
-   int status = MESSAGE_STATUS_OK;
-
-   memset(&msg, 0, sizeof(struct message));
-   header_len = pgexporter_snprintf(response_header, sizeof(response_header),
-                                    "HTTP/1.1 200 OK\r\n"
-                                    "Content-Type: %s\r\n"
-                                    "Content-Length: %zu\r\n"
-                                    "Connection: close\r\n"
-                                    "\r\n",
-                                    content_type,
-                                    body_len);
-
-   msg.data = response_header;
-   msg.length = header_len;
-   status = pgexporter_write_message(client_ssl, client_fd, &msg);
-   if (status != MESSAGE_STATUS_OK)
-   {
-      pgexporter_log_error("console %s: failed to write header (status=%d, len=%d)", page_name, status, header_len);
-   }
-
-   if (status == MESSAGE_STATUS_OK && body_len > 0)
-   {
-      memset(&msg, 0, sizeof(struct message));
-      msg.data = body;
-      msg.length = body_len;
-      status = pgexporter_write_message(client_ssl, client_fd, &msg);
-      if (status != MESSAGE_STATUS_OK)
-      {
-         pgexporter_log_error("console %s: failed to write body (status=%d, len=%zu)", page_name, status, body_len);
-      }
-   }
-
-   return status;
-}
-
-static int
-badrequest_page(SSL* client_ssl, int client_fd)
-{
-   struct message msg;
-   char* data = NULL;
-   int status;
-
-   memset(&msg, 0, sizeof(struct message));
-
-   data = pgexporter_append(data, "HTTP/1.1 400 Bad Request\r\n");
-   data = pgexporter_append(data, "Content-Length: 0\r\n");
-   data = pgexporter_append(data, "Connection: close\r\n\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
-   status = pgexporter_write_message(client_ssl, client_fd, &msg);
-
-   free(data);
-
-   return status;
-}
+static struct http_route console_routes[] = {
+   {"/", home_page},
+   {"/index.html", home_page},
+   {"/api", api_page},
+   {"/api/", api_page},
+};
 
 static int
 console_init(int endpoint, const char* brand_name, const char* metric_prefix, struct console_page** result)
@@ -339,28 +238,28 @@ home_page(SSL* client_ssl, int client_fd)
    struct console_page* console = NULL;
    char* html = NULL;
    size_t html_size = 0;
-   int status = 0;
+   int status = MESSAGE_STATUS_OK;
 
    if (console_init(0, "pgexporter", "pgexporter_", &console))
    {
       pgexporter_log_error("Failed to initialize console");
-      status = 1;
-      goto error;
+      status = MESSAGE_STATUS_ERROR;
+      goto done;
    }
 
    if (console_generate_html(console, &html, &html_size))
    {
       pgexporter_log_error("Failed to generate HTML");
-      status = 1;
-      goto error;
+      status = MESSAGE_STATUS_ERROR;
+      goto done;
    }
 
-   status = send_http_response(client_ssl, client_fd, "text/html; charset=utf-8", html, html_size, "home_page");
+   status = pgexporter_http_respond_ok(client_ssl, client_fd, "text/html; charset=utf-8", html, html_size);
 
-error:
-   if (status != 0)
+done:
+   if (status != MESSAGE_STATUS_OK)
    {
-      badrequest_page(client_ssl, client_fd);
+      pgexporter_http_respond_400(client_ssl, client_fd);
    }
    free(html);
    if (console != NULL)
@@ -377,28 +276,28 @@ api_page(SSL* client_ssl, int client_fd)
    struct console_page* console = NULL;
    char* json = NULL;
    size_t json_size = 0;
-   int status = 0;
+   int status = MESSAGE_STATUS_OK;
 
    if (console_init(0, "pgexporter", "pgexporter_", &console))
    {
       pgexporter_log_error("Failed to initialize console for API");
-      status = 1;
-      goto error;
+      status = MESSAGE_STATUS_ERROR;
+      goto done;
    }
 
    if (console_generate_json(console, &json, &json_size))
    {
       pgexporter_log_error("Failed to generate JSON");
-      status = 1;
-      goto error;
+      status = MESSAGE_STATUS_ERROR;
+      goto done;
    }
 
-   status = send_http_response(client_ssl, client_fd, "application/json; charset=utf-8", json, json_size, "api_page");
+   status = pgexporter_http_respond_ok(client_ssl, client_fd, "application/json; charset=utf-8", json, json_size);
 
-error:
-   if (status != 0)
+done:
+   if (status != MESSAGE_STATUS_OK)
    {
-      badrequest_page(client_ssl, client_fd);
+      pgexporter_http_respond_400(client_ssl, client_fd);
    }
    free(json);
    if (console != NULL)
@@ -2183,54 +2082,23 @@ generate_category_tabs(struct console_page* console)
 void
 pgexporter_console(SSL* client_ssl, int client_fd)
 {
-   struct configuration* config = (struct configuration*)shmem;
-   struct message* msg = NULL;
-   int page;
+   struct http_server_request* req = NULL;
    int status = MESSAGE_STATUS_OK;
 
    pgexporter_start_logging();
    pgexporter_memory_init();
 
-   if (client_ssl)
-   {
-      char buffer[TLS_PROBE_SIZE] = {0};
-
-      recv(client_fd, buffer, TLS_PROBE_SIZE, MSG_PEEK);
-
-      if ((unsigned char)buffer[0] == TLS_HANDSHAKE_BYTE || (unsigned char)buffer[0] == TLS_SSL2_BYTE) // SSL/TLS request
-      {
-         if (SSL_accept(client_ssl) <= 0)
-         {
-            pgexporter_log_error("Failed to accept SSL connection");
-            goto error;
-         }
-      }
-   }
-
-   status = pgexporter_read_timeout_message(client_ssl, client_fd,
-                                            (int)pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S),
-                                            &msg);
-   if (status != MESSAGE_STATUS_OK)
+   if (pgexporter_http_server_parse(client_ssl, client_fd, &req) != MESSAGE_STATUS_OK)
    {
       goto error;
    }
 
-   page = resolve_page(msg);
-
-   if (page == PAGE_HOME)
-   {
-      status = home_page(client_ssl, client_fd);
-   }
-   else if (page == PAGE_API)
-   {
-      status = api_page(client_ssl, client_fd);
-   }
-   else
-   {
-      status = badrequest_page(client_ssl, client_fd);
-   }
+   status = pgexporter_http_server_dispatch(client_ssl, client_fd, req,
+                                            console_routes,
+                                            sizeof(console_routes) / sizeof(console_routes[0]));
 
 error:
+   pgexporter_http_server_request_destroy(req);
    pgexporter_close_ssl(client_ssl);
    pgexporter_disconnect(client_fd);
 

--- a/src/libpgexporter/http_server.c
+++ b/src/libpgexporter/http_server.c
@@ -1,0 +1,367 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* pgexporter */
+#include <pgexporter.h>
+#include <http_server.h>
+#include <logging.h>
+#include <message.h>
+#include <shmem.h>
+#include <utils.h>
+
+/* system */
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+
+static void
+fill_date(char* buf, size_t len)
+{
+   time_t now = time(NULL);
+   ctime_r(&now, buf);
+   buf[strlen(buf) - 1] = '\0'; /* strip trailing newline */
+   (void)len;
+}
+
+int
+pgexporter_http_server_ssl_accept(SSL* ssl, int fd)
+{
+   char buffer[5] = {0};
+
+   if (ssl == NULL)
+   {
+      return MESSAGE_STATUS_OK;
+   }
+
+   recv(fd, buffer, 5, MSG_PEEK);
+
+   if ((unsigned char)buffer[0] == 0x16 || (unsigned char)buffer[0] == 0x80)
+   {
+      if (SSL_accept(ssl) <= 0)
+      {
+         pgexporter_log_error("http_server: SSL_accept failed");
+         return MESSAGE_STATUS_ERROR;
+      }
+      return MESSAGE_STATUS_OK;
+   }
+
+   return MESSAGE_STATUS_ZERO; /* plain HTTP on a TLS-configured socket */
+}
+
+int
+pgexporter_http_server_parse(SSL* ssl, int fd, struct http_server_request** req)
+{
+   struct message* msg = NULL;
+   struct configuration* config;
+   struct http_server_request* r = NULL;
+   char* from = NULL;
+   int index;
+   int status;
+
+   *req = NULL;
+
+   config = (struct configuration*)shmem;
+
+   status = pgexporter_read_timeout_message(ssl, fd,
+                                            (int)pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S),
+                                            &msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      pgexporter_log_debug("http_server: failed to read request");
+      return MESSAGE_STATUS_ERROR;
+   }
+
+   if (msg == NULL || msg->data == NULL || msg->length < 3 ||
+       strncmp((char*)msg->data, "GET", 3) != 0)
+   {
+      pgexporter_log_debug("http_server: not a GET request");
+      return MESSAGE_STATUS_ERROR;
+   }
+
+   index = 4;
+   from = (char*)msg->data + index;
+
+   while (index < (int)msg->length && pgexporter_read_byte(msg->data + index) != ' ')
+   {
+      index++;
+   }
+
+   if (index >= (int)msg->length)
+   {
+      pgexporter_log_debug("http_server: malformed request line");
+      return MESSAGE_STATUS_ERROR;
+   }
+
+   pgexporter_write_byte(msg->data + index, '\0');
+
+   r = malloc(sizeof(struct http_server_request));
+   if (r == NULL)
+   {
+      return MESSAGE_STATUS_ERROR;
+   }
+
+   memset(r, 0, sizeof(struct http_server_request));
+   strncpy(r->path, from, sizeof(r->path) - 1);
+
+   *req = r;
+   return MESSAGE_STATUS_OK;
+}
+
+void
+pgexporter_http_server_request_destroy(struct http_server_request* req)
+{
+   free(req);
+}
+
+int
+pgexporter_http_server_dispatch(SSL* ssl, int fd, struct http_server_request* req,
+                                struct http_route* routes, int n_routes)
+{
+   if (req == NULL)
+   {
+      return pgexporter_http_respond_400(ssl, fd);
+   }
+
+   for (int i = 0; i < n_routes; i++)
+   {
+      if (strcmp(req->path, routes[i].path) == 0)
+      {
+         return routes[i].handler(ssl, fd);
+      }
+   }
+
+   pgexporter_log_debug("http_server: no route for path '%s'", req->path);
+   return pgexporter_http_respond_404(ssl, fd);
+}
+
+int
+pgexporter_http_respond_ok(SSL* ssl, int fd, const char* content_type,
+                           const void* body, size_t len)
+{
+   char header[512];
+   int header_len;
+   struct message msg;
+   int status;
+
+   memset(&msg, 0, sizeof(struct message));
+
+   header_len = pgexporter_snprintf(header, sizeof(header),
+                                    "HTTP/1.1 200 OK\r\n"
+                                    "Content-Type: %s\r\n"
+                                    "Content-Length: %zu\r\n"
+                                    "Connection: close\r\n"
+                                    "\r\n",
+                                    content_type, len);
+
+   msg.data = header;
+   msg.length = header_len;
+   status = pgexporter_write_message(ssl, fd, &msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      return status;
+   }
+
+   if (len > 0 && body != NULL)
+   {
+      memset(&msg, 0, sizeof(struct message));
+      msg.data = (void*)body;
+      msg.length = len;
+      status = pgexporter_write_message(ssl, fd, &msg);
+   }
+
+   return status;
+}
+
+int
+pgexporter_http_respond_400(SSL* ssl, int fd)
+{
+   char* data = NULL;
+   struct message msg;
+   int status;
+
+   memset(&msg, 0, sizeof(struct message));
+
+   data = pgexporter_append(data, "HTTP/1.1 400 Bad Request\r\n");
+   data = pgexporter_append(data, "Content-Length: 0\r\n");
+   data = pgexporter_append(data, "Connection: close\r\n");
+   data = pgexporter_append(data, "\r\n");
+
+   msg.kind = 0;
+   msg.length = strlen(data);
+   msg.data = data;
+
+   status = pgexporter_write_message(ssl, fd, &msg);
+
+   free(data);
+   return status;
+}
+
+int
+pgexporter_http_respond_404(SSL* ssl, int fd)
+{
+   char* data = NULL;
+   char time_buf[32];
+   struct message msg;
+   int status;
+
+   memset(&msg, 0, sizeof(struct message));
+   fill_date(time_buf, sizeof(time_buf));
+
+   data = pgexporter_vappend(data, 6,
+                             "HTTP/1.1 404 Not Found\r\n",
+                             "Date: ",
+                             time_buf,
+                             "\r\n",
+                             "Content-Length: 0\r\n",
+                             "Connection: close\r\n\r\n");
+
+   msg.kind = 0;
+   msg.length = strlen(data);
+   msg.data = data;
+
+   status = pgexporter_write_message(ssl, fd, &msg);
+
+   free(data);
+   return status;
+}
+
+int
+pgexporter_http_respond_redirect(SSL* ssl, int fd, const char* location)
+{
+   char* data = NULL;
+   char time_buf[32];
+   struct message msg;
+   int status;
+
+   memset(&msg, 0, sizeof(struct message));
+   fill_date(time_buf, sizeof(time_buf));
+
+   data = pgexporter_append(data, "HTTP/1.1 301 Moved Permanently\r\n");
+   data = pgexporter_append(data, "Location: ");
+   data = pgexporter_append(data, (char*)location);
+   data = pgexporter_append(data, "\r\n");
+   data = pgexporter_append(data, "Date: ");
+   data = pgexporter_append(data, time_buf);
+   data = pgexporter_append(data, "\r\n");
+   data = pgexporter_append(data, "Content-Length: 0\r\n");
+   data = pgexporter_append(data, "Connection: close\r\n");
+   data = pgexporter_append(data, "\r\n");
+
+   msg.kind = 0;
+   msg.length = strlen(data);
+   msg.data = data;
+
+   status = pgexporter_write_message(ssl, fd, &msg);
+
+   free(data);
+   return status;
+}
+
+int
+pgexporter_http_respond_chunked_start(SSL* ssl, int fd, const char* content_type)
+{
+   char* data = NULL;
+   char time_buf[32];
+   struct message msg;
+   int status;
+
+   memset(&msg, 0, sizeof(struct message));
+   fill_date(time_buf, sizeof(time_buf));
+
+   data = pgexporter_vappend(data, 7,
+                             "HTTP/1.1 200 OK\r\n",
+                             "Content-Type: ",
+                             content_type,
+                             "\r\n",
+                             "Date: ",
+                             time_buf,
+                             "\r\nTransfer-Encoding: chunked\r\n\r\n");
+
+   msg.kind = 0;
+   msg.length = strlen(data);
+   msg.data = data;
+
+   status = pgexporter_write_message(ssl, fd, &msg);
+
+   free(data);
+   return status;
+}
+
+int
+pgexporter_http_respond_chunked_write(SSL* ssl, int fd, const char* data)
+{
+   char* m = NULL;
+   struct message msg;
+   int status;
+
+   memset(&msg, 0, sizeof(struct message));
+
+   if (data == NULL)
+   {
+      return MESSAGE_STATUS_ERROR;
+   }
+
+   m = malloc(20);
+   if (m == NULL)
+   {
+      return MESSAGE_STATUS_ERROR;
+   }
+   memset(m, 0, 20);
+
+   pgexporter_snprintf(m, 20, "%zX\r\n", strlen(data));
+
+   m = pgexporter_vappend(m, 2, data, "\r\n");
+   if (m == NULL)
+   {
+      return MESSAGE_STATUS_ERROR;
+   }
+
+   msg.kind = 0;
+   msg.length = strlen(m);
+   msg.data = m;
+
+   status = pgexporter_write_message(ssl, fd, &msg);
+
+   free(m);
+   return status;
+}
+
+int
+pgexporter_http_respond_chunked_end(SSL* ssl, int fd)
+{
+   struct message msg;
+
+   memset(&msg, 0, sizeof(struct message));
+   msg.kind = 0;
+   msg.data = "0\r\n\r\n";
+   msg.length = 5;
+
+   return pgexporter_write_message(ssl, fd, &msg);
+}

--- a/src/libpgexporter/prometheus.c
+++ b/src/libpgexporter/prometheus.c
@@ -34,6 +34,7 @@
 #include <fips.h>
 #include <history.h>
 #include <http.h>
+#include <http_server.h>
 #include <logging.h>
 #include <memory.h>
 #include <message.h>
@@ -57,11 +58,6 @@
 
 #define CHUNK_SIZE                       32768
 #define DEFAULT_BLOCKING_TIMEOUT_SECONDS 30
-
-#define PAGE_UNKNOWN                     0
-#define PAGE_HOME                        1
-#define PAGE_METRICS                     2
-#define BAD_REQUEST                      3
 
 #define MAX_ARR_LENGTH                   256
 #define NUMBER_OF_HISTOGRAM_COLUMNS      4
@@ -137,13 +133,8 @@ static int add_metric_to_art(struct art* art_tree, char* key, char* value,
 static void output_art_metrics(SSL* client_ssl, int client_fd, struct art* art_tree);
 static void output_all_metrics(SSL* client_ssl, int client_fd, prometheus_metrics_container_t* container);
 
-static int resolve_page(struct message* msg);
-static int badrequest_page(SSL* client_ssl, int client_fd);
-static int unknown_page(SSL* client_ssl, int client_fd);
 static int home_page(SSL* client_ssl, int client_fd);
 static int metrics_page(SSL* client_ssl, int client_fd);
-static int bad_request(SSL* client_ssl, int client_fd);
-static int redirect_page(SSL* client_ssl, int client_fd, char* path);
 
 static bool allowed_collector(const char* collector);
 static bool excluded_collector(const char* collector);
@@ -173,7 +164,6 @@ static void handle_default_histogram(column_store_t* store, int* n_store, query_
 static void handle_gauge_counter(column_store_t* store, int* n_store, query_list_t* temp);
 static void handle_default_gauge_counter(column_store_t* store, int* n_store, query_list_t* temp);
 
-static int send_chunk(SSL* client_ssl, int client_fd, char* data);
 static int parse_list(char* list_str, char** strs, int* n_strs);
 
 static char* get_value(char* tag, char* name, char* val);
@@ -189,44 +179,51 @@ static bool metrics_cache_finalize(void);
 static size_t metrics_cache_size_to_alloc(void);
 static void metrics_cache_invalidate(void);
 
+static struct http_route prometheus_routes[] = {
+   {"/", home_page},
+   {"/index.html", home_page},
+   {"/metrics", metrics_page},
+};
+
 void
 pgexporter_prometheus(SSL* client_ssl, int client_fd)
 {
-   int status;
-   int page;
-   struct message* msg = NULL;
+   struct http_server_request* req = NULL;
    struct configuration* config;
 
    pgexporter_start_logging();
    pgexporter_memory_init();
 
    config = (struct configuration*)shmem;
+
    if (client_ssl)
    {
-      char buffer[5] = {0};
+      int ssl_status = pgexporter_http_server_ssl_accept(client_ssl, client_fd);
 
-      recv(client_fd, buffer, 5, MSG_PEEK);
-
-      if ((unsigned char)buffer[0] == 0x16 || (unsigned char)buffer[0] == 0x80) // SSL/TLS request
+      if (ssl_status == MESSAGE_STATUS_ERROR)
       {
-         if (SSL_accept(client_ssl) <= 0)
-         {
-            pgexporter_log_error("Failed to accept SSL connection");
-            goto error;
-         }
+         pgexporter_log_error("Metrics: SSL accept failed");
+         goto error;
       }
-      else
+
+      if (ssl_status == MESSAGE_STATUS_ZERO)
       {
+         /*
+          * Plain HTTP on a TLS port — redirect to HTTPS. Read the raw message
+          * here (not via pgexporter_http_server_parse) because we need the path
+          * for the redirect URL and the process exits immediately after.
+          */
+         struct message* redirect_msg = NULL;
          char* path = "/";
          char* base_url = NULL;
 
-         if (pgexporter_read_timeout_message(NULL, client_fd, (int)pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S), &msg) != MESSAGE_STATUS_OK)
+         if (pgexporter_read_timeout_message(NULL, client_fd, (int)pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S), &redirect_msg) != MESSAGE_STATUS_OK)
          {
-            pgexporter_log_error("Failed to read message");
+            pgexporter_log_error("Failed to read redirect message");
             goto error;
          }
 
-         char* path_start = strstr(msg->data, " ");
+         char* path_start = strstr(redirect_msg->data, " ");
          if (path_start)
          {
             path_start++;
@@ -240,70 +237,49 @@ pgexporter_prometheus(SSL* client_ssl, int client_fd)
 
          base_url = pgexporter_format_and_append(base_url, "https://localhost:%d%s", config->metrics, path);
 
-         if (redirect_page(NULL, client_fd, base_url) != MESSAGE_STATUS_OK)
+         if (pgexporter_http_respond_redirect(NULL, client_fd, base_url) != MESSAGE_STATUS_OK)
          {
             pgexporter_log_error("Failed to redirect to: %s", base_url);
             free(base_url);
             goto error;
          }
 
+         free(base_url);
          pgexporter_close_ssl(client_ssl);
          pgexporter_disconnect(client_fd);
-
          pgexporter_memory_destroy();
          pgexporter_stop_logging();
-
-         free(base_url);
-
          exit(0);
       }
+      /* MESSAGE_STATUS_OK: TLS handshake done, proceed to parse */
    }
-   status = pgexporter_read_timeout_message(client_ssl, client_fd, (int)pgexporter_time_convert(config->authentication_timeout, FORMAT_TIME_S), &msg);
 
-   if (status != MESSAGE_STATUS_OK)
+   if (pgexporter_http_server_parse(client_ssl, client_fd, &req) != MESSAGE_STATUS_OK)
    {
       goto error;
    }
 
-   page = resolve_page(msg);
+   pgexporter_http_server_dispatch(client_ssl, client_fd, req,
+                                   prometheus_routes,
+                                   sizeof(prometheus_routes) / sizeof(prometheus_routes[0]));
 
-   if (page == PAGE_HOME)
-   {
-      home_page(client_ssl, client_fd);
-   }
-   else if (page == PAGE_METRICS)
-   {
-      metrics_page(client_ssl, client_fd);
-   }
-   else if (page == PAGE_UNKNOWN)
-   {
-      unknown_page(client_ssl, client_fd);
-   }
-   else
-   {
-      bad_request(client_ssl, client_fd);
-   }
-
+   pgexporter_http_server_request_destroy(req);
    pgexporter_close_ssl(client_ssl);
    pgexporter_disconnect(client_fd);
-
    pgexporter_memory_destroy();
    pgexporter_stop_logging();
-
    OPENSSL_cleanup();
 
    exit(0);
 
 error:
 
-   badrequest_page(client_ssl, client_fd);
-
+   pgexporter_http_respond_400(client_ssl, client_fd);
+   pgexporter_http_server_request_destroy(req);
    pgexporter_close_ssl(client_ssl);
    pgexporter_disconnect(client_fd);
-
    pgexporter_memory_destroy();
    pgexporter_stop_logging();
-
    OPENSSL_cleanup();
 
    exit(1);
@@ -366,194 +342,19 @@ pgexporter_prometheus_logging(int type)
 }
 
 static int
-redirect_page(SSL* client_ssl, int client_fd, char* path)
-{
-   char* data = NULL;
-   time_t now;
-   char time_buf[32];
-   int status;
-   struct message msg;
-
-   memset(&msg, 0, sizeof(struct message));
-   memset(&data, 0, sizeof(data));
-
-   now = time(NULL);
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&now, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
-
-   data = pgexporter_append(data, "HTTP/1.1 301 Moved Permanently\r\n");
-   data = pgexporter_append(data, "Location: ");
-   data = pgexporter_append(data, path);
-   data = pgexporter_append(data, "\r\n");
-   data = pgexporter_append(data, "Date: ");
-   data = pgexporter_append(data, &time_buf[0]);
-   data = pgexporter_append(data, "\r\n");
-   data = pgexporter_append(data, "Content-Length: 0\r\n");
-   data = pgexporter_append(data, "Connection: close\r\n");
-   data = pgexporter_append(data, "\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
-   status = pgexporter_write_message(client_ssl, client_fd, &msg);
-
-   free(data);
-
-   return status;
-}
-
-static int
-resolve_page(struct message* msg)
-{
-   char* from = NULL;
-   int index;
-
-   if (msg == NULL || msg->data == NULL || msg->length < 3 ||
-       strncmp((char*)msg->data, "GET", 3) != 0)
-   {
-      pgexporter_log_debug("Prometheus: Not a GET request");
-      return BAD_REQUEST;
-   }
-
-   index = 4;
-   from = (char*)msg->data + index;
-
-   while (index < msg->length && pgexporter_read_byte(msg->data + index) != ' ')
-   {
-      index++;
-   }
-
-   if (index >= msg->length)
-   {
-      return BAD_REQUEST;
-   }
-
-   pgexporter_write_byte(msg->data + index, '\0');
-
-   if (strcmp(from, "/") == 0 || strcmp(from, "/index.html") == 0)
-   {
-      return PAGE_HOME;
-   }
-   else if (strcmp(from, "/metrics") == 0)
-   {
-      return PAGE_METRICS;
-   }
-
-   return PAGE_UNKNOWN;
-}
-
-static int
-badrequest_page(SSL* client_ssl, int client_fd)
-{
-   char* data = NULL;
-   time_t now;
-   char time_buf[32];
-   int status;
-   struct message msg;
-
-   memset(&msg, 0, sizeof(struct message));
-   memset(&data, 0, sizeof(data));
-
-   now = time(NULL);
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&now, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
-
-   data = pgexporter_vappend(data, 4,
-                             "HTTP/1.1 400 Bad Request\r\n",
-                             "Date: ",
-                             &time_buf[0],
-                             "\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
-   status = pgexporter_write_message(client_ssl, client_fd, &msg);
-
-   free(data);
-
-   return status;
-}
-
-static int
-unknown_page(SSL* client_ssl, int client_fd)
-{
-   char* data = NULL;
-   time_t now;
-   char time_buf[32];
-   int status;
-   struct message msg;
-
-   memset(&msg, 0, sizeof(struct message));
-   memset(&data, 0, sizeof(data));
-
-   now = time(NULL);
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&now, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
-
-   data = pgexporter_vappend(data, 4,
-                             "HTTP/1.1 403 Forbidden\r\n",
-                             "Date: ",
-                             &time_buf[0],
-                             "\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
-   status = pgexporter_write_message(client_ssl, client_fd, &msg);
-
-   free(data);
-
-   return status;
-}
-
-static int
 home_page(SSL* client_ssl, int client_fd)
 {
    char* data = NULL;
    int status;
-   time_t now;
-   char time_buf[32];
-   struct message msg;
    struct configuration* config;
 
    config = (struct configuration*)shmem;
 
-   now = time(NULL);
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&now, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
-
-   data = pgexporter_vappend(data, 7,
-                             "HTTP/1.1 200 OK\r\n",
-                             "Content-Type: text/html; charset=utf-8\r\n",
-                             "Date: ",
-                             &time_buf[0],
-                             "\r\n",
-                             "Transfer-Encoding: chunked\r\n",
-                             "\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
-   status = pgexporter_write_message(client_ssl, client_fd, &msg);
+   status = pgexporter_http_respond_chunked_start(client_ssl, client_fd, "text/html; charset=utf-8");
    if (status != MESSAGE_STATUS_OK)
    {
       goto error;
    }
-
-   free(data);
-   data = NULL;
 
    data = pgexporter_vappend(data, 12,
                              "<html>\n",
@@ -569,7 +370,7 @@ home_page(SSL* client_ssl, int client_fd)
                              "  Support for\n",
                              "  <ul>\n");
 
-   send_chunk(client_ssl, client_fd, data);
+   pgexporter_http_respond_chunked_write(client_ssl, client_fd, data);
    free(data);
    data = NULL;
 
@@ -593,7 +394,7 @@ home_page(SSL* client_ssl, int client_fd)
                              "  <li>pgexporter_alert_xid_wraparound</li>\n",
                              "  <li>pgexporter_alert_multixact_wraparound</li>\n");
 
-   send_chunk(client_ssl, client_fd, data);
+   pgexporter_http_respond_chunked_write(client_ssl, client_fd, data);
    free(data);
    data = NULL;
 
@@ -619,7 +420,7 @@ home_page(SSL* client_ssl, int client_fd)
       }
    }
 
-   send_chunk(client_ssl, client_fd, data);
+   pgexporter_http_respond_chunked_write(client_ssl, client_fd, data);
    free(data);
    data = NULL;
 
@@ -630,12 +431,11 @@ home_page(SSL* client_ssl, int client_fd)
                              "</body>\n",
                              "</html>\n");
 
-   /* Footer */
-   data = pgexporter_append(data, "\r\n\r\n");
-
-   send_chunk(client_ssl, client_fd, data);
+   pgexporter_http_respond_chunked_write(client_ssl, client_fd, data);
    free(data);
    data = NULL;
+
+   pgexporter_http_respond_chunked_end(client_ssl, client_fd);
 
    return 0;
 
@@ -701,13 +501,18 @@ retry_cache_locking:
          ctime_r(&now, &time_buf[0]);
          time_buf[strlen(time_buf) - 1] = 0;
 
+         /*
+          * Build the response header manually instead of using
+          * pgexporter_http_respond_chunked_start() because the cache must store
+          * only the status line + content-type + date
+          */
          data = pgexporter_vappend(data, 5,
                                    "HTTP/1.1 200 OK\r\n",
                                    "Content-Type: text/plain; version=0.0.1; charset=utf-8\r\n",
                                    "Date: ",
                                    &time_buf[0],
                                    "\r\n");
-         metrics_cache_append(data); // cache here to avoid the chunking for the cache
+         metrics_cache_append(data);
          data = pgexporter_vappend(data, 2,
                                    "Transfer-Encoding: chunked\r\n",
                                    "\r\n");
@@ -759,13 +564,7 @@ retry_cache_locking:
          prometheus_endpoints_information(client_ssl, client_fd);
 
          /* Footer */
-         data = pgexporter_append(data, "0\r\n\r\n");
-
-         msg.kind = 0;
-         msg.length = strlen(data);
-         msg.data = data;
-
-         status = pgexporter_write_message(client_ssl, client_fd, &msg);
+         status = pgexporter_http_respond_chunked_end(client_ssl, client_fd);
          if (status != MESSAGE_STATUS_OK)
          {
             goto error;
@@ -800,41 +599,6 @@ error:
    free(data);
 
    return 1;
-}
-
-static int
-bad_request(SSL* client_ssl, int client_fd)
-{
-   char* data = NULL;
-   time_t now;
-   char time_buf[32];
-   int status;
-   struct message msg;
-
-   memset(&msg, 0, sizeof(struct message));
-   memset(&data, 0, sizeof(data));
-
-   now = time(NULL);
-
-   memset(&time_buf, 0, sizeof(time_buf));
-   ctime_r(&now, &time_buf[0]);
-   time_buf[strlen(time_buf) - 1] = 0;
-
-   data = pgexporter_vappend(data, 4,
-                             "HTTP/1.1 400 Bad Request\r\n",
-                             "Date: ",
-                             &time_buf[0],
-                             "\r\n");
-
-   msg.kind = 0;
-   msg.length = strlen(data);
-   msg.data = data;
-
-   status = pgexporter_write_message(client_ssl, client_fd, &msg);
-
-   free(data);
-
-   return status;
 }
 
 static bool
@@ -3019,54 +2783,6 @@ append_type_info(char** data, char* tag, char* name, int typeId)
    *data = pgexporter_append(*data, "\n");
 }
 
-static int
-send_chunk(SSL* client_ssl, int client_fd, char* data)
-{
-   int status;
-   char* m = NULL;
-   struct message msg;
-
-   memset(&msg, 0, sizeof(struct message));
-
-   if (data == NULL)
-   {
-      return MESSAGE_STATUS_ERROR;
-   }
-
-   m = malloc(20);
-
-   if (m == NULL)
-   {
-      goto error;
-   }
-
-   memset(m, 0, 20);
-
-   pgexporter_snprintf(m, 20, "%zX\r\n", strlen(data));
-
-   m = pgexporter_vappend(m, 2,
-                          data,
-                          "\r\n");
-   if (m == NULL)
-   {
-      goto error;
-   }
-
-   msg.kind = 0;
-   msg.length = strlen(m);
-   msg.data = m;
-
-   status = pgexporter_write_message(client_ssl, client_fd, &msg);
-
-   free(m);
-
-   return status;
-
-error:
-
-   return MESSAGE_STATUS_ERROR;
-}
-
 static char*
 get_value(char* tag __attribute__((unused)), char* name __attribute__((unused)), char* val)
 {
@@ -3447,7 +3163,7 @@ prometheus_endpoints_information(SSL* client_ssl, int client_fd)
 
          free(body_copy);
 
-         send_chunk(client_ssl, client_fd, data);
+         pgexporter_http_respond_chunked_write(client_ssl, client_fd, data);
          metrics_cache_append(data);
          free(data);
          data = NULL;
@@ -3718,7 +3434,7 @@ output_art_metrics(SSL* client_ssl, int client_fd, struct art* art_tree)
 
    if (data != NULL)
    {
-      send_chunk(client_ssl, client_fd, data);
+      pgexporter_http_respond_chunked_write(client_ssl, client_fd, data);
       metrics_cache_append(data);
       free(data);
    }

--- a/src/main.c
+++ b/src/main.c
@@ -114,6 +114,22 @@ struct accept_io
    char** argv;
 };
 
+static void http_child_serve(int client_fd, struct accept_io* ai, const char* title,
+                             const char* cert_file, const char* key_file, const char* ca_file,
+                             void (*serve_fn)(SSL* ssl, int fd));
+static void accept_http_cb(struct io_watcher* watcher,
+                           void (*serve_fn)(SSL* ssl, int fd),
+                           const char* title,
+                           const char* cert_file, const char* key_file, const char* ca_file,
+                           int fork_error_code,
+                           void (*restart_fn)(void));
+static void restart_metrics(void);
+static void restart_console(void);
+static void restart_bridge(void);
+static void restart_bridge_json(void);
+static void bridge_serve(SSL* ssl, int fd);
+static void bridge_json_serve(SSL* ssl, int fd);
+
 static volatile int stop = 0;
 static char** argv_ptr;
 static struct event_loop* main_loop = NULL;
@@ -1924,7 +1940,184 @@ error:
 }
 
 static void
-accept_metrics_cb(struct io_watcher* watcher)
+http_child_serve(int client_fd, struct accept_io* ai, const char* title,
+                 const char* cert_file, const char* key_file, const char* ca_file,
+                 void (*serve_fn)(SSL* ssl, int fd))
+{
+   SSL_CTX* ctx = NULL;
+   SSL* client_ssl = NULL;
+
+   if (main_loop)
+   {
+      pgexporter_event_loop_fork();
+   }
+
+   shutdown_ports(false);
+
+   if (cert_file != NULL && key_file != NULL &&
+       strlen(cert_file) > 0 && strlen(key_file) > 0)
+   {
+      if (pgexporter_create_ssl_ctx(false, &ctx))
+      {
+         pgexporter_log_error("http_child_serve: could not create SSL context for %s", title);
+         exit(1);
+      }
+
+      if (pgexporter_create_ssl_server(ctx, (char*)key_file, (char*)cert_file, (char*)ca_file, client_fd, &client_ssl))
+      {
+         pgexporter_log_error("http_child_serve: could not create SSL server for %s", title);
+         SSL_CTX_free(ctx);
+         exit(1);
+      }
+   }
+
+   pgexporter_set_proc_title(1, ai->argv, (char*)title, NULL);
+   serve_fn(client_ssl, client_fd);
+}
+
+static void
+bridge_serve(SSL* ssl __attribute__((unused)), int fd)
+{
+   pgexporter_bridge(fd);
+}
+
+static void
+bridge_json_serve(SSL* ssl __attribute__((unused)), int fd)
+{
+   pgexporter_bridge_json(fd);
+}
+
+static void
+restart_metrics(void)
+{
+   struct configuration* config = (struct configuration*)shmem;
+
+   shutdown_metrics(false);
+
+   free(metrics_fds);
+   metrics_fds = NULL;
+   metrics_fds_length = 0;
+
+   if (pgexporter_bind(config->host, config->metrics, &metrics_fds, &metrics_fds_length))
+   {
+      pgexporter_log_fatal("Could not bind to %s:%d", config->host, config->metrics);
+      exit(1);
+   }
+
+   if (metrics_fds_length > MAX_FDS)
+   {
+      pgexporter_log_fatal("Too many descriptors %d", metrics_fds_length);
+      exit(1);
+   }
+
+   start_metrics();
+
+   for (int i = 0; i < metrics_fds_length; i++)
+   {
+      pgexporter_log_debug("Metrics: %d", *(metrics_fds + i));
+   }
+}
+
+static void
+restart_console(void)
+{
+   struct configuration* config = (struct configuration*)shmem;
+
+   shutdown_console(false);
+
+   free(console_fds);
+   console_fds = NULL;
+   console_fds_length = 0;
+
+   if (pgexporter_bind(config->host, config->console, &console_fds, &console_fds_length))
+   {
+      pgexporter_log_fatal("Could not bind to %s:%d", config->host, config->console);
+      exit(1);
+   }
+
+   if (console_fds_length > MAX_FDS)
+   {
+      pgexporter_log_fatal("Too many descriptors %d", console_fds_length);
+      exit(1);
+   }
+
+   start_console();
+
+   for (int i = 0; i < console_fds_length; i++)
+   {
+      pgexporter_log_debug("Console: %d", *(console_fds + i));
+   }
+}
+
+static void
+restart_bridge(void)
+{
+   struct configuration* config = (struct configuration*)shmem;
+
+   shutdown_bridge(false);
+
+   free(bridge_fds);
+   bridge_fds = NULL;
+   bridge_fds_length = 0;
+
+   if (pgexporter_bind(config->host, config->bridge, &bridge_fds, &bridge_fds_length))
+   {
+      pgexporter_log_fatal("Could not bind to %s:%d", config->host, config->bridge);
+      exit(1);
+   }
+
+   if (bridge_fds_length > MAX_FDS)
+   {
+      pgexporter_log_fatal("Too many descriptors %d", bridge_fds_length);
+      exit(1);
+   }
+
+   start_bridge();
+
+   for (int i = 0; i < bridge_fds_length; i++)
+   {
+      pgexporter_log_debug("Bridge: %d", *(bridge_fds + i));
+   }
+}
+
+static void
+restart_bridge_json(void)
+{
+   struct configuration* config = (struct configuration*)shmem;
+
+   shutdown_bridge_json(false);
+
+   free(bridge_json_fds);
+   bridge_json_fds = NULL;
+   bridge_json_fds_length = 0;
+
+   if (pgexporter_bind(config->host, config->bridge_json, &bridge_json_fds, &bridge_json_fds_length))
+   {
+      pgexporter_log_fatal("Could not bind to %s:%d", config->host, config->bridge_json);
+      exit(1);
+   }
+
+   if (bridge_json_fds_length > MAX_FDS)
+   {
+      pgexporter_log_fatal("Too many descriptors %d", bridge_json_fds_length);
+      exit(1);
+   }
+
+   start_bridge_json();
+
+   for (int i = 0; i < bridge_json_fds_length; i++)
+   {
+      pgexporter_log_debug("Bridge JSON: %d", *(bridge_json_fds + i));
+   }
+}
+
+static void
+accept_http_cb(struct io_watcher* watcher,
+               void (*serve_fn)(SSL* ssl, int fd),
+               const char* title,
+               const char* cert_file, const char* key_file, const char* ca_file,
+               int fork_error_code,
+               void (*restart_fn)(void))
 {
    struct sockaddr_in6 client_addr;
    socklen_t client_addr_length;
@@ -1932,18 +2125,16 @@ accept_metrics_cb(struct io_watcher* watcher)
    pid_t pid;
    struct accept_io* ai;
    struct configuration* config;
-   SSL_CTX* ctx = NULL;
-   SSL* client_ssl = NULL;
 
    config = (struct configuration*)shmem;
    ai = (struct accept_io*)watcher;
 
-   pgexporter_log_trace("accept_metrics_cb: %d", watcher->fds.main.listen_fd);
+   pgexporter_log_trace("accept_%s_cb: %d", title, watcher->fds.main.listen_fd);
 
    errno = 0;
-
    memset(&client_addr, 0, sizeof(client_addr));
    client_addr_length = sizeof(client_addr);
+
    if (watcher->fds.main.client_fd != -1)
    {
       client_fd = watcher->fds.main.client_fd;
@@ -1959,31 +2150,7 @@ accept_metrics_cb(struct io_watcher* watcher)
       if (accept_fatal(errno) && config->keep_running)
       {
          pgexporter_log_warn("Restarting listening port due to: %s (%d)", strerror(errno), watcher->fds.main.listen_fd);
-
-         shutdown_metrics(false);
-
-         free(metrics_fds);
-         metrics_fds = NULL;
-         metrics_fds_length = 0;
-
-         if (pgexporter_bind(config->host, config->metrics, &metrics_fds, &metrics_fds_length))
-         {
-            pgexporter_log_fatal("Could not bind to %s:%d", config->host, config->metrics);
-            exit(1);
-         }
-
-         if (metrics_fds_length > MAX_FDS)
-         {
-            pgexporter_log_fatal("Too many descriptors %d", metrics_fds_length);
-            exit(1);
-         }
-
-         start_metrics();
-
-         for (int i = 0; i < metrics_fds_length; i++)
-         {
-            pgexporter_log_debug("Metrics: %d", *(metrics_fds + i));
-         }
+         restart_fn();
       }
       else
       {
@@ -1993,354 +2160,54 @@ accept_metrics_cb(struct io_watcher* watcher)
       return;
    }
 
-   /* Handle the accepted connection */
-   pgexporter_log_trace("Metrics: Forking for client_fd %d", client_fd);
    pid = fork();
    if (pid == -1)
    {
-      pgexporter_log_error("Metrics: No fork (%d)", MANAGEMENT_ERROR_METRICS_NOFORK);
-      goto error;
+      pgexporter_log_error("%s: No fork (%d)", title, fork_error_code);
+      pgexporter_disconnect(client_fd);
+      return;
    }
-   else if (pid == 0)
+
+   if (pid == 0)
    {
-      pgexporter_log_trace("Metrics: Child process started (pid %d)", getpid());
-      /* Child process - fork event loop if needed */
-      if (main_loop)
-      {
-         pgexporter_log_trace("Metrics: Forking event loop in child");
-         pgexporter_event_loop_fork();
-      }
-
-      /* We are leaving the socket descriptor valid such that the client won't reuse it */
-      shutdown_ports(false);
-      if (strlen(config->metrics_cert_file) > 0 && strlen(config->metrics_key_file) > 0)
-      {
-         if (pgexporter_create_ssl_ctx(false, &ctx))
-         {
-            pgexporter_log_error("Could not create metrics SSL context");
-            return;
-         }
-
-         if (pgexporter_create_ssl_server(ctx, config->metrics_key_file, config->metrics_cert_file, config->metrics_ca_file, client_fd, &client_ssl))
-         {
-            pgexporter_log_error("Could not create metrics SSL server");
-            return;
-         }
-      }
-      pgexporter_set_proc_title(1, ai->argv, "metrics", NULL);
-      pgexporter_prometheus(client_ssl, client_fd);
+      http_child_serve(client_fd, ai, title, cert_file, key_file, ca_file, serve_fn);
    }
 
-   pgexporter_log_trace("Metrics: Parent process continuing for client_fd %d", client_fd);
-   pgexporter_close_ssl(client_ssl);
    pgexporter_disconnect(client_fd);
+}
 
-   return;
-
-error:
-
-   pgexporter_close_ssl(client_ssl);
-   pgexporter_disconnect(client_fd);
+static void
+accept_metrics_cb(struct io_watcher* watcher)
+{
+   struct configuration* config = (struct configuration*)shmem;
+   accept_http_cb(watcher, pgexporter_prometheus, "metrics",
+                  config->metrics_cert_file, config->metrics_key_file,
+                  config->metrics_ca_file, MANAGEMENT_ERROR_METRICS_NOFORK,
+                  restart_metrics);
 }
 
 static void
 accept_console_cb(struct io_watcher* watcher)
 {
-   struct sockaddr_in6 client_addr;
-   socklen_t client_addr_length;
-   int client_fd;
-   pid_t pid;
-   struct accept_io* ai;
-   struct configuration* config;
-
-   config = (struct configuration*)shmem;
-   ai = (struct accept_io*)watcher;
-
-   pgexporter_log_trace("accept_console_cb: %d", watcher->fds.main.listen_fd);
-
-   errno = 0;
-   memset(&client_addr, 0, sizeof(client_addr));
-   client_addr_length = sizeof(client_addr);
-
-   if (watcher->fds.main.client_fd != -1)
-   {
-      client_fd = watcher->fds.main.client_fd;
-      watcher->fds.main.client_fd = -1;
-   }
-   else
-   {
-      client_fd = accept(watcher->fds.main.listen_fd, (struct sockaddr*)&client_addr, &client_addr_length);
-   }
-
-   if (client_fd == -1)
-   {
-      if (accept_fatal(errno) && config->keep_running)
-      {
-         pgexporter_log_warn("Restarting listening port due to: %s (%d)", strerror(errno), watcher->fds.main.listen_fd);
-
-         shutdown_console(false);
-
-         free(console_fds);
-         console_fds = NULL;
-         console_fds_length = 0;
-
-         if (pgexporter_bind(config->host, config->console, &console_fds, &console_fds_length))
-         {
-            pgexporter_log_fatal("Could not bind to %s:%d", config->host, config->console);
-            exit(1);
-         }
-
-         if (console_fds_length > MAX_FDS)
-         {
-            pgexporter_log_fatal("Too many descriptors %d", console_fds_length);
-            exit(1);
-         }
-
-         start_console();
-
-         for (int i = 0; i < console_fds_length; i++)
-         {
-            pgexporter_log_debug("Console: %d", *(console_fds + i));
-         }
-      }
-      else
-      {
-         pgexporter_log_debug("accept: %s (%d)", strerror(errno), watcher->fds.main.listen_fd);
-      }
-      errno = 0;
-      return;
-   }
-
-   /* Handle the accepted connection */
-   pid = fork();
-   if (pid == -1)
-   {
-      pgexporter_log_error("Console: No fork (%d)", MANAGEMENT_ERROR_CONSOLE_NOFORK);
-      goto error;
-   }
-   else if (pid == 0)
-   {
-      /* Child process - fork event loop if needed */
-      if (main_loop)
-      {
-         pgexporter_event_loop_fork();
-      }
-
-      /* We are leaving the socket descriptor valid such that the client won't reuse it */
-
-      shutdown_ports(false);
-      pgexporter_set_proc_title(1, ai->argv, "console", NULL);
-      pgexporter_console(NULL, client_fd);
-   }
-
-   pgexporter_disconnect(client_fd);
-
-   return;
-
-error:
-
-   pgexporter_disconnect(client_fd);
+   accept_http_cb(watcher, pgexporter_console, "console",
+                  NULL, NULL, NULL, MANAGEMENT_ERROR_CONSOLE_NOFORK,
+                  restart_console);
 }
 
 static void
 accept_bridge_cb(struct io_watcher* watcher)
 {
-   struct sockaddr_in6 client_addr;
-   socklen_t client_addr_length;
-   int client_fd;
-   char address[INET6_ADDRSTRLEN];
-   pid_t pid;
-   struct accept_io* ai;
-   struct configuration* config;
-
-   pgexporter_log_trace("accept_bridge_cb: %d", watcher->fds.main.listen_fd);
-
-   config = (struct configuration*)shmem;
-   ai = (struct accept_io*)watcher;
-
-   errno = 0;
-
-   memset(&client_addr, 0, sizeof(client_addr));
-   memset(&client_addr, 0, sizeof(client_addr));
-   client_addr_length = sizeof(client_addr);
-   if (watcher->fds.main.client_fd != -1)
-   {
-      client_fd = watcher->fds.main.client_fd;
-      watcher->fds.main.client_fd = -1;
-      if (getpeername(client_fd, (struct sockaddr*)&client_addr, &client_addr_length) == -1)
-      {
-         pgexporter_log_debug("getpeername error for fd %d: %s", client_fd, strerror(errno));
-         pgexporter_snprintf(address, sizeof(address), "%s", "unknown");
-      }
-   }
-   else
-   {
-      client_fd = accept(watcher->fds.main.listen_fd, (struct sockaddr*)&client_addr, &client_addr_length);
-   }
-   if (client_fd == -1)
-   {
-      if (accept_fatal(errno) && config->keep_running)
-      {
-         pgexporter_log_warn("Restarting listening port due to: %s (%d)", strerror(errno), watcher->fds.main.listen_fd);
-
-         shutdown_bridge(false);
-
-         free(bridge_fds);
-         bridge_fds = NULL;
-         bridge_fds_length = 0;
-
-         if (pgexporter_bind(config->host, config->bridge, &bridge_fds, &bridge_fds_length))
-         {
-            pgexporter_log_fatal("Could not bind to %s:%d", config->host, config->bridge);
-            exit(1);
-         }
-
-         if (bridge_fds_length > MAX_FDS)
-         {
-            pgexporter_log_fatal("Too many descriptors %d", bridge_fds_length);
-            exit(1);
-         }
-
-         start_bridge();
-
-         for (int i = 0; i < bridge_fds_length; i++)
-         {
-            pgexporter_log_debug("Bridge: %d", *(bridge_fds + i));
-         }
-      }
-      else
-      {
-         pgexporter_log_debug("accept: %s (%d)", strerror(errno), watcher->fds.main.listen_fd);
-      }
-      errno = 0;
-      return;
-   }
-
-   pid = fork();
-   if (pid == -1)
-   {
-      pgexporter_log_error("Bridge: No fork (%d)", MANAGEMENT_ERROR_BRIDGE_NOFORK);
-      goto error;
-   }
-   else if (pid == 0)
-   {
-      /* Child process - fork event loop if needed */
-      if (main_loop)
-      {
-         pgexporter_event_loop_fork();
-      }
-
-      /* We are leaving the socket descriptor valid such that the client won't reuse it */
-      shutdown_ports(false);
-
-      pgexporter_set_proc_title(1, ai->argv, "bridge", NULL);
-      pgexporter_bridge(client_fd);
-   }
-
-   pgexporter_disconnect(client_fd);
-
-   return;
-
-error:
-
-   pgexporter_disconnect(client_fd);
+   accept_http_cb(watcher, bridge_serve, "bridge",
+                  NULL, NULL, NULL, MANAGEMENT_ERROR_BRIDGE_NOFORK,
+                  restart_bridge);
 }
 
 static void
 accept_bridge_json_cb(struct io_watcher* watcher)
 {
-   struct sockaddr_in6 client_addr;
-   socklen_t client_addr_length;
-   int client_fd;
-   pid_t pid;
-   struct accept_io* ai;
-   struct configuration* config;
-
-   pgexporter_log_trace("accept_bridge_json_cb: %d", watcher->fds.main.listen_fd);
-
-   config = (struct configuration*)shmem;
-   ai = (struct accept_io*)watcher;
-
-   errno = 0;
-
-   memset(&client_addr, 0, sizeof(client_addr));
-   client_addr_length = sizeof(client_addr);
-   if (watcher->fds.main.client_fd != -1)
-   {
-      client_fd = watcher->fds.main.client_fd;
-      watcher->fds.main.client_fd = -1;
-   }
-   else
-   {
-      client_fd = accept(watcher->fds.main.listen_fd, (struct sockaddr*)&client_addr, &client_addr_length);
-   }
-   if (client_fd == -1)
-   {
-      if (accept_fatal(errno) && config->keep_running)
-      {
-         pgexporter_log_warn("Restarting listening port due to: %s (%d)", strerror(errno), watcher->fds.main.listen_fd);
-
-         shutdown_bridge_json(false);
-
-         free(bridge_json_fds);
-         bridge_json_fds = NULL;
-         bridge_json_fds_length = 0;
-
-         if (pgexporter_bind(config->host, config->bridge_json, &bridge_json_fds, &bridge_json_fds_length))
-         {
-            pgexporter_log_fatal("Could not bind to %s:%d", config->host, config->bridge_json);
-            exit(1);
-         }
-
-         if (bridge_json_fds_length > MAX_FDS)
-         {
-            pgexporter_log_fatal("Too many descriptors %d", bridge_json_fds_length);
-            exit(1);
-         }
-
-         start_bridge_json();
-
-         for (int i = 0; i < bridge_json_fds_length; i++)
-         {
-            pgexporter_log_debug("Bridge JSON: %d", *(bridge_json_fds + i));
-         }
-      }
-      else
-      {
-         pgexporter_log_debug("accept: %s (%d)", strerror(errno), watcher->fds.main.listen_fd);
-      }
-      errno = 0;
-      return;
-   }
-
-   pid = fork();
-   if (pid == -1)
-   {
-      pgexporter_log_error("Bridge JSON: No fork (%d)", MANAGEMENT_ERROR_BRIDGE_JSON_NOFORK);
-      goto error;
-   }
-   else if (pid == 0)
-   {
-      /* Child process - fork event loop if needed */
-      if (main_loop)
-      {
-         pgexporter_event_loop_fork();
-      }
-
-      /* We are leaving the socket descriptor valid such that the client won't reuse it */
-      shutdown_ports(false);
-
-      pgexporter_set_proc_title(1, ai->argv, "bridge_json", NULL);
-      pgexporter_bridge_json(client_fd);
-   }
-
-   pgexporter_disconnect(client_fd);
-
-   return;
-
-error:
-
-   pgexporter_disconnect(client_fd);
+   accept_http_cb(watcher, bridge_json_serve, "bridge_json",
+                  NULL, NULL, NULL, MANAGEMENT_ERROR_BRIDGE_JSON_NOFORK,
+                  restart_bridge_json);
 }
 
 static void


### PR DESCRIPTION
Resolves #554 

### Changes
- Extracted shared HTTP server logic (`http_server.c/h`) - request parsing, TLS probe+handshake, route dispatch, and all response helpers (chunked start/write/end, 400/403/301/200) now live in one place. Each service file keeps only its route table and handlers.
- `main.c` fork boilerplate simplified
- Fixed `pgexporter_http_respond_403()` missing the blank-line header terminator - old response had no `\r\n\r\n` after headers, causing clients to hang.
- Fixed missing terminal chunk in `home_page()` across prometheus and bridge.