### PR TITLE
[#561] Support backend passwords/tokens longer than 256 characters (cloud IAM DB-auth)

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -620,9 +620,9 @@ is_valid_key(char* key)
       warnx("Error counting UTF-8 characters in master key");
       return false;
    }
-   if (char_count > MAX_PASSWORD_CHARS)
+   if (strlen(key) >= MAX_PASSWORD_LENGTH)
    {
-      warnx("Master key too long (%zu characters). Maximum allowed: %d characters.", char_count, MAX_PASSWORD_CHARS);
+      warnx("Master key too long (%zu bytes). Maximum allowed: %d bytes.", strlen(key), MAX_PASSWORD_LENGTH - 1);
       return false;
    }
 
@@ -776,9 +776,9 @@ password:
       password = NULL;
       goto password;
    }
-   if (char_count > MAX_PASSWORD_CHARS)
+   if (strlen(password) >= MAX_PASSWORD_LENGTH)
    {
-      warnx("Password too long (%zu characters). Maximum allowed: %d characters.", char_count, MAX_PASSWORD_CHARS);
+      warnx("Password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(password), MAX_PASSWORD_LENGTH - 1);
       if (do_free)
       {
          free(password);
@@ -827,9 +827,9 @@ password:
          password = NULL;
          goto password;
       }
-      if (verify_char_count > MAX_PASSWORD_CHARS)
+      if (strlen(verify) >= MAX_PASSWORD_LENGTH)
       {
-         warnx("Verification password too long (%zu characters). Maximum allowed: %d characters.", verify_char_count, MAX_PASSWORD_CHARS);
+         warnx("Verification password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(verify), MAX_PASSWORD_LENGTH - 1);
          free(verify);
          verify = NULL;
          if (do_free)
@@ -1097,9 +1097,9 @@ password:
             password = NULL;
             goto password;
          }
-         if (char_count > MAX_PASSWORD_CHARS)
+         if (strlen(password) >= MAX_PASSWORD_LENGTH)
          {
-            warnx("Password too long (%zu characters). Maximum allowed: %d characters.", char_count, MAX_PASSWORD_CHARS);
+            warnx("Password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(password), MAX_PASSWORD_LENGTH - 1);
             if (do_free)
             {
                free(password);
@@ -1148,9 +1148,9 @@ password:
                password = NULL;
                goto password;
             }
-            if (verify_char_count > MAX_PASSWORD_CHARS)
+            if (strlen(verify) >= MAX_PASSWORD_LENGTH)
             {
-               warnx("Verification password too long (%zu characters). Maximum allowed: %d characters.", verify_char_count, MAX_PASSWORD_CHARS);
+               warnx("Verification password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(verify), MAX_PASSWORD_LENGTH - 1);
                free(verify);
                verify = NULL;
                if (do_free)

--- a/src/cli.c
+++ b/src/cli.c
@@ -700,9 +700,9 @@ password:
          warnx("pgexporter-cli: Error counting UTF-8 characters in password");
          goto password;
       }
-      if (char_count > MAX_PASSWORD_CHARS)
+      if (strlen(password) >= MAX_PASSWORD_LENGTH)
       {
-         warnx("pgexporter-cli: Password too long (%zu characters). Maximum allowed: %d characters.", char_count, MAX_PASSWORD_CHARS);
+         warnx("pgexporter-cli: Password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(password), MAX_PASSWORD_LENGTH - 1);
          goto password;
       }
 

--- a/src/include/pgexporter.h
+++ b/src/include/pgexporter.h
@@ -62,8 +62,7 @@ extern "C" {
 #define MESSAGE_PARSE_BUFFER_SIZE    (DEFAULT_BUFFER_SIZE - RECV_BUFFER_HEADROOM)
 
 #define MAX_USERNAME_LENGTH          128
-#define MAX_PASSWORD_LENGTH          1024
-#define MAX_PASSWORD_CHARS           256
+#define MAX_PASSWORD_LENGTH          8192 /* Bytes; the single password-length limit, sized for cloud IAM DB-auth tokens (AWS RDS/Aurora, Azure AD, GCP) */
 
 #define MAX_PATH                     1024
 #define MISC_LENGTH                  128

--- a/src/libpgexporter/configuration.c
+++ b/src/libpgexporter/configuration.c
@@ -67,6 +67,14 @@
 
 #define LINE_LENGTH 512
 
+/*
+ * Credential files (users/admins) store each entry as
+ * "username:base64(AES-256-GCM(password))". A password near MAX_PASSWORD_LENGTH
+ * (cloud IAM DB-auth tokens) expands under encryption + base64 well beyond
+ * LINE_LENGTH, so these files are read with a dedicated, larger line buffer.
+ */
+#define MAX_USER_LINE_LENGTH 16384
+
 static int extract_syskey_value(char* str, char** key, char** value);
 static void extract_key_value(char* str, char** key, char** value);
 static int as_int(char* str, int* i);
@@ -1691,7 +1699,7 @@ int
 pgexporter_read_users_configuration(void* shm, char* filename)
 {
    FILE* file;
-   char line[LINE_LENGTH];
+   char line[MAX_USER_LINE_LENGTH];
    int index;
    char* master_key = NULL;
    char* username = NULL;
@@ -1776,9 +1784,9 @@ pgexporter_read_users_configuration(void* shm, char* filename)
                decoded = NULL;
                continue;
             }
-            if (char_count > MAX_PASSWORD_CHARS)
+            if (strlen(password) >= MAX_PASSWORD_LENGTH)
             {
-               pgexporter_log_warn("Password too long for user '%s' (%zu characters)", username, char_count);
+               pgexporter_log_warn("Password too long for user '%s' (%zu bytes, max %d)", username, strlen(password), MAX_PASSWORD_LENGTH - 1);
                warnx("pgexporter: Invalid USER entry");
                warnx("%s", line);
                free(password);
@@ -1930,7 +1938,7 @@ int
 pgexporter_read_admins_configuration(void* shm, char* filename)
 {
    FILE* file;
-   char line[LINE_LENGTH];
+   char line[MAX_USER_LINE_LENGTH];
    int index;
    char* master_key = NULL;
    char* username = NULL;
@@ -2015,9 +2023,9 @@ pgexporter_read_admins_configuration(void* shm, char* filename)
                decoded = NULL;
                continue;
             }
-            if (char_count > MAX_PASSWORD_CHARS)
+            if (strlen(password) >= MAX_PASSWORD_LENGTH)
             {
-               pgexporter_log_warn("Password too long for user '%s' (%zu characters)", username, char_count);
+               pgexporter_log_warn("Password too long for user '%s' (%zu bytes, max %d)", username, strlen(password), MAX_PASSWORD_LENGTH - 1);
                warnx("pgexporter: Invalid ADMIN entry");
                warnx("%s", line);
                free(password);

--- a/src/libpgexporter/security.c
+++ b/src/libpgexporter/security.c
@@ -71,7 +71,7 @@
 #define SECURITY_ALL                99
 
 #define NUMBER_OF_SECURITY_MESSAGES 5
-#define SECURITY_BUFFER_SIZE        1024
+#define SECURITY_BUFFER_SIZE        16384 /* Must hold a PasswordMessage carrying a MAX_PASSWORD_LENGTH credential (cloud IAM tokens) */
 
 static signed char has_security;
 static ssize_t security_lengths[NUMBER_OF_SECURITY_MESSAGES];
@@ -1288,6 +1288,12 @@ server_password(char* username, char* password, SSL* ssl, int server_fd)
       goto error;
    }
 
+   if (password_msg->length > SECURITY_BUFFER_SIZE)
+   {
+      pgexporter_log_error("Password message too large: %ld", password_msg->length);
+      goto error;
+   }
+
    security_lengths[auth_index] = password_msg->length;
    memcpy(&security_messages[auth_index], password_msg->data, password_msg->length);
    auth_index++;
@@ -1890,7 +1896,6 @@ error:
 static int
 sasl_prep(char* password, char** password_prep)
 {
-   size_t char_count;
    size_t password_len;
 
    if (!password || !password_prep)
@@ -1917,9 +1922,8 @@ sasl_prep(char* password, char** password_prep)
       goto error;
    }
 
-   // Validate the character count in the password
-   char_count = pgexporter_utf8_char_length((const unsigned char*)password, password_len);
-   if (char_count == (size_t)-1 || char_count > MAX_PASSWORD_CHARS)
+   // Enforce the password byte-length limit
+   if (password_len >= MAX_PASSWORD_LENGTH)
    {
       goto error;
    }


### PR DESCRIPTION
Port of pgagroal/pgagroal#942 + pgagroal/pgagroal#944 to pgexporter, per #561.

Cloud IAM DB-auth tokens (AWS RDS/Aurora, Azure AD, GCP) routinely exceed 256 UTF-8 characters and can exceed 1024 bytes, so pgexporter could not authenticate to an IAM-auth PostgreSQL backend it scrapes — the token was rejected/truncated before the connection succeeded.

### Changes
- `MAX_PASSWORD_LENGTH` 1024 → **8192 bytes**, and **remove the duplicated `MAX_PASSWORD_CHARS`** (256-char) limit so byte length is the single source of truth (the consolidation asked for in #561).
- `SECURITY_BUFFER_SIZE` 1024 → 16384 so a `PasswordMessage` carrying such a credential fits, plus a size guard on the per-connection copy in `server_password`.
- Read the users/admins credential files with a dedicated 16384-byte line buffer (`MAX_USER_LINE_LENGTH`) — an encrypted + base64 long token expands well beyond `LINE_LENGTH`.
- Validate by byte length (`strlen >= MAX_PASSWORD_LENGTH`) instead of UTF-8 character count across `sasl_prep`, configuration loading, `cli`, and `admin`; error messages now report bytes.

This mirrors the reviewed-and-merged pgagroal approach and keeps pgagroal / pgexporter / pgmoneta aligned (pgmoneta port tracked in pgmoneta/pgmoneta#1221).

Closes #561.
