### PR TITLE
[#567] Enhanced history test suite

### DIFF
--- a/src/libpgexporter/history.c
+++ b/src/libpgexporter/history.c
@@ -28,6 +28,7 @@
 
 /* pgexporter */
 #include <pgexporter.h>
+#include <deque.h>
 #include <history.h>
 #include <history_sqlite.h>
 #include <http.h>
@@ -661,7 +662,7 @@ pgexporter_history_http(SSL* ssl, int fd)
       query++;
    }
 
-   if (strncmp(path, "/history/", strlen("/history/")) != 0 || strlen(path) <= strlen("/history/"))
+   if (strncmp(path, "/history/", strlen("/history/")) != 0)
    {
       pgexporter_http_respond_404(ssl, fd);
       goto done;
@@ -721,6 +722,15 @@ pgexporter_history_http(SSL* ssl, int fd)
    }
 
    if (pgexporter_json_create(&root))
+   {
+      pgexporter_http_respond_500(ssl, fd);
+      goto done;
+   }
+
+   /* Force root to be a JSON array even when 0 records are returned, so the
+    * response is always "[]", never "{}" for an empty result. */
+   root->type = JSONArray;
+   if (pgexporter_deque_create(false, (struct deque**)&root->elements))
    {
       pgexporter_http_respond_500(ssl, fd);
       goto done;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TESTCASE_FILES
   testcases/test_art.c
   testcases/test_deque.c
   testcases/test_history.c
+  testcases/test_history_http.c
   testcases/test_message_complete.c
 )
 set(SOURCE_FILES ${LIB_SOURCE_FILES} ${TESTCASE_FILES} ${HEADER_FILES})

--- a/test/testcases/test_history.c
+++ b/test/testcases/test_history.c
@@ -441,6 +441,150 @@ cleanup:
    MCTF_FINISH();
 }
 
+MCTF_TEST_NEGATIVE(test_history_store_metrics_null_container)
+{
+   MCTF_ASSERT_INT_EQ(pgexporter_history_store_metrics(NULL), 1, cleanup,
+                      "store_metrics with NULL container should fail");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_store_metrics_crlf_line_ending)
+{
+   struct configuration* config = (struct configuration*)shmem;
+   prometheus_metrics_container_t* container = NULL;
+   struct art* t = NULL;
+   struct history_record* out = NULL;
+   int out_len = 0;
+   time_t now = time(NULL);
+
+   unlink_db("test_crlf.db");
+   pgexporter_snprintf(config->history_path, MAX_PATH, "test_crlf.db");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "history_init failed");
+
+   container = malloc(sizeof(prometheus_metrics_container_t));
+   memset(container, 0, sizeof(prometheus_metrics_container_t));
+
+   pgexporter_art_create(&t);
+   container->general_metrics = t;
+
+   struct mock_prometheus_metric_value m;
+   memset(&m, 0, sizeof(m));
+   m.value = "crlf_metric 7\r\n";
+   pgexporter_art_insert(t, "m", (uintptr_t)&m, ValueRef);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_store_metrics(container), 0, cleanup, "store_metrics returned error");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("crlf_metric", now - 10, now + 10, &out, &out_len), 0,
+                      cleanup, "query failed");
+   MCTF_ASSERT_INT_EQ(out_len, 1, cleanup, "expected 1 record for crlf_metric, got %d", out_len);
+   MCTF_ASSERT(out[0].value == 7.0, cleanup, "expected value 7, trailing \\r not stripped correctly");
+
+cleanup:
+   pgexporter_history_records_free(out, out_len);
+   if (container)
+   {
+      if (container->general_metrics)
+         pgexporter_art_destroy(container->general_metrics);
+      free(container);
+   }
+   pgexporter_history_shutdown();
+   unlink_db("test_crlf.db");
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_store_metrics_escaped_quote_in_label)
+{
+   struct configuration* config = (struct configuration*)shmem;
+   prometheus_metrics_container_t* container = NULL;
+   struct art* t = NULL;
+   struct history_record* out = NULL;
+   int out_len = 0;
+   time_t now = time(NULL);
+
+   unlink_db("test_escaped_quote.db");
+   pgexporter_snprintf(config->history_path, MAX_PATH, "test_escaped_quote.db");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "history_init failed");
+
+   container = malloc(sizeof(prometheus_metrics_container_t));
+   memset(container, 0, sizeof(prometheus_metrics_container_t));
+
+   pgexporter_art_create(&t);
+   container->general_metrics = t;
+
+   /* The label value contains an escaped quote (\") and a literal '}' inside quotes. */
+   struct mock_prometheus_metric_value m;
+   memset(&m, 0, sizeof(m));
+   m.value = "escaped_metric{server=\"db1\",note=\"a\\\"b}c\"} 5\n";
+   pgexporter_art_insert(t, "m", (uintptr_t)&m, ValueRef);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_store_metrics(container), 0, cleanup, "store_metrics returned error");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("escaped_metric", now - 10, now + 10, &out, &out_len), 0,
+                      cleanup, "query failed");
+   MCTF_ASSERT_INT_EQ(out_len, 1, cleanup, "expected 1 record for escaped_metric, got %d", out_len);
+   MCTF_ASSERT_STR_EQ(out[0].server, "db1", cleanup, "expected server db1");
+   MCTF_ASSERT(out[0].value == 5.0, cleanup, "expected value 5, brace/quote scanning mis-terminated the label set");
+
+cleanup:
+   pgexporter_history_records_free(out, out_len);
+   if (container)
+   {
+      if (container->general_metrics)
+         pgexporter_art_destroy(container->general_metrics);
+      free(container);
+   }
+   pgexporter_history_shutdown();
+   unlink_db("test_escaped_quote.db");
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_store_metrics_bare_metric_no_value)
+{
+   struct configuration* config = (struct configuration*)shmem;
+   prometheus_metrics_container_t* container = NULL;
+   struct art* t = NULL;
+   struct history_record* out = NULL;
+   int out_len = 0;
+   time_t now = time(NULL);
+
+   unlink_db("test_bare_metric.db");
+   pgexporter_snprintf(config->history_path, MAX_PATH, "test_bare_metric.db");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "history_init failed");
+
+   container = malloc(sizeof(prometheus_metrics_container_t));
+   memset(container, 0, sizeof(prometheus_metrics_container_t));
+
+   pgexporter_art_create(&t);
+   container->general_metrics = t;
+
+   /* A line with a metric name but no trailing value at all. */
+   struct mock_prometheus_metric_value m;
+   memset(&m, 0, sizeof(m));
+   m.value = "bare_metric\n";
+   pgexporter_art_insert(t, "m", (uintptr_t)&m, ValueRef);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_store_metrics(container), 0, cleanup, "store_metrics returned error");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("bare_metric", now - 10, now + 10, &out, &out_len), 0,
+                      cleanup, "query failed");
+   MCTF_ASSERT_INT_EQ(out_len, 1, cleanup, "expected 1 record for bare_metric, got %d", out_len);
+   MCTF_ASSERT(out[0].value == 0.0, cleanup, "missing value should default to 0.0");
+
+cleanup:
+   pgexporter_history_records_free(out, out_len);
+   if (container)
+   {
+      if (container->general_metrics)
+         pgexporter_art_destroy(container->general_metrics);
+      free(container);
+   }
+   pgexporter_history_shutdown();
+   unlink_db("test_bare_metric.db");
+   MCTF_FINISH();
+}
+
 MCTF_TEST(test_history_prune_deletes_old_keeps_new)
 {
    struct configuration* config = (struct configuration*)shmem;

--- a/test/testcases/test_history_http.c
+++ b/test/testcases/test_history_http.c
@@ -1,0 +1,384 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+ * Exercises pgexporter_history_http() end-to-end (path routing, query-param
+ * parsing, SQLite lookup, JSON encoding) without a live daemon: each test
+ * binds an ephemeral loopback TCP listener, forks a child that accepts the
+ * one connection and calls pgexporter_history_http(NULL, fd) directly on it,
+ * while the parent drives the request with the same HTTP client library
+ * test_http.c uses (pgexporter_http_create/pgexporter_http_invoke). This
+ * mirrors how main.c invokes the same function from a forked per-connection
+ * worker, just without main.c's own accept loop around it, and lets us reuse
+ * the client's request building/response parsing instead of hand-rolling it.
+ */
+
+#include <pgexporter.h>
+#include <history.h>
+#include <http.h>
+#include <memory.h>
+#include <shmem.h>
+#include <utils.h>
+
+#include <mctf.h>
+#include <tscommon.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+static char db_path[MAX_PATH];
+
+static void
+unlink_db(const char* path)
+{
+   char sibling[MAX_PATH];
+
+   if (path == NULL || path[0] == '\0')
+   {
+      return;
+   }
+
+   unlink(path);
+
+   pgexporter_snprintf(sibling, MAX_PATH, "%s-wal", path);
+   unlink(sibling);
+   pgexporter_snprintf(sibling, MAX_PATH, "%s-shm", path);
+   unlink(sibling);
+   pgexporter_snprintf(sibling, MAX_PATH, "%s-journal", path);
+   unlink(sibling);
+}
+
+static void
+make_record(struct history_record* r, time_t ts, const char* server,
+            const char* metric, const char* labels, double value)
+{
+   memset(r, 0, sizeof(*r));
+   r->ts = ts;
+   if (server)
+   {
+      pgexporter_snprintf(r->server, MISC_LENGTH, "%s", server);
+   }
+   if (metric)
+   {
+      pgexporter_snprintf(r->metric, PROMETHEUS_LENGTH, "%s", metric);
+   }
+   r->labels = (char*)labels;
+   r->value = value;
+}
+
+/* Bind an ephemeral loopback TCP listener and report the port the kernel picked. */
+static int
+create_loopback_listener(int* out_port)
+{
+   int fd;
+   struct sockaddr_in addr;
+   socklen_t addr_len = sizeof(addr);
+
+   fd = socket(AF_INET, SOCK_STREAM, 0);
+   if (fd < 0)
+   {
+      return -1;
+   }
+
+   memset(&addr, 0, sizeof(addr));
+   addr.sin_family = AF_INET;
+   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   addr.sin_port = 0;
+
+   if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) != 0 || listen(fd, 1) != 0)
+   {
+      close(fd);
+      return -1;
+   }
+
+   if (getsockname(fd, (struct sockaddr*)&addr, &addr_len) != 0)
+   {
+      close(fd);
+      return -1;
+   }
+
+   *out_port = ntohs(addr.sin_port);
+   return fd;
+}
+
+/* Fork a child that accepts the single incoming connection and serves it via
+ * pgexporter_history_http(NULL, fd), while the parent issues `path` as a GET
+ * through the real HTTP client and returns the response (caller destroys via
+ * pgexporter_http_response_destroy). Returns PGEXPORTER_HTTP_STATUS_OK/ERROR. */
+static int
+do_http_get(const char* path, struct http_response** out_response)
+{
+   int listen_fd = -1;
+   int port = 0;
+   pid_t pid;
+   int ret = PGEXPORTER_HTTP_STATUS_ERROR;
+   struct http* connection = NULL;
+   struct http_request* request = NULL;
+
+   listen_fd = create_loopback_listener(&port);
+   if (listen_fd < 0)
+   {
+      return PGEXPORTER_HTTP_STATUS_ERROR;
+   }
+
+   pid = fork();
+   if (pid < 0)
+   {
+      close(listen_fd);
+      return PGEXPORTER_HTTP_STATUS_ERROR;
+   }
+
+   if (pid == 0)
+   {
+      int client_fd = accept(listen_fd, NULL, NULL);
+
+      close(listen_fd);
+      if (client_fd < 0)
+      {
+         _exit(1);
+      }
+      pgexporter_history_http(NULL, client_fd);
+      _exit(1);
+   }
+
+   close(listen_fd);
+
+   if (pgexporter_http_create("127.0.0.1", port, false, NULL, NULL, NULL, &connection) != PGEXPORTER_HTTP_STATUS_OK)
+   {
+      waitpid(pid, NULL, 0);
+      return PGEXPORTER_HTTP_STATUS_ERROR;
+   }
+
+   if (pgexporter_http_request_create(PGEXPORTER_HTTP_GET, (char*)path, &request) != PGEXPORTER_HTTP_STATUS_OK)
+   {
+      pgexporter_http_destroy(connection);
+      waitpid(pid, NULL, 0);
+      return PGEXPORTER_HTTP_STATUS_ERROR;
+   }
+
+   ret = pgexporter_http_invoke(connection, request, out_response);
+
+   pgexporter_http_request_destroy(request);
+   pgexporter_http_destroy(connection);
+   waitpid(pid, NULL, 0);
+
+   return ret;
+}
+
+MCTF_TEST_SETUP(history_http)
+{
+   struct configuration* config;
+
+   pgexporter_test_config_save();
+   pgexporter_memory_init();
+
+   config = (struct configuration*)shmem;
+   config->history_backend = HISTORY_BACKEND_SQLITE;
+
+   pgexporter_snprintf(db_path, MAX_PATH, "/tmp/pgexporter-test/history-http-%d.db", (int)getpid());
+   unlink_db(db_path);
+   pgexporter_snprintf(config->history_path, MAX_PATH, "%s", db_path);
+}
+
+MCTF_TEST_TEARDOWN(history_http)
+{
+   pgexporter_history_shutdown();
+   unlink_db(db_path);
+   db_path[0] = '\0';
+   pgexporter_memory_destroy();
+   pgexporter_test_config_restore();
+}
+
+MCTF_TEST(test_history_http_valid_query_returns_200_json)
+{
+   struct history_record in[2];
+   struct http_response* response = NULL;
+   char path[256];
+   char* body = NULL;
+   time_t now = time(NULL);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+   make_record(&in[0], now, "srv1", "pg_up", "server=\"srv1\"", 1.0);
+   make_record(&in[1], now, "srv1", "pg_up", "server=\"srv1\"", 1.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 2), 0, cleanup, "write_batch failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_shutdown(), 0, cleanup, "shutdown before request failed");
+
+   pgexporter_snprintf(path, sizeof(path), "/history/pg_up?timestamp=%ld&duration=10", (long)now);
+
+   MCTF_ASSERT_INT_EQ(do_http_get(path, &response), PGEXPORTER_HTTP_STATUS_OK, cleanup,
+                      "HTTP request failed at the transport layer");
+   MCTF_ASSERT_PTR_NONNULL(response, cleanup, "no response object returned");
+   MCTF_ASSERT_INT_EQ(response->status_code, 200, cleanup, "expected 200, got %d", response->status_code);
+
+   body = (char*)response->payload.data;
+   MCTF_ASSERT_PTR_NONNULL(body, cleanup, "expected a response body");
+   MCTF_ASSERT_PTR_NONNULL(strstr(body, "\"metric\": \"pg_up\""), cleanup,
+                           "expected metric field in body: %s", body);
+   MCTF_ASSERT_PTR_NONNULL(strstr(body, "\"server\": \"srv1\""), cleanup,
+                           "expected server field in body: %s", body);
+   MCTF_ASSERT_PTR_NONNULL(strchr(body, '['), cleanup, "expected a JSON array body");
+
+cleanup:
+   pgexporter_http_response_destroy(response);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_http_no_matching_rows_returns_empty_array)
+{
+   struct http_response* response = NULL;
+   char* body = NULL;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_shutdown(), 0, cleanup, "shutdown before request failed");
+
+   MCTF_ASSERT_INT_EQ(do_http_get("/history/does_not_exist", &response), PGEXPORTER_HTTP_STATUS_OK, cleanup,
+                      "HTTP request failed at the transport layer");
+   MCTF_ASSERT_PTR_NONNULL(response, cleanup, "no response object returned");
+   MCTF_ASSERT_INT_EQ(response->status_code, 200, cleanup, "expected 200, got %d", response->status_code);
+
+   body = (char*)response->payload.data;
+   MCTF_ASSERT_PTR_NONNULL(body, cleanup, "expected a response body");
+   MCTF_ASSERT_PTR_NONNULL(strstr(body, "[]"), cleanup, "expected an empty JSON array, got: %s", body);
+   MCTF_ASSERT(strstr(body, "\"metric\"") == NULL, cleanup, "expected no records for an unknown metric");
+
+cleanup:
+   pgexporter_http_response_destroy(response);
+   MCTF_FINISH();
+}
+
+MCTF_TEST_NEGATIVE(test_history_http_missing_metric_returns_400)
+{
+   struct http_response* response = NULL;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_shutdown(), 0, cleanup, "shutdown before request failed");
+
+   MCTF_ASSERT_INT_EQ(do_http_get("/history/", &response), PGEXPORTER_HTTP_STATUS_OK, cleanup,
+                      "HTTP request failed at the transport layer");
+   MCTF_ASSERT_PTR_NONNULL(response, cleanup, "no response object returned");
+   MCTF_ASSERT_INT_EQ(response->status_code, 400, cleanup, "expected 400, got %d", response->status_code);
+
+cleanup:
+   pgexporter_http_response_destroy(response);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_http_unknown_path_returns_404)
+{
+   struct http_response* response = NULL;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_shutdown(), 0, cleanup, "shutdown before request failed");
+
+   MCTF_ASSERT_INT_EQ(do_http_get("/not-history", &response), PGEXPORTER_HTTP_STATUS_OK, cleanup,
+                      "HTTP request failed at the transport layer");
+   MCTF_ASSERT_PTR_NONNULL(response, cleanup, "no response object returned");
+   MCTF_ASSERT_INT_EQ(response->status_code, 404, cleanup, "expected 404, got %d", response->status_code);
+
+cleanup:
+   pgexporter_http_response_destroy(response);
+   MCTF_FINISH();
+}
+
+MCTF_TEST_NEGATIVE(test_history_http_non_numeric_timestamp_returns_400)
+{
+   struct http_response* response = NULL;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_shutdown(), 0, cleanup, "shutdown before request failed");
+
+   MCTF_ASSERT_INT_EQ(do_http_get("/history/pg_up?timestamp=not-a-number", &response), PGEXPORTER_HTTP_STATUS_OK,
+                      cleanup, "HTTP request failed at the transport layer");
+   MCTF_ASSERT_PTR_NONNULL(response, cleanup, "no response object returned");
+   MCTF_ASSERT_INT_EQ(response->status_code, 400, cleanup, "expected 400, got %d", response->status_code);
+
+cleanup:
+   pgexporter_http_response_destroy(response);
+   MCTF_FINISH();
+}
+
+MCTF_TEST_NEGATIVE(test_history_http_non_numeric_duration_returns_400)
+{
+   struct http_response* response = NULL;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_shutdown(), 0, cleanup, "shutdown before request failed");
+
+   MCTF_ASSERT_INT_EQ(do_http_get("/history/pg_up?duration=not-a-number", &response), PGEXPORTER_HTTP_STATUS_OK,
+                      cleanup, "HTTP request failed at the transport layer");
+   MCTF_ASSERT_PTR_NONNULL(response, cleanup, "no response object returned");
+   MCTF_ASSERT_INT_EQ(response->status_code, 400, cleanup, "expected 400, got %d", response->status_code);
+
+cleanup:
+   pgexporter_http_response_destroy(response);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_http_zero_duration_zero_width_window)
+{
+   struct history_record in[2];
+   struct http_response* response = NULL;
+   char path[256];
+   char* body = NULL;
+   time_t now = time(NULL);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+   /* One row exactly at `now`, one a second before it: with duration=0 the
+    * query window collapses to [now, now], so only the exact-match row should
+    * come back. */
+   make_record(&in[0], now, "s", "zero_window_metric", "", 1.0);
+   make_record(&in[1], now - 1, "s", "zero_window_metric", "", 2.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 2), 0, cleanup, "write_batch failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_shutdown(), 0, cleanup, "shutdown before request failed");
+
+   pgexporter_snprintf(path, sizeof(path), "/history/zero_window_metric?timestamp=%ld&duration=0", (long)now);
+
+   MCTF_ASSERT_INT_EQ(do_http_get(path, &response), PGEXPORTER_HTTP_STATUS_OK, cleanup,
+                      "HTTP request failed at the transport layer");
+   MCTF_ASSERT_PTR_NONNULL(response, cleanup, "no response object returned");
+   MCTF_ASSERT_INT_EQ(response->status_code, 200, cleanup, "expected 200, got %d", response->status_code);
+
+   body = (char*)response->payload.data;
+   MCTF_ASSERT_PTR_NONNULL(body, cleanup, "expected a response body");
+   MCTF_ASSERT_PTR_NONNULL(strstr(body, "\"value\": 1.000000"), cleanup,
+                           "expected only the exact-timestamp row in a zero-width window: %s", body);
+   MCTF_ASSERT(strstr(body, "\"value\": 2.000000") == NULL, cleanup,
+               "row outside a zero-width window should not be returned: %s", body);
+
+cleanup:
+   pgexporter_http_response_destroy(response);
+   MCTF_FINISH();
+}


### PR DESCRIPTION
Resolves #567 

### Changes
- Added parser edge-case tests for `pgexporter_history_store_metrics()` (NULL container, CRLF lines, escaped quotes/braces, missing value, oversized value truncation).
- Added new `test_history_http.c` module covering the `/history` JSON HTTP API
- Fixed: GET `/history/ `(empty metric) wrongly returned 404 instead of 400
- Fixed: empty query results returned {} instead of []
