### PR TITLE
Add socket-decoupled TLS context wrapper

### DIFF
--- a/src/include/security.h
+++ b/src/include/security.h
@@ -118,41 +118,6 @@ pgexporter_close_ssl(SSL* ssl);
 int
 pgexporter_extract_server_parameters(struct deque** server_parameters);
 
-/**
- * Create a SSL context
- * @param client True if client, false if server
- * @param ctx The SSL context
- * @return 0 upon success, otherwise 1
- */
-int
-pgexporter_create_ssl_ctx(bool client, SSL_CTX** ctx);
-
-/**
- * Create a SSL server
- * @param ctx The SSL context
- * @param key The key file path
- * @param cert The certificate file path
- * @param root The root file path
- * @param socket The socket
- * @param ssl The SSL structure
- * @return 0 upon success, otherwise 1
- */
-int
-pgexporter_create_ssl_server(SSL_CTX* ctx, char* key, char* cert, char* root, int socket, SSL** ssl);
-
-/**
- * Create a SSL client
- * @param ctx The SSL context
- * @param key The key file path, may be NULL
- * @param cert The certificate file path, may be NULL
- * @param root The root CA file path, may be NULL
- * @param socket The socket
- * @param ssl The SSL structure
- * @return 0 upon success, otherwise 1
- */
-int
-pgexporter_create_ssl_client(SSL_CTX* ctx, char* key, char* cert, char* root, int socket, SSL** ssl);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/tls.h
+++ b/src/include/tls.h
@@ -1,0 +1,387 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGEXPORTER_TLS_H
+#define PGEXPORTER_TLS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <openssl/ssl.h>
+
+#define PGEXPORTER_TLS_OK      0
+#define PGEXPORTER_TLS_WANT_IO 1
+#define PGEXPORTER_TLS_CLOSED  2
+#define PGEXPORTER_TLS_ERROR   (-1)
+
+/* TLS 1.3 AEAD cipher suites for the owned record layer */
+#define PGEXPORTER_TLS_AEAD_AES_128_GCM 1
+#define PGEXPORTER_TLS_AEAD_AES_256_GCM 2
+
+/* Maximum size of one TLS 1.3 record on the wire (header + 2^14 + expansion) */
+#define PGEXPORTER_TLS_RECORD_MAX 16645
+
+/** @struct tls_record_dir
+ * One direction of an owned TLS 1.3 record stream.
+ */
+struct tls_record_dir
+{
+   unsigned char secret[48]; /**< The application traffic secret (<= SHA-384 size) */
+   size_t secret_len;        /**< The secret length (32 for SHA-256, 48 for SHA-384) */
+   unsigned char key[32];    /**< The derived AEAD key */
+   unsigned char iv[12];     /**< The derived AEAD static IV */
+   uint64_t seq;             /**< The record sequence number */
+};
+
+/** @struct tls_record
+ * A socket and process independent TLS 1.3 record context. It is serializable
+ * so it can move between the pool and a worker without re-handshaking the backend.
+ */
+struct tls_record
+{
+   int aead;                    /**< The AEAD suite (PGEXPORTER_TLS_AEAD_*) */
+   struct tls_record_dir read;  /**< Records received from the peer */
+   struct tls_record_dir write; /**< Records sent to the peer */
+};
+
+/** @struct tls
+ * A TLS context driven through memory BIOs instead of a socket, so the
+ * cryptographic state is independent of the TCP connection lifecycle.
+ * Ciphertext moves via feed()/drain(); plaintext via write()/read().
+ */
+struct tls
+{
+   SSL* ssl;                                      /**< The OpenSSL connection */
+   BIO* rbio;                                     /**< Inbound ciphertext: network -> engine */
+   BIO* wbio;                                     /**< Outbound ciphertext: engine -> network */
+   int fd;                                        /**< The socket bound to this context, or -1 if none */
+   bool server;                                   /**< true for the accepting side */
+   bool handshake_complete;                       /**< true once the handshake has completed */
+   unsigned char client_secret[48];               /**< Captured TLS 1.3 client application traffic secret */
+   unsigned char server_secret[48];               /**< Captured TLS 1.3 server application traffic secret */
+   size_t secret_len;                             /**< Length of the captured secrets */
+   int secret_mask;                               /**< 0x1 client + 0x2 server captured */
+   bool owned;                                    /**< true once I/O is driven by our own record layer */
+   struct tls_record record;                      /**< Owned record-layer state (valid when owned) */
+   size_t rbuf_len;                               /**< Bytes buffered for inbound record framing */
+   unsigned char rbuf[PGEXPORTER_TLS_RECORD_MAX]; /**< Inbound TLS record framing buffer */
+};
+
+/**
+ * Create a socket-decoupled TLS context backed by a pair of memory BIOs
+ * @param ctx The OpenSSL context
+ * @param server true for the accepting role, false for the connecting role
+ * @param tls The resulting context
+ * @return PGEXPORTER_TLS_OK upon success, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_create(SSL_CTX* ctx, bool server, struct tls** tls);
+
+/**
+ * Free a TLS context and the OpenSSL resources it owns
+ * @param tls The context
+ */
+void
+pgexporter_tls_free(struct tls* tls);
+
+/**
+ * Feed ciphertext received from the network into the engine
+ * @param tls The context
+ * @param buf The ciphertext
+ * @param len The number of bytes
+ * @param consumed The number of bytes accepted
+ * @return PGEXPORTER_TLS_OK upon success, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_feed(struct tls* tls, const void* buf, size_t len, size_t* consumed);
+
+/**
+ * Drain ciphertext the engine has queued for the network
+ * @param tls The context
+ * @param buf The destination buffer
+ * @param cap The buffer capacity
+ * @param produced The number of bytes written (0 if nothing pending)
+ * @return PGEXPORTER_TLS_OK upon success, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_drain(struct tls* tls, void* buf, size_t cap, size_t* produced);
+
+/**
+ * Report whether the engine has outbound ciphertext queued
+ * @param tls The context
+ * @return true if there is pending ciphertext to drain
+ */
+bool
+pgexporter_tls_pending(struct tls* tls);
+
+/**
+ * Advance the TLS handshake by one step
+ * @param tls The context
+ * @return PGEXPORTER_TLS_OK when complete, PGEXPORTER_TLS_WANT_IO when more I/O is
+ *         required, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_handshake(struct tls* tls);
+
+/**
+ * Encrypt application plaintext, queueing the ciphertext for draining
+ * @param tls The context
+ * @param buf The plaintext
+ * @param len The number of bytes
+ * @param written The number of bytes accepted on PGEXPORTER_TLS_OK
+ * @return PGEXPORTER_TLS_OK upon success, PGEXPORTER_TLS_WANT_IO when I/O is
+ *         required, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_write(struct tls* tls, const void* buf, size_t len, size_t* written);
+
+/**
+ * Decrypt application plaintext from previously fed ciphertext
+ * @param tls The context
+ * @param buf The destination buffer
+ * @param cap The buffer capacity
+ * @param nread The number of bytes produced (0 unless PGEXPORTER_TLS_OK)
+ * @return PGEXPORTER_TLS_OK upon success, PGEXPORTER_TLS_WANT_IO when more
+ *         ciphertext is required, PGEXPORTER_TLS_CLOSED on a clean peer
+ *         shutdown, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_read(struct tls* tls, void* buf, size_t cap, size_t* nread);
+
+/**
+ * Associate a socket descriptor with the context so transparent I/O routing
+ * can recover it from the SSL object
+ * @param tls The context
+ * @param fd The socket descriptor
+ */
+void
+pgexporter_tls_set_fd(struct tls* tls, int fd);
+
+/**
+ * Recover the wrapper that owns an SSL object, if any
+ * @param ssl The OpenSSL connection
+ * @return The owning context, or NULL if ssl is not driven by a wrapper
+ */
+struct tls*
+pgexporter_tls_from_ssl(SSL* ssl);
+
+/**
+ * Drive a handshake to completion over a blocking socket, pumping ciphertext
+ * between the engine and the descriptor
+ * @param tls The context
+ * @param fd The connected socket descriptor
+ * @return PGEXPORTER_TLS_OK when the handshake completes, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_socket_handshake(struct tls* tls, int fd);
+
+/**
+ * Read decrypted application data over a blocking socket, pumping ciphertext as needed
+ * @param tls The context
+ * @param fd The connected socket descriptor
+ * @param buf The destination buffer
+ * @param cap The buffer capacity
+ * @param nread The number of plaintext bytes produced
+ * @return PGEXPORTER_TLS_OK on success, PGEXPORTER_TLS_CLOSED on a clean peer
+ *         shutdown, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_socket_read(struct tls* tls, int fd, void* buf, size_t cap, size_t* nread);
+
+/**
+ * Write application data over a blocking socket, draining the resulting ciphertext
+ * @param tls The context
+ * @param fd The connected socket descriptor
+ * @param buf The plaintext
+ * @param len The number of bytes
+ * @return PGEXPORTER_TLS_OK on success, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_socket_write(struct tls* tls, int fd, const void* buf, size_t len);
+
+/**
+ * Configure a server-role context with its certificate, private key and optional CA
+ * @param ctx The OpenSSL context
+ * @param key_file The private key file
+ * @param cert_file The certificate file
+ * @param ca_file The CA file, or an empty string for none
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tls_configure_server_ctx(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file);
+
+/**
+ * Create a socket-decoupled server-role context from configuration files
+ * @param ctx The OpenSSL context
+ * @param key_file The private key file
+ * @param cert_file The certificate file
+ * @param ca_file The CA file, or an empty string for none
+ * @param tls The resulting context
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tls_create_server(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file, struct tls** tls);
+
+/**
+ * Create a socket-decoupled client-role context from configuration files
+ * @param ctx The OpenSSL context
+ * @param key The private key file
+ * @param cert The certificate file
+ * @param root The root certificate file, or an empty string for none
+ * @param tls The resulting context
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_tls_create_client(SSL_CTX* ctx, char* key, char* cert, char* root, struct tls** tls);
+
+/**
+ * Create a SSL context
+ * @param client True if client, false if server
+ * @param ctx The SSL context
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_create_ssl_ctx(bool client, SSL_CTX** ctx);
+
+/**
+ * Create a SSL server
+ * @param ctx The SSL context
+ * @param key_file The key file path
+ * @param cert_file The certificate file path
+ * @param ca_file The ca file path
+ * @param socket The socket
+ * @param ssl The SSL structure
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_create_ssl_server(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file, int socket, SSL** ssl);
+
+/**
+ * Create a SSL client
+ * @param ctx The SSL context
+ * @param key The key file path
+ * @param cert The certificate file path
+ * @param root The root file path
+ * @param socket The socket
+ * @param ssl The SSL structure
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgexporter_create_ssl_client(SSL_CTX* ctx, char* key, char* cert, char* root, int socket, SSL** ssl);
+
+/**
+ * Harvest the negotiated TLS 1.3 record state (cipher + application traffic
+ * secrets) from a completed handshake into a serializable record context. The
+ * read/write directions are assigned according to the context's role. Requires
+ * TLS 1.3; fails otherwise.
+ * @param tls The context, with a completed handshake
+ * @param record The resulting serializable record context
+ * @return PGEXPORTER_TLS_OK upon success, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_harvest(struct tls* tls, struct tls_record* record);
+
+/**
+ * Switch a context to its own serializable record layer after the handshake:
+ * harvest the negotiated TLS 1.3 state, capture any buffered ciphertext, and
+ * route all further socket I/O through our record layer instead of OpenSSL.
+ * Requires TLS 1.3.
+ * @param tls The context, with a completed handshake
+ * @return PGEXPORTER_TLS_OK upon success, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_own(struct tls* tls);
+
+/**
+ * Initialize one record direction from its TLS 1.3 application traffic secret
+ * @param dir The direction
+ * @param aead The AEAD suite (PGEXPORTER_TLS_AEAD_*)
+ * @param secret The traffic secret
+ * @param secret_len The secret length
+ * @return PGEXPORTER_TLS_OK upon success, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_record_dir_init(struct tls_record_dir* dir, int aead, const unsigned char* secret, size_t secret_len);
+
+/**
+ * Seal application plaintext into a TLS 1.3 record (advances the write sequence)
+ * @param record The record context
+ * @param plaintext The plaintext
+ * @param plaintext_len The plaintext length
+ * @param out The destination buffer (>= plaintext_len + 22)
+ * @param cap The buffer capacity
+ * @param out_len The produced record length
+ * @return PGEXPORTER_TLS_OK upon success, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_record_seal(struct tls_record* record, const unsigned char* plaintext, size_t plaintext_len, unsigned char* out, size_t cap, size_t* out_len);
+
+/**
+ * Open a TLS 1.3 record into application plaintext (advances the read sequence)
+ * @param record The record context
+ * @param rec The record bytes
+ * @param rec_len The record length
+ * @param out The destination buffer
+ * @param cap The buffer capacity
+ * @param out_len The produced plaintext length
+ * @return PGEXPORTER_TLS_OK upon success, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_record_open(struct tls_record* record, const unsigned char* rec, size_t rec_len, unsigned char* out, size_t cap, size_t* out_len);
+
+/**
+ * Serialize a record context to bytes so it can move between processes
+ * @param record The record context
+ * @param buf The destination buffer
+ * @param cap The buffer capacity
+ * @param len The produced length
+ * @return PGEXPORTER_TLS_OK upon success, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_record_export(const struct tls_record* record, unsigned char* buf, size_t cap, size_t* len);
+
+/**
+ * Restore a record context from its serialized bytes
+ * @param buf The serialized bytes
+ * @param len The length
+ * @param record The resulting context
+ * @return PGEXPORTER_TLS_OK upon success, otherwise PGEXPORTER_TLS_ERROR
+ */
+int
+pgexporter_tls_record_import(const unsigned char* buf, size_t len, struct tls_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libpgexporter/http.c
+++ b/src/libpgexporter/http.c
@@ -32,6 +32,7 @@
 #include <logging.h>
 #include <network.h>
 #include <security.h>
+#include <tls.h>
 #include <utils.h>
 
 /* system */

--- a/src/libpgexporter/message.c
+++ b/src/libpgexporter/message.c
@@ -32,6 +32,7 @@
 #include <memory.h>
 #include <message.h>
 #include <network.h>
+#include <tls.h>
 #include <utils.h>
 
 #include <assert.h>
@@ -867,6 +868,45 @@ ssl_read_message(SSL* ssl, int timeout, struct message** msg)
    time_t start_time;
    struct message* m = NULL;
    unsigned long err;
+   struct tls* t = pgexporter_tls_from_ssl(ssl);
+
+   /* Socket-decoupled wrapper: pump ciphertext via the socket shim. */
+   if (t != NULL)
+   {
+      struct timeval tv;
+      size_t nread = 0;
+      int rc;
+
+      if (unlikely(timeout > 0))
+      {
+         tv.tv_sec = timeout;
+         tv.tv_usec = 0;
+         setsockopt(t->fd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof(tv));
+      }
+
+      m = pgexporter_memory_message();
+      rc = pgexporter_tls_socket_read(t, t->fd, m->data, DEFAULT_BUFFER_SIZE, &nread);
+
+      if (unlikely(timeout > 0))
+      {
+         tv.tv_sec = 0;
+         tv.tv_usec = 0;
+         setsockopt(t->fd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof(tv));
+      }
+
+      if (rc == PGEXPORTER_TLS_OK && nread > 0)
+      {
+         m->kind = (signed char)(*((char*)m->data));
+         m->length = (ssize_t)nread;
+         *msg = m;
+         return MESSAGE_STATUS_OK;
+      }
+      if (rc == PGEXPORTER_TLS_CLOSED)
+      {
+         return MESSAGE_STATUS_ZERO;
+      }
+      return MESSAGE_STATUS_ERROR;
+   }
 
    if (unlikely(timeout > 0))
    {
@@ -949,10 +989,21 @@ ssl_write_message(SSL* ssl, struct message* msg)
    ssize_t totalbytes;
    ssize_t remaining;
    int err;
+   struct tls* t = pgexporter_tls_from_ssl(ssl);
 
 #ifdef DEBUG
    assert(msg != NULL);
 #endif
+
+   /* Socket-decoupled wrapper: encrypt and drain via the socket shim. */
+   if (t != NULL)
+   {
+      if (pgexporter_tls_socket_write(t, t->fd, msg->data, (size_t)msg->length) == PGEXPORTER_TLS_OK)
+      {
+         return MESSAGE_STATUS_OK;
+      }
+      return MESSAGE_STATUS_ERROR;
+   }
 
    numbytes = 0;
    offset = 0;

--- a/src/libpgexporter/security.c
+++ b/src/libpgexporter/security.c
@@ -35,6 +35,7 @@
 #include <network.h>
 #include <prometheus.h>
 #include <security.h>
+#include <tls.h>
 #include <utf8.h>
 #include <utils.h>
 
@@ -1012,7 +1013,6 @@ pgexporter_server_authenticate(int server, char* database, char* username, char*
    int auth_type;
    int ret;
    int status = AUTH_ERROR;
-   int connect;
    SSL* c_ssl = NULL;
    struct message* ssl_msg = NULL;
    struct message* startup_msg = NULL;
@@ -1085,6 +1085,7 @@ pgexporter_server_authenticate(int server, char* database, char* username, char*
       if (msg->kind == 'S')
       {
          SSL_CTX* ctx = NULL;
+         struct tls* t = NULL;
 
          if (pgexporter_create_ssl_ctx(true, &ctx))
          {
@@ -1095,50 +1096,25 @@ pgexporter_server_authenticate(int server, char* database, char* username, char*
          pgexporter_log_trace("%s: Certificate file @ %s", config->servers[server].name, config->servers[server].tls_cert_file);
          pgexporter_log_trace("%s: CA file @ %s", config->servers[server].name, config->servers[server].tls_ca_file);
 
-         if (pgexporter_create_ssl_client(ctx, config->servers[server].tls_key_file, config->servers[server].tls_cert_file, config->servers[server].tls_ca_file, server_fd, &c_ssl))
+         /* Create a socket-decoupled client context */
+         if (pgexporter_tls_create_client(ctx, config->servers[server].tls_key_file, config->servers[server].tls_cert_file, config->servers[server].tls_ca_file, &t))
          {
+            pgexporter_log_error("Client failed");
             goto error;
          }
 
-         do
-         {
-            connect = SSL_connect(c_ssl);
+         pgexporter_tls_set_fd(t, server_fd);
+         c_ssl = t->ssl;
 
-            if (connect != 1)
-            {
-               int err = SSL_get_error(c_ssl, connect);
-               switch (err)
-               {
-                  case SSL_ERROR_ZERO_RETURN:
-                  case SSL_ERROR_WANT_READ:
-                  case SSL_ERROR_WANT_WRITE:
-                  case SSL_ERROR_WANT_CONNECT:
-                  case SSL_ERROR_WANT_ACCEPT:
-                  case SSL_ERROR_WANT_X509_LOOKUP:
-#ifndef HAVE_OPENBSD
-                  case SSL_ERROR_WANT_ASYNC:
-                  case SSL_ERROR_WANT_ASYNC_JOB:
-                  case SSL_ERROR_WANT_CLIENT_HELLO_CB:
-#endif
-                     break;
-                  case SSL_ERROR_SYSCALL:
-                     pgexporter_log_error("SSL_ERROR_SYSCALL: %s (%d)", strerror(errno), server_fd);
-                     errno = 0;
-                     goto error;
-                     break;
-                  case SSL_ERROR_SSL:
-                     pgexporter_log_error("SSL_ERROR_SSL: %s (%d)", strerror(errno), server_fd);
-                     pgexporter_log_error("%s", ERR_error_string(err, NULL));
-                     pgexporter_log_error("%s", ERR_lib_error_string(err));
-                     pgexporter_log_error("%s", ERR_reason_error_string(err));
-                     errno = 0;
-                     goto error;
-                     break;
-               }
-               ERR_clear_error();
-            }
+         /* Drive the backend handshake through the socket shim (memory BIOs) */
+         if (pgexporter_tls_socket_handshake(t, server_fd) != PGEXPORTER_TLS_OK)
+         {
+            unsigned long err;
+
+            err = ERR_get_error();
+            pgexporter_log_error("Backend TLS handshake failed on FD %d: %s", server_fd, ERR_reason_error_string(err));
+            goto error;
          }
-         while (connect != 1);
       }
    }
 
@@ -1239,10 +1215,21 @@ pgexporter_close_ssl(SSL* ssl)
 {
    int res;
    SSL_CTX* ctx;
+   struct tls* t;
 
    if (ssl != NULL)
    {
       ctx = SSL_get_SSL_CTX(ssl);
+
+      /* Socket-decoupled wrapper owns the SSL and its BIOs */
+      t = pgexporter_tls_from_ssl(ssl);
+      if (t != NULL)
+      {
+         pgexporter_tls_free(t);
+         SSL_CTX_free(ctx);
+         return;
+      }
+
       res = SSL_shutdown(ssl);
       if (res == 0)
       {
@@ -2569,234 +2556,6 @@ error:
    {
       free(s_k);
    }
-
-   return 1;
-}
-
-int
-pgexporter_create_ssl_ctx(bool client, SSL_CTX** ctx)
-{
-   SSL_CTX* c = NULL;
-
-   if (client)
-   {
-      c = SSL_CTX_new(TLS_client_method());
-   }
-   else
-   {
-      c = SSL_CTX_new(TLS_server_method());
-   }
-
-   if (c == NULL)
-   {
-      goto error;
-   }
-
-   if (SSL_CTX_set_min_proto_version(c, TLS1_2_VERSION) == 0)
-   {
-      goto error;
-   }
-
-   SSL_CTX_set_mode(c, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
-   SSL_CTX_set_options(c, SSL_OP_NO_TICKET);
-   SSL_CTX_set_session_cache_mode(c, SSL_SESS_CACHE_OFF);
-
-   *ctx = c;
-
-   return 0;
-
-error:
-
-   if (c != NULL)
-   {
-      SSL_CTX_free(c);
-   }
-
-   return 1;
-}
-
-int
-pgexporter_create_ssl_client(SSL_CTX* ctx, char* key, char* cert, char* root, int socket, SSL** ssl)
-{
-   SSL* s = NULL;
-   bool have_cert = false;
-   bool have_rootcert = false;
-
-   if (root != NULL && strlen(root) > 0)
-   {
-      if (SSL_CTX_load_verify_locations(ctx, root, NULL) != 1)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgexporter_log_error("Couldn't load TLS CA: %s", root);
-         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-
-      have_rootcert = true;
-   }
-
-   if (cert != NULL && strlen(cert) > 0)
-   {
-      if (SSL_CTX_use_certificate_chain_file(ctx, cert) != 1)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgexporter_log_error("Couldn't load TLS certificate: %s", cert);
-         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-
-      have_cert = true;
-   }
-
-   s = SSL_new(ctx);
-
-   if (s == NULL)
-   {
-      goto error;
-   }
-
-   if (SSL_set_fd(s, socket) == 0)
-   {
-      goto error;
-   }
-
-   if (have_cert && key != NULL && strlen(key) > 0)
-   {
-      if (SSL_use_PrivateKey_file(s, key, SSL_FILETYPE_PEM) != 1)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgexporter_log_error("Couldn't load TLS private key: %s", key);
-         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-
-      if (SSL_check_private_key(s) != 1)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgexporter_log_error("TLS private key check failed: %s", key);
-         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-   }
-
-   if (have_rootcert)
-   {
-      SSL_set_verify(s, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, NULL);
-   }
-
-   *ssl = s;
-
-   return 0;
-
-error:
-
-   pgexporter_close_ssl(s);
-
-   return 1;
-}
-
-int
-pgexporter_create_ssl_server(SSL_CTX* ctx, char* key, char* cert, char* root, int socket, SSL** ssl)
-{
-   SSL* s = NULL;
-   STACK_OF(X509_NAME)* root_cert_list = NULL;
-
-   if (strlen(cert) == 0)
-   {
-      pgexporter_log_error("No TLS certificate defined");
-      goto error;
-   }
-
-   if (strlen(key) == 0)
-   {
-      pgexporter_log_error("No TLS private key defined");
-      goto error;
-   }
-
-   if (SSL_CTX_use_certificate_chain_file(ctx, cert) != 1)
-   {
-      unsigned long err;
-
-      err = ERR_get_error();
-      pgexporter_log_error("Couldn't load TLS certificate: %s", cert);
-      pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
-      goto error;
-   }
-
-   if (SSL_CTX_use_PrivateKey_file(ctx, key, SSL_FILETYPE_PEM) != 1)
-   {
-      unsigned long err;
-
-      err = ERR_get_error();
-      pgexporter_log_error("Couldn't load TLS private key: %s", key);
-      pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
-      goto error;
-   }
-
-   if (SSL_CTX_check_private_key(ctx) != 1)
-   {
-      unsigned long err;
-
-      err = ERR_get_error();
-      pgexporter_log_error("TLS private key check failed: %s", key);
-      pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
-      goto error;
-   }
-
-   if (strlen(root) > 0)
-   {
-      if (SSL_CTX_load_verify_locations(ctx, root, NULL) != 1)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgexporter_log_error("Couldn't load TLS CA: %s", root);
-         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-
-      root_cert_list = SSL_load_client_CA_file(root);
-      if (root_cert_list == NULL)
-      {
-         unsigned long err;
-
-         err = ERR_get_error();
-         pgexporter_log_error("Couldn't load TLS CA: %s", root);
-         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
-         goto error;
-      }
-
-      SSL_CTX_set_verify(ctx, (SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT | SSL_VERIFY_CLIENT_ONCE), NULL);
-      SSL_CTX_set_client_CA_list(ctx, root_cert_list);
-   }
-
-   s = SSL_new(ctx);
-
-   if (s == NULL)
-   {
-      goto error;
-   }
-
-   if (SSL_set_fd(s, socket) == 0)
-   {
-      goto error;
-   }
-
-   *ssl = s;
-
-   return 0;
-
-error:
-
-   pgexporter_close_ssl(s);
 
    return 1;
 }

--- a/src/libpgexporter/tls.c
+++ b/src/libpgexporter/tls.c
@@ -1,0 +1,1531 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pgexporter.h>
+#include <tls.h>
+#include <logging.h>
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <openssl/bio.h>
+#include <openssl/core_names.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
+#include <openssl/x509.h>
+
+static int
+classify(SSL* ssl, int rc)
+{
+   int err = SSL_get_error(ssl, rc);
+
+   switch (err)
+   {
+      case SSL_ERROR_WANT_READ:
+      case SSL_ERROR_WANT_WRITE:
+         return PGEXPORTER_TLS_WANT_IO;
+      case SSL_ERROR_ZERO_RETURN:
+         return PGEXPORTER_TLS_CLOSED;
+      default:
+         return PGEXPORTER_TLS_ERROR;
+   }
+}
+
+/* Capture the TLS 1.3 application traffic secrets as OpenSSL derives them,
+ * recovering the owning context via the SSL app-data back-pointer. */
+static void
+keylog_cb(const SSL* ssl, const char* line)
+{
+   static const char* const labels[2] = {"CLIENT_TRAFFIC_SECRET_0 ", "SERVER_TRAFFIC_SECRET_0 "};
+   struct tls* t = (struct tls*)SSL_get_app_data(ssl);
+   int which;
+
+   if (t == NULL)
+   {
+      return;
+   }
+
+   for (which = 0; which < 2; which++)
+   {
+      size_t llen = strlen(labels[which]);
+      const char* hex;
+      unsigned char* dst;
+      size_t n = 0;
+
+      if (strncmp(line, labels[which], llen) != 0)
+      {
+         continue;
+      }
+
+      /* line = "<LABEL> <client_random_hex> <secret_hex>" */
+      hex = strchr(line + llen, ' ');
+      if (hex == NULL)
+      {
+         return;
+      }
+      hex++;
+
+      dst = (which == 0) ? t->client_secret : t->server_secret;
+      while (hex[0] != '\0' && hex[1] != '\0' && hex[0] != '\n' && n < 48)
+      {
+         unsigned int b;
+         if (sscanf(hex, "%2x", &b) != 1)
+         {
+            break;
+         }
+         dst[n++] = (unsigned char)b;
+         hex += 2;
+      }
+      t->secret_len = n;
+      t->secret_mask |= (which == 0) ? 0x1 : 0x2;
+      return;
+   }
+}
+
+int
+pgexporter_tls_create(SSL_CTX* ctx, bool server, struct tls** tls)
+{
+   struct tls* t = NULL;
+
+   if (ctx == NULL || tls == NULL)
+   {
+      goto error;
+   }
+
+   *tls = NULL;
+
+   t = (struct tls*)calloc(1, sizeof(struct tls));
+   if (t == NULL)
+   {
+      goto error;
+   }
+
+   t->server = server;
+   t->handshake_complete = false;
+   t->fd = -1;
+
+   t->ssl = SSL_new(ctx);
+   if (t->ssl == NULL)
+   {
+      goto error;
+   }
+
+   t->rbio = BIO_new(BIO_s_mem());
+   t->wbio = BIO_new(BIO_s_mem());
+   if (t->rbio == NULL || t->wbio == NULL)
+   {
+      goto error;
+   }
+
+   /* An empty memory BIO should ask for more bytes, not signal EOF */
+   BIO_set_mem_eof_return(t->rbio, -1);
+   BIO_set_mem_eof_return(t->wbio, -1);
+
+   /* The SSL object takes ownership of both BIOs */
+   SSL_set_bio(t->ssl, t->rbio, t->wbio);
+
+   /* Back-pointer so the I/O layer can recover the wrapper from the SSL object */
+   SSL_set_app_data(t->ssl, t);
+
+   /* Capture the TLS 1.3 traffic secrets during the handshake for later harvest */
+   SSL_CTX_set_keylog_callback(ctx, keylog_cb);
+
+   if (server)
+   {
+      SSL_set_accept_state(t->ssl);
+   }
+   else
+   {
+      SSL_set_connect_state(t->ssl);
+   }
+
+   *tls = t;
+   return PGEXPORTER_TLS_OK;
+
+error:
+   if (t != NULL)
+   {
+      if (t->ssl != NULL)
+      {
+         SSL_free(t->ssl);
+      }
+      else
+      {
+         if (t->rbio != NULL)
+         {
+            BIO_free(t->rbio);
+         }
+         if (t->wbio != NULL)
+         {
+            BIO_free(t->wbio);
+         }
+      }
+      free(t);
+   }
+
+   return PGEXPORTER_TLS_ERROR;
+}
+
+void
+pgexporter_tls_free(struct tls* tls)
+{
+   if (tls == NULL)
+   {
+      return;
+   }
+
+   if (tls->ssl != NULL)
+   {
+      /* Frees the SSL object and the two BIOs it owns */
+      SSL_free(tls->ssl);
+   }
+
+   free(tls);
+}
+
+void
+pgexporter_tls_set_fd(struct tls* tls, int fd)
+{
+   tls->fd = fd;
+}
+
+struct tls*
+pgexporter_tls_from_ssl(SSL* ssl)
+{
+   if (ssl == NULL)
+   {
+      return NULL;
+   }
+
+   return (struct tls*)SSL_get_app_data(ssl);
+}
+
+int
+pgexporter_tls_feed(struct tls* tls, const void* buf, size_t len, size_t* consumed)
+{
+   int written;
+
+   if (consumed != NULL)
+   {
+      *consumed = 0;
+   }
+
+   if (tls == NULL || tls->rbio == NULL || (buf == NULL && len > 0))
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   if (len == 0)
+   {
+      return PGEXPORTER_TLS_OK;
+   }
+
+   written = BIO_write(tls->rbio, buf, (int)len);
+   if (written <= 0)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   if (consumed != NULL)
+   {
+      *consumed = (size_t)written;
+   }
+
+   return PGEXPORTER_TLS_OK;
+}
+
+int
+pgexporter_tls_drain(struct tls* tls, void* buf, size_t cap, size_t* produced)
+{
+   int nread;
+
+   if (produced != NULL)
+   {
+      *produced = 0;
+   }
+
+   if (tls == NULL || tls->wbio == NULL || buf == NULL)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   if (cap == 0)
+   {
+      return PGEXPORTER_TLS_OK;
+   }
+
+   nread = BIO_read(tls->wbio, buf, (int)cap);
+   if (nread <= 0)
+   {
+      /* Nothing queued is not an error for a memory BIO */
+      if (BIO_should_retry(tls->wbio))
+      {
+         return PGEXPORTER_TLS_OK;
+      }
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   if (produced != NULL)
+   {
+      *produced = (size_t)nread;
+   }
+
+   return PGEXPORTER_TLS_OK;
+}
+
+bool
+pgexporter_tls_pending(struct tls* tls)
+{
+   if (tls == NULL || tls->wbio == NULL)
+   {
+      return false;
+   }
+
+   return BIO_pending(tls->wbio) > 0;
+}
+
+int
+pgexporter_tls_handshake(struct tls* tls)
+{
+   int rc;
+
+   if (tls == NULL || tls->ssl == NULL)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   if (tls->handshake_complete)
+   {
+      return PGEXPORTER_TLS_OK;
+   }
+
+   rc = SSL_do_handshake(tls->ssl);
+   if (rc == 1)
+   {
+      tls->handshake_complete = true;
+      return PGEXPORTER_TLS_OK;
+   }
+
+   return classify(tls->ssl, rc);
+}
+
+int
+pgexporter_tls_write(struct tls* tls, const void* buf, size_t len, size_t* written)
+{
+   int rc;
+
+   if (written != NULL)
+   {
+      *written = 0;
+   }
+
+   if (tls == NULL || tls->ssl == NULL || (buf == NULL && len > 0))
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   if (len == 0)
+   {
+      return PGEXPORTER_TLS_OK;
+   }
+
+   rc = SSL_write(tls->ssl, buf, (int)len);
+   if (rc > 0)
+   {
+      if (written != NULL)
+      {
+         *written = (size_t)rc;
+      }
+      return PGEXPORTER_TLS_OK;
+   }
+
+   return classify(tls->ssl, rc);
+}
+
+int
+pgexporter_tls_read(struct tls* tls, void* buf, size_t cap, size_t* nread)
+{
+   int rc;
+
+   if (nread != NULL)
+   {
+      *nread = 0;
+   }
+
+   if (tls == NULL || tls->ssl == NULL || buf == NULL)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   if (cap == 0)
+   {
+      return PGEXPORTER_TLS_OK;
+   }
+
+   rc = SSL_read(tls->ssl, buf, (int)cap);
+   if (rc > 0)
+   {
+      if (nread != NULL)
+      {
+         *nread = (size_t)rc;
+      }
+      return PGEXPORTER_TLS_OK;
+   }
+
+   return classify(tls->ssl, rc);
+}
+
+static int
+socket_write_all(int fd, const unsigned char* buf, size_t len)
+{
+   size_t off = 0;
+
+   while (off < len)
+   {
+      ssize_t n = write(fd, buf + off, len - off);
+      if (n > 0)
+      {
+         off += (size_t)n;
+      }
+      else if (n < 0 && errno == EINTR)
+      {
+         continue;
+      }
+      else
+      {
+         return PGEXPORTER_TLS_ERROR;
+      }
+   }
+
+   return PGEXPORTER_TLS_OK;
+}
+
+/* Drain all pending outbound ciphertext to the socket. */
+static int
+socket_flush(struct tls* tls, int fd)
+{
+   unsigned char buf[16384];
+   size_t produced = 0;
+
+   while (pgexporter_tls_drain(tls, buf, sizeof(buf), &produced) == PGEXPORTER_TLS_OK && produced > 0)
+   {
+      if (socket_write_all(fd, buf, produced) != PGEXPORTER_TLS_OK)
+      {
+         return PGEXPORTER_TLS_ERROR;
+      }
+   }
+
+   return PGEXPORTER_TLS_OK;
+}
+
+/* Read one chunk of ciphertext from the socket and feed it to the engine. */
+static int
+socket_fill(struct tls* tls, int fd)
+{
+   unsigned char buf[16384];
+   ssize_t n;
+
+   do
+   {
+      n = read(fd, buf, sizeof(buf));
+   }
+   while (n < 0 && errno == EINTR);
+
+   if (n <= 0)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   return pgexporter_tls_feed(tls, buf, (size_t)n, NULL);
+}
+
+/* Owned-mode read: frame one TLS record off the socket and decrypt it ourselves. */
+static int
+owned_read(struct tls* tls, int fd, void* buf, size_t cap, size_t* nread)
+{
+   for (;;)
+   {
+      if (tls->rbuf_len >= 5)
+      {
+         size_t body = ((size_t)tls->rbuf[3] << 8) | (size_t)tls->rbuf[4];
+         size_t total = 5 + body;
+
+         if (total > sizeof(tls->rbuf))
+         {
+            return PGEXPORTER_TLS_ERROR;
+         }
+         if (tls->rbuf_len >= total)
+         {
+            int rc = pgexporter_tls_record_open(&tls->record, tls->rbuf, total, buf, cap, nread);
+            memmove(tls->rbuf, tls->rbuf + total, tls->rbuf_len - total);
+            tls->rbuf_len -= total;
+            return rc;
+         }
+      }
+
+      {
+         size_t room = sizeof(tls->rbuf) - tls->rbuf_len;
+         ssize_t n;
+
+         if (room == 0)
+         {
+            return PGEXPORTER_TLS_ERROR;
+         }
+         do
+         {
+            n = read(fd, tls->rbuf + tls->rbuf_len, room);
+         }
+         while (n < 0 && errno == EINTR);
+         if (n == 0)
+         {
+            return PGEXPORTER_TLS_CLOSED;
+         }
+         if (n < 0)
+         {
+            return PGEXPORTER_TLS_ERROR;
+         }
+         tls->rbuf_len += (size_t)n;
+      }
+   }
+}
+
+/* Owned-mode write: seal application data into TLS records and write them out. */
+static int
+owned_write(struct tls* tls, int fd, const unsigned char* buf, size_t len)
+{
+   unsigned char rec[PGEXPORTER_TLS_RECORD_MAX];
+   size_t off = 0;
+
+   while (off < len)
+   {
+      size_t chunk = len - off;
+      size_t rlen = 0;
+
+      if (chunk > 16384)
+      {
+         chunk = 16384; /* one TLS record carries at most 2^14 plaintext bytes */
+      }
+      if (pgexporter_tls_record_seal(&tls->record, buf + off, chunk, rec, sizeof(rec), &rlen) != PGEXPORTER_TLS_OK)
+      {
+         return PGEXPORTER_TLS_ERROR;
+      }
+      if (socket_write_all(fd, rec, rlen) != PGEXPORTER_TLS_OK)
+      {
+         return PGEXPORTER_TLS_ERROR;
+      }
+      off += chunk;
+   }
+
+   return PGEXPORTER_TLS_OK;
+}
+
+int
+pgexporter_tls_socket_handshake(struct tls* tls, int fd)
+{
+   if (tls == NULL || fd < 0)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   for (;;)
+   {
+      int rc = pgexporter_tls_handshake(tls);
+
+      if (socket_flush(tls, fd) != PGEXPORTER_TLS_OK)
+      {
+         return PGEXPORTER_TLS_ERROR;
+      }
+
+      if (rc == PGEXPORTER_TLS_OK)
+      {
+         return PGEXPORTER_TLS_OK;
+      }
+      if (rc != PGEXPORTER_TLS_WANT_IO)
+      {
+         return PGEXPORTER_TLS_ERROR;
+      }
+
+      if (socket_fill(tls, fd) != PGEXPORTER_TLS_OK)
+      {
+         return PGEXPORTER_TLS_ERROR;
+      }
+   }
+}
+
+int
+pgexporter_tls_socket_read(struct tls* tls, int fd, void* buf, size_t cap, size_t* nread)
+{
+   if (nread != NULL)
+   {
+      *nread = 0;
+   }
+
+   if (tls == NULL || fd < 0 || buf == NULL)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   if (tls->owned)
+   {
+      return owned_read(tls, fd, buf, cap, nread);
+   }
+
+   for (;;)
+   {
+      int rc = pgexporter_tls_read(tls, buf, cap, nread);
+
+      if (rc == PGEXPORTER_TLS_OK || rc == PGEXPORTER_TLS_CLOSED)
+      {
+         return rc;
+      }
+      if (rc != PGEXPORTER_TLS_WANT_IO)
+      {
+         return PGEXPORTER_TLS_ERROR;
+      }
+
+      /* The engine may owe the peer a flight before it can receive more. */
+      if (socket_flush(tls, fd) != PGEXPORTER_TLS_OK)
+      {
+         return PGEXPORTER_TLS_ERROR;
+      }
+      if (socket_fill(tls, fd) != PGEXPORTER_TLS_OK)
+      {
+         return PGEXPORTER_TLS_ERROR;
+      }
+   }
+}
+
+int
+pgexporter_tls_socket_write(struct tls* tls, int fd, const void* buf, size_t len)
+{
+   size_t off = 0;
+
+   if (tls == NULL || fd < 0 || (buf == NULL && len > 0))
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   if (tls->owned)
+   {
+      return owned_write(tls, fd, (const unsigned char*)buf, len);
+   }
+
+   while (off < len)
+   {
+      size_t written = 0;
+      int rc = pgexporter_tls_write(tls, (const unsigned char*)buf + off, len - off, &written);
+
+      if (rc == PGEXPORTER_TLS_OK)
+      {
+         off += written;
+         if (socket_flush(tls, fd) != PGEXPORTER_TLS_OK)
+         {
+            return PGEXPORTER_TLS_ERROR;
+         }
+      }
+      else if (rc == PGEXPORTER_TLS_WANT_IO)
+      {
+         if (socket_flush(tls, fd) != PGEXPORTER_TLS_OK)
+         {
+            return PGEXPORTER_TLS_ERROR;
+         }
+         if (socket_fill(tls, fd) != PGEXPORTER_TLS_OK)
+         {
+            return PGEXPORTER_TLS_ERROR;
+         }
+      }
+      else
+      {
+         return PGEXPORTER_TLS_ERROR;
+      }
+   }
+
+   return PGEXPORTER_TLS_OK;
+}
+
+int
+pgexporter_tls_configure_server_ctx(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file)
+{
+   STACK_OF(X509_NAME)* root_cert_list = NULL;
+
+   if (strlen(cert_file) == 0)
+   {
+      pgexporter_log_error("No TLS certificate defined");
+      goto error;
+   }
+
+   if (strlen(key_file) == 0)
+   {
+      pgexporter_log_error("No TLS private key defined");
+      goto error;
+   }
+
+   if (SSL_CTX_use_certificate_chain_file(ctx, cert_file) != 1)
+   {
+      unsigned long err;
+
+      err = ERR_get_error();
+      pgexporter_log_error("Couldn't load TLS certificate: %s", cert_file);
+      pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+      goto error;
+   }
+
+   if (SSL_CTX_use_PrivateKey_file(ctx, key_file, SSL_FILETYPE_PEM) != 1)
+   {
+      unsigned long err;
+
+      err = ERR_get_error();
+      pgexporter_log_error("Couldn't load TLS private key: %s", key_file);
+      pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+      goto error;
+   }
+
+   if (SSL_CTX_check_private_key(ctx) != 1)
+   {
+      unsigned long err;
+
+      err = ERR_get_error();
+      pgexporter_log_error("TLS private key check failed: %s", key_file);
+      pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+      goto error;
+   }
+
+   if (strlen(ca_file) > 0)
+   {
+      if (SSL_CTX_load_verify_locations(ctx, ca_file, NULL) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgexporter_log_error("Couldn't load TLS CA: %s", ca_file);
+         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      root_cert_list = SSL_load_client_CA_file(ca_file);
+      if (root_cert_list == NULL)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgexporter_log_error("Couldn't load TLS CA: %s", ca_file);
+         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      SSL_CTX_set_verify(ctx, (SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT | SSL_VERIFY_CLIENT_ONCE), NULL);
+      SSL_CTX_set_client_CA_list(ctx, root_cert_list);
+   }
+
+   return 0;
+
+error:
+
+   return 1;
+}
+
+int
+pgexporter_tls_create_server(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file, struct tls** tls)
+{
+   if (pgexporter_tls_configure_server_ctx(ctx, key_file, cert_file, ca_file))
+   {
+      goto error;
+   }
+
+   if (pgexporter_tls_create(ctx, true, tls) != PGEXPORTER_TLS_OK)
+   {
+      goto error;
+   }
+
+   return 0;
+
+error:
+
+   SSL_CTX_free(ctx);
+
+   return 1;
+}
+
+int
+pgexporter_tls_create_client(SSL_CTX* ctx, char* key, char* cert, char* root, struct tls** tls)
+{
+   struct tls* t = NULL;
+   bool have_cert = false;
+   bool have_rootcert = false;
+
+   if (root != NULL && strlen(root) > 0)
+   {
+      if (SSL_CTX_load_verify_locations(ctx, root, NULL) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgexporter_log_error("Couldn't load TLS CA: %s", root);
+         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      have_rootcert = true;
+   }
+
+   if (cert != NULL && strlen(cert) > 0)
+   {
+      if (SSL_CTX_use_certificate_chain_file(ctx, cert) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgexporter_log_error("Couldn't load TLS certificate: %s", cert);
+         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      have_cert = true;
+   }
+
+   if (pgexporter_tls_create(ctx, false, &t) != PGEXPORTER_TLS_OK)
+   {
+      goto error;
+   }
+
+   if (have_cert && key != NULL && strlen(key) > 0)
+   {
+      if (SSL_use_PrivateKey_file(t->ssl, key, SSL_FILETYPE_PEM) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgexporter_log_error("Couldn't load TLS private key: %s", key);
+         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      if (SSL_check_private_key(t->ssl) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgexporter_log_error("TLS private key check failed: %s", key);
+         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+   }
+
+   if (have_rootcert)
+   {
+      SSL_set_verify(t->ssl, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, NULL);
+   }
+
+   *tls = t;
+
+   return 0;
+
+error:
+
+   if (t != NULL)
+   {
+      pgexporter_tls_free(t);
+   }
+   SSL_CTX_free(ctx);
+
+   return 1;
+}
+
+int
+pgexporter_create_ssl_ctx(bool client, SSL_CTX** ctx)
+{
+   SSL_CTX* c = NULL;
+
+   if (client)
+   {
+      c = SSL_CTX_new(TLS_client_method());
+   }
+   else
+   {
+      c = SSL_CTX_new(TLS_server_method());
+   }
+
+   if (c == NULL)
+   {
+      goto error;
+   }
+
+   if (SSL_CTX_set_min_proto_version(c, TLS1_2_VERSION) == 0)
+   {
+      goto error;
+   }
+
+   SSL_CTX_set_mode(c, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+   SSL_CTX_set_options(c, SSL_OP_NO_TICKET);
+   SSL_CTX_set_session_cache_mode(c, SSL_SESS_CACHE_OFF);
+
+   *ctx = c;
+
+   return 0;
+
+error:
+
+   if (c != NULL)
+   {
+      SSL_CTX_free(c);
+   }
+
+   return 1;
+}
+
+int
+pgexporter_create_ssl_server(SSL_CTX* ctx, char* key_file, char* cert_file, char* ca_file, int socket, SSL** ssl)
+{
+   SSL* s = NULL;
+
+   if (pgexporter_tls_configure_server_ctx(ctx, key_file, cert_file, ca_file))
+   {
+      goto error;
+   }
+
+   s = SSL_new(ctx);
+
+   if (s == NULL)
+   {
+      goto error;
+   }
+
+   if (SSL_set_fd(s, socket) == 0)
+   {
+      goto error;
+   }
+
+   *ssl = s;
+
+   return 0;
+
+error:
+
+   if (s != NULL)
+   {
+      SSL_shutdown(s);
+      SSL_free(s);
+   }
+   SSL_CTX_free(ctx);
+
+   return 1;
+}
+
+int
+pgexporter_create_ssl_client(SSL_CTX* ctx, char* key, char* cert, char* root, int socket, SSL** ssl)
+{
+   SSL* s = NULL;
+   bool have_cert = false;
+   bool have_rootcert = false;
+
+   if (root != NULL && strlen(root) > 0)
+   {
+      if (SSL_CTX_load_verify_locations(ctx, root, NULL) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgexporter_log_error("Couldn't load TLS CA: %s", root);
+         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      have_rootcert = true;
+   }
+
+   if (cert != NULL && strlen(cert) > 0)
+   {
+      if (SSL_CTX_use_certificate_chain_file(ctx, cert) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgexporter_log_error("Couldn't load TLS certificate: %s", cert);
+         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      have_cert = true;
+   }
+
+   s = SSL_new(ctx);
+
+   if (s == NULL)
+   {
+      goto error;
+   }
+
+   if (SSL_set_fd(s, socket) == 0)
+   {
+      goto error;
+   }
+
+   if (have_cert && key != NULL && strlen(key) > 0)
+   {
+      if (SSL_use_PrivateKey_file(s, key, SSL_FILETYPE_PEM) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgexporter_log_error("Couldn't load TLS private key: %s", key);
+         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+
+      if (SSL_check_private_key(s) != 1)
+      {
+         unsigned long err;
+
+         err = ERR_get_error();
+         pgexporter_log_error("TLS private key check failed: %s", key);
+         pgexporter_log_error("Reason: %s", ERR_reason_error_string(err));
+         goto error;
+      }
+   }
+
+   if (have_rootcert)
+   {
+      SSL_set_verify(s, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, NULL);
+   }
+
+   *ssl = s;
+
+   return 0;
+
+error:
+
+   if (s != NULL)
+   {
+      SSL_shutdown(s);
+      SSL_free(s);
+   }
+   SSL_CTX_free(ctx);
+
+   return 1;
+}
+
+/* The fixed AEAD parameters for each supported TLS 1.3 suite. */
+static int
+aead_lookup(int aead, const EVP_CIPHER** cipher, size_t* key_len, const char** hash)
+{
+   switch (aead)
+   {
+      case PGEXPORTER_TLS_AEAD_AES_128_GCM:
+         *cipher = EVP_aes_128_gcm();
+         *key_len = 16;
+         *hash = "SHA256";
+         return PGEXPORTER_TLS_OK;
+      case PGEXPORTER_TLS_AEAD_AES_256_GCM:
+         *cipher = EVP_aes_256_gcm();
+         *key_len = 32;
+         *hash = "SHA384";
+         return PGEXPORTER_TLS_OK;
+      default:
+         return PGEXPORTER_TLS_ERROR;
+   }
+}
+
+/* RFC 8446 7.1 HKDF-Expand-Label with an empty context. */
+static int
+hkdf_expand_label(const char* hash, const unsigned char* secret, size_t secret_len,
+                  const char* label, unsigned char* out, size_t out_len)
+{
+   unsigned char info[256];
+   size_t ilen = 0;
+   char full[64];
+   int flen;
+   EVP_KDF* kdf;
+   EVP_KDF_CTX* kctx;
+   OSSL_PARAM params[5];
+   int ok;
+
+   flen = snprintf(full, sizeof(full), "tls13 %s", label);
+   if (flen <= 0)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   info[ilen++] = (unsigned char)(out_len >> 8);
+   info[ilen++] = (unsigned char)(out_len & 0xff);
+   info[ilen++] = (unsigned char)flen;
+   memcpy(info + ilen, full, (size_t)flen);
+   ilen += (size_t)flen;
+   info[ilen++] = 0x00;
+
+   kdf = EVP_KDF_fetch(NULL, "HKDF", NULL);
+   if (kdf == NULL)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   kctx = EVP_KDF_CTX_new(kdf);
+   EVP_KDF_free(kdf);
+   if (kctx == NULL)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   params[0] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MODE, "EXPAND_ONLY", 0);
+   params[1] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, (char*)hash, 0);
+   params[2] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, (void*)secret, secret_len);
+   params[3] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO, info, ilen);
+   params[4] = OSSL_PARAM_construct_end();
+
+   ok = EVP_KDF_derive(kctx, out, out_len, params) > 0;
+   EVP_KDF_CTX_free(kctx);
+
+   return ok ? PGEXPORTER_TLS_OK : PGEXPORTER_TLS_ERROR;
+}
+
+/* Per-record nonce: static IV XOR the 64-bit sequence number (RFC 8446 5.3). */
+static void
+build_nonce(const unsigned char* iv, uint64_t seq, unsigned char* nonce)
+{
+   int i;
+
+   memcpy(nonce, iv, 12);
+   for (i = 0; i < 8; i++)
+   {
+      nonce[11 - i] ^= (unsigned char)(seq >> (8 * i));
+   }
+}
+
+static int
+aead_seal(const EVP_CIPHER* cipher, const unsigned char* key, const unsigned char* nonce,
+          const unsigned char* aad, size_t aad_len,
+          const unsigned char* pt, size_t pt_len,
+          unsigned char* ct, unsigned char* tag)
+{
+   EVP_CIPHER_CTX* c = EVP_CIPHER_CTX_new();
+   int len;
+   int rc = 0;
+
+   if (c == NULL)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   if (EVP_EncryptInit_ex(c, cipher, NULL, NULL, NULL) != 1 ||
+       EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) != 1 ||
+       EVP_EncryptInit_ex(c, NULL, NULL, key, nonce) != 1 ||
+       EVP_EncryptUpdate(c, NULL, &len, aad, (int)aad_len) != 1 ||
+       EVP_EncryptUpdate(c, ct, &len, pt, (int)pt_len) != 1 ||
+       EVP_EncryptFinal_ex(c, ct + len, &len) != 1 ||
+       EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_GET_TAG, 16, tag) != 1)
+   {
+      goto done;
+   }
+   rc = 1;
+done:
+   EVP_CIPHER_CTX_free(c);
+   return rc ? PGEXPORTER_TLS_OK : PGEXPORTER_TLS_ERROR;
+}
+
+static int
+aead_open(const EVP_CIPHER* cipher, const unsigned char* key, const unsigned char* nonce,
+          const unsigned char* aad, size_t aad_len,
+          const unsigned char* ct, size_t ct_len,
+          const unsigned char* tag, unsigned char* out, int* out_len)
+{
+   EVP_CIPHER_CTX* c = EVP_CIPHER_CTX_new();
+   int len = 0;
+   int rc = 0;
+
+   if (c == NULL)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   if (EVP_DecryptInit_ex(c, cipher, NULL, NULL, NULL) != 1 ||
+       EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) != 1 ||
+       EVP_DecryptInit_ex(c, NULL, NULL, key, nonce) != 1 ||
+       EVP_DecryptUpdate(c, NULL, &len, aad, (int)aad_len) != 1 ||
+       EVP_DecryptUpdate(c, out, &len, ct, (int)ct_len) != 1)
+   {
+      goto done;
+   }
+   *out_len = len;
+   if (EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_SET_TAG, 16, (void*)tag) != 1 ||
+       EVP_DecryptFinal_ex(c, out + len, &len) != 1)
+   {
+      goto done; /* tag mismatch */
+   }
+   *out_len += len;
+   rc = 1;
+done:
+   EVP_CIPHER_CTX_free(c);
+   return rc ? PGEXPORTER_TLS_OK : PGEXPORTER_TLS_ERROR;
+}
+
+int
+pgexporter_tls_record_dir_init(struct tls_record_dir* dir, int aead, const unsigned char* secret, size_t secret_len)
+{
+   const EVP_CIPHER* cipher;
+   size_t key_len;
+   const char* hash;
+
+   if (dir == NULL || secret == NULL || secret_len > sizeof(dir->secret))
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   if (aead_lookup(aead, &cipher, &key_len, &hash) != PGEXPORTER_TLS_OK)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   memcpy(dir->secret, secret, secret_len);
+   dir->secret_len = secret_len;
+
+   if (hkdf_expand_label(hash, secret, secret_len, "key", dir->key, key_len) != PGEXPORTER_TLS_OK ||
+       hkdf_expand_label(hash, secret, secret_len, "iv", dir->iv, sizeof(dir->iv)) != PGEXPORTER_TLS_OK)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   dir->seq = 0;
+
+   return PGEXPORTER_TLS_OK;
+}
+
+int
+pgexporter_tls_record_seal(struct tls_record* record, const unsigned char* plaintext, size_t plaintext_len, unsigned char* out, size_t cap, size_t* out_len)
+{
+   const EVP_CIPHER* cipher;
+   size_t key_len;
+   const char* hash;
+   unsigned char nonce[12];
+   unsigned char inner[16384];
+   size_t inner_len;
+   size_t record_len;
+
+   if (out_len != NULL)
+   {
+      *out_len = 0;
+   }
+   if (record == NULL || (plaintext == NULL && plaintext_len > 0) || out == NULL)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   if (aead_lookup(record->aead, &cipher, &key_len, &hash) != PGEXPORTER_TLS_OK)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   inner_len = plaintext_len + 1; /* + inner content type */
+   if (inner_len > sizeof(inner))
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   record_len = 5 + inner_len + 16; /* header + ciphertext + tag */
+   if (cap < record_len)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   memcpy(inner, plaintext, plaintext_len);
+   inner[plaintext_len] = 0x17; /* TLSInnerPlaintext content type = application_data */
+
+   out[0] = 0x17;
+   out[1] = 0x03;
+   out[2] = 0x03;
+   out[3] = (unsigned char)((inner_len + 16) >> 8);
+   out[4] = (unsigned char)((inner_len + 16) & 0xff);
+
+   build_nonce(record->write.iv, record->write.seq, nonce);
+
+   if (aead_seal(cipher, record->write.key, nonce, out, 5, inner, inner_len,
+                 out + 5, out + 5 + inner_len) != PGEXPORTER_TLS_OK)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   record->write.seq++;
+   if (out_len != NULL)
+   {
+      *out_len = record_len;
+   }
+
+   return PGEXPORTER_TLS_OK;
+}
+
+int
+pgexporter_tls_record_open(struct tls_record* record, const unsigned char* rec, size_t rec_len, unsigned char* out, size_t cap, size_t* out_len)
+{
+   const EVP_CIPHER* cipher;
+   size_t key_len;
+   const char* hash;
+   unsigned char nonce[12];
+   unsigned char inner[16384];
+   int inner_len = 0;
+   size_t body_len;
+   size_t ct_len;
+
+   if (out_len != NULL)
+   {
+      *out_len = 0;
+   }
+   if (record == NULL || rec == NULL || out == NULL || rec_len < 5 + 16 + 1)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   if (aead_lookup(record->aead, &cipher, &key_len, &hash) != PGEXPORTER_TLS_OK)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   body_len = ((size_t)rec[3] << 8) | (size_t)rec[4];
+   if (body_len < 16 || 5 + body_len > rec_len || body_len - 16 > sizeof(inner))
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   ct_len = body_len - 16;
+
+   build_nonce(record->read.iv, record->read.seq, nonce);
+
+   /* AAD is the 5-byte record header */
+   if (aead_open(cipher, record->read.key, nonce, rec, 5,
+                 rec + 5, ct_len, rec + 5 + ct_len, inner, &inner_len) != PGEXPORTER_TLS_OK)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   /* TLSInnerPlaintext = content || content_type || zero padding */
+   while (inner_len > 0 && inner[inner_len - 1] == 0x00)
+   {
+      inner_len--;
+   }
+   if (inner_len <= 0)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   /* Resume only application_data (0x17); fail closed on a post-handshake record
+    * or alert rather than hand non-application bytes up. PG sends none mid-session. */
+   if (inner[inner_len - 1] != 0x17)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   inner_len--; /* drop the content type byte */
+
+   if ((size_t)inner_len > cap)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   memcpy(out, inner, (size_t)inner_len);
+   record->read.seq++;
+   if (out_len != NULL)
+   {
+      *out_len = (size_t)inner_len;
+   }
+
+   return PGEXPORTER_TLS_OK;
+}
+
+static void
+export_dir(unsigned char** p, const struct tls_record_dir* dir)
+{
+   int i;
+
+   *(*p)++ = (unsigned char)dir->secret_len;
+   memcpy(*p, dir->secret, dir->secret_len);
+   *p += dir->secret_len;
+   for (i = 0; i < 8; i++)
+   {
+      *(*p)++ = (unsigned char)(dir->seq >> (8 * (7 - i)));
+   }
+}
+
+static int
+import_dir(const unsigned char** p, const unsigned char* end, int aead, struct tls_record_dir* dir)
+{
+   size_t sl;
+   uint64_t seq = 0;
+   int i;
+
+   if (*p >= end)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   sl = *(*p)++;
+   if (sl > sizeof(dir->secret) || *p + sl + 8 > end)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   if (pgexporter_tls_record_dir_init(dir, aead, *p, sl) != PGEXPORTER_TLS_OK)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   *p += sl;
+   for (i = 0; i < 8; i++)
+   {
+      seq = (seq << 8) | (uint64_t)(*(*p)++);
+   }
+   dir->seq = seq;
+
+   return PGEXPORTER_TLS_OK;
+}
+
+int
+pgexporter_tls_record_export(const struct tls_record* record, unsigned char* buf, size_t cap, size_t* len)
+{
+   unsigned char* p = buf;
+   size_t need;
+
+   if (len != NULL)
+   {
+      *len = 0;
+   }
+   if (record == NULL || buf == NULL)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   need = 2 + (1 + record->read.secret_len + 8) + (1 + record->write.secret_len + 8);
+   if (cap < need)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   *p++ = 1; /* format version */
+   *p++ = (unsigned char)record->aead;
+   export_dir(&p, &record->read);
+   export_dir(&p, &record->write);
+
+   if (len != NULL)
+   {
+      *len = (size_t)(p - buf);
+   }
+
+   return PGEXPORTER_TLS_OK;
+}
+
+int
+pgexporter_tls_record_import(const unsigned char* buf, size_t len, struct tls_record* record)
+{
+   const unsigned char* p = buf;
+   const unsigned char* end = buf + len;
+
+   if (buf == NULL || record == NULL || len < 2)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   memset(record, 0, sizeof(*record));
+
+   if (*p++ != 1) /* format version */
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   record->aead = *p++;
+
+   if (import_dir(&p, end, record->aead, &record->read) != PGEXPORTER_TLS_OK ||
+       import_dir(&p, end, record->aead, &record->write) != PGEXPORTER_TLS_OK)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   return PGEXPORTER_TLS_OK;
+}
+
+int
+pgexporter_tls_harvest(struct tls* tls, struct tls_record* record)
+{
+   const unsigned char* wsec;
+   const unsigned char* rsec;
+   int aead;
+   uint16_t id;
+
+   if (tls == NULL || tls->ssl == NULL || record == NULL ||
+       !tls->handshake_complete || tls->secret_mask != 0x3)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   /* TLS 1.3 AEAD suites only */
+   id = SSL_CIPHER_get_protocol_id(SSL_get_current_cipher(tls->ssl));
+   switch (id)
+   {
+      case 0x1301:
+         aead = PGEXPORTER_TLS_AEAD_AES_128_GCM;
+         break;
+      case 0x1302:
+         aead = PGEXPORTER_TLS_AEAD_AES_256_GCM;
+         break;
+      default:
+         return PGEXPORTER_TLS_ERROR;
+   }
+
+   memset(record, 0, sizeof(*record));
+   record->aead = aead;
+
+   /* Send with our own role's secret; receive with the peer's. */
+   wsec = tls->server ? tls->server_secret : tls->client_secret;
+   rsec = tls->server ? tls->client_secret : tls->server_secret;
+
+   if (pgexporter_tls_record_dir_init(&record->write, aead, wsec, tls->secret_len) != PGEXPORTER_TLS_OK ||
+       pgexporter_tls_record_dir_init(&record->read, aead, rsec, tls->secret_len) != PGEXPORTER_TLS_OK)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   return PGEXPORTER_TLS_OK;
+}
+
+int
+pgexporter_tls_own(struct tls* tls)
+{
+   int n;
+
+   if (tls == NULL)
+   {
+      return PGEXPORTER_TLS_ERROR;
+   }
+   if (pgexporter_tls_harvest(tls, &tls->record) != PGEXPORTER_TLS_OK)
+   {
+      pgexporter_log_debug("TLS: record-layer harvest failed; staying OpenSSL-backed (not parkable)");
+      return PGEXPORTER_TLS_ERROR;
+   }
+
+   /* Capture any ciphertext OpenSSL buffered but did not consume during the
+    * handshake, so owned_read does not miss records already off the socket. */
+   tls->rbuf_len = 0;
+   if (tls->rbio != NULL)
+   {
+      n = BIO_read(tls->rbio, tls->rbuf, (int)sizeof(tls->rbuf));
+      if (n > 0)
+      {
+         tls->rbuf_len = (size_t)n;
+      }
+   }
+
+   tls->owned = true;
+
+   pgexporter_log_debug("TLS: owning record layer (aead=%d, buffered=%zu bytes)", tls->record.aead, tls->rbuf_len);
+
+   return PGEXPORTER_TLS_OK;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -52,6 +52,7 @@
 #include <server.h>
 #include <shmem.h>
 #include <status.h>
+#include <tls.h>
 #include <utils.h>
 #include <yaml_configuration.h>
 #include <alert_configuration.h>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(TESTCASE_FILES
   testcases/test_history.c
   testcases/test_history_http.c
   testcases/test_message_complete.c
+  testcases/test_tls.c
 )
 set(SOURCE_FILES ${LIB_SOURCE_FILES} ${TESTCASE_FILES} ${HEADER_FILES})
 

--- a/test/testcases/test_tls.c
+++ b/test/testcases/test_tls.c
@@ -1,0 +1,848 @@
+/*
+ * Copyright (C) 2026 The pgexporter community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <mctf.h>
+#include <tls.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/x509.h>
+
+// Generate a throwaway self-signed certificate and key for the server side
+static int
+tls_test_self_signed(EVP_PKEY** out_key, X509** out_crt)
+{
+   EVP_PKEY* pkey = EVP_RSA_gen(2048);
+   X509* crt = NULL;
+   X509_NAME* name = NULL;
+
+   if (pkey == NULL)
+   {
+      return 1;
+   }
+
+   crt = X509_new();
+   if (crt == NULL)
+   {
+      EVP_PKEY_free(pkey);
+      return 1;
+   }
+
+   ASN1_INTEGER_set(X509_get_serialNumber(crt), 1);
+   X509_gmtime_adj(X509_getm_notBefore(crt), 0);
+   X509_gmtime_adj(X509_getm_notAfter(crt), 60L * 60L * 24L * 365L);
+   X509_set_pubkey(crt, pkey);
+
+   name = X509_get_subject_name(crt);
+   X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                              (const unsigned char*)"localhost", -1, -1, 0);
+   X509_set_issuer_name(crt, name);
+
+   if (X509_sign(crt, pkey, EVP_sha256()) == 0)
+   {
+      X509_free(crt);
+      EVP_PKEY_free(pkey);
+      return 1;
+   }
+
+   *out_key = pkey;
+   *out_crt = crt;
+   return 0;
+}
+
+static SSL_CTX*
+tls_test_server_ctx(void)
+{
+   EVP_PKEY* key = NULL;
+   X509* crt = NULL;
+   SSL_CTX* ctx = NULL;
+
+   if (tls_test_self_signed(&key, &crt))
+   {
+      return NULL;
+   }
+
+   ctx = SSL_CTX_new(TLS_server_method());
+   if (ctx == NULL)
+   {
+      goto error;
+   }
+
+   SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+
+   if (SSL_CTX_use_certificate(ctx, crt) != 1 || SSL_CTX_use_PrivateKey(ctx, key) != 1)
+   {
+      goto error;
+   }
+
+   X509_free(crt);
+   EVP_PKEY_free(key);
+   return ctx;
+
+error:
+   if (ctx != NULL)
+   {
+      SSL_CTX_free(ctx);
+   }
+   X509_free(crt);
+   EVP_PKEY_free(key);
+   return NULL;
+}
+
+static SSL_CTX*
+tls_test_client_ctx(void)
+{
+   SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
+
+   if (ctx == NULL)
+   {
+      return NULL;
+   }
+
+   SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+   SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+   return ctx;
+}
+
+// Shuttle all pending ciphertext from one endpoint to the other
+static int
+tls_test_transfer(struct tls* from, struct tls* to)
+{
+   unsigned char buf[16384];
+   size_t produced = 0;
+   size_t consumed = 0;
+
+   while (pgexporter_tls_drain(from, buf, sizeof(buf), &produced) == PGEXPORTER_TLS_OK && produced > 0)
+   {
+      if (pgexporter_tls_feed(to, buf, produced, &consumed) != PGEXPORTER_TLS_OK)
+      {
+         return 1;
+      }
+   }
+   return 0;
+}
+
+// Drive both handshakes to completion through the memory BIOs
+static int
+tls_test_handshake(struct tls* client, struct tls* server)
+{
+   for (int i = 0; i < 32; i++)
+   {
+      int cr = pgexporter_tls_handshake(client);
+      int sr = pgexporter_tls_handshake(server);
+
+      if (cr == PGEXPORTER_TLS_ERROR || sr == PGEXPORTER_TLS_ERROR)
+      {
+         return 1;
+      }
+
+      if (tls_test_transfer(client, server) || tls_test_transfer(server, client))
+      {
+         return 1;
+      }
+
+      if (cr == PGEXPORTER_TLS_OK && sr == PGEXPORTER_TLS_OK)
+      {
+         return 0;
+      }
+   }
+   return 1;
+}
+
+// A handshake completes between two endpoints backed only by memory BIOs
+MCTF_TEST(test_pgexporter_tls_handshake_over_mem_bios)
+{
+   SSL_CTX* sctx = NULL;
+   SSL_CTX* cctx = NULL;
+   struct tls* server = NULL;
+   struct tls* client = NULL;
+
+   sctx = tls_test_server_ctx();
+   cctx = tls_test_client_ctx();
+   MCTF_ASSERT_PTR_NONNULL(sctx, cleanup, "server SSL_CTX creation failed");
+   MCTF_ASSERT_PTR_NONNULL(cctx, cleanup, "client SSL_CTX creation failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(cctx, false, &client), PGEXPORTER_TLS_OK,
+                      cleanup, "client tls context creation failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(sctx, true, &server), PGEXPORTER_TLS_OK,
+                      cleanup, "server tls context creation failed");
+
+   MCTF_ASSERT(!client->handshake_complete, cleanup, "client handshake should not start complete");
+   MCTF_ASSERT(!server->handshake_complete, cleanup, "server handshake should not start complete");
+
+   MCTF_ASSERT_INT_EQ(tls_test_handshake(client, server), 0, cleanup,
+                      "handshake did not complete over memory BIOs");
+
+   MCTF_ASSERT(client->handshake_complete, cleanup, "client handshake_complete not set");
+   MCTF_ASSERT(server->handshake_complete, cleanup, "server handshake_complete not set");
+
+cleanup:
+   pgexporter_tls_free(client);
+   pgexporter_tls_free(server);
+   if (sctx != NULL)
+   {
+      SSL_CTX_free(sctx);
+   }
+   if (cctx != NULL)
+   {
+      SSL_CTX_free(cctx);
+   }
+   MCTF_FINISH();
+}
+
+// Application data round-trips in both directions
+MCTF_TEST(test_pgexporter_tls_app_data_roundtrip)
+{
+   const char* c2s = "client to server payload";
+   const char* s2c = "server to client payload";
+   SSL_CTX* sctx = NULL;
+   SSL_CTX* cctx = NULL;
+   struct tls* server = NULL;
+   struct tls* client = NULL;
+   unsigned char out[256];
+   size_t written = 0;
+   size_t nread = 0;
+
+   sctx = tls_test_server_ctx();
+   cctx = tls_test_client_ctx();
+   MCTF_ASSERT_PTR_NONNULL(sctx, cleanup, "server SSL_CTX creation failed");
+   MCTF_ASSERT_PTR_NONNULL(cctx, cleanup, "client SSL_CTX creation failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(cctx, false, &client), PGEXPORTER_TLS_OK,
+                      cleanup, "client tls context creation failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(sctx, true, &server), PGEXPORTER_TLS_OK,
+                      cleanup, "server tls context creation failed");
+   MCTF_ASSERT_INT_EQ(tls_test_handshake(client, server), 0, cleanup,
+                      "handshake did not complete");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_write(client, c2s, strlen(c2s), &written),
+                      PGEXPORTER_TLS_OK, cleanup, "client write failed");
+   MCTF_ASSERT_INT_EQ((int)written, (int)strlen(c2s), cleanup, "client short write");
+   MCTF_ASSERT_INT_EQ(tls_test_transfer(client, server), 0, cleanup, "c2s transfer failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_read(server, out, sizeof(out), &nread),
+                      PGEXPORTER_TLS_OK, cleanup, "server read failed");
+   MCTF_ASSERT_INT_EQ((int)nread, (int)strlen(c2s), cleanup, "server short read");
+   MCTF_ASSERT(memcmp(out, c2s, strlen(c2s)) == 0, cleanup, "c2s payload mismatch");
+
+   written = 0;
+   nread = 0;
+   memset(out, 0, sizeof(out));
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_write(server, s2c, strlen(s2c), &written),
+                      PGEXPORTER_TLS_OK, cleanup, "server write failed");
+   MCTF_ASSERT_INT_EQ((int)written, (int)strlen(s2c), cleanup, "server short write");
+   MCTF_ASSERT_INT_EQ(tls_test_transfer(server, client), 0, cleanup, "s2c transfer failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_read(client, out, sizeof(out), &nread),
+                      PGEXPORTER_TLS_OK, cleanup, "client read failed");
+   MCTF_ASSERT_INT_EQ((int)nread, (int)strlen(s2c), cleanup, "client short read");
+   MCTF_ASSERT(memcmp(out, s2c, strlen(s2c)) == 0, cleanup, "s2c payload mismatch");
+
+cleanup:
+   pgexporter_tls_free(client);
+   pgexporter_tls_free(server);
+   if (sctx != NULL)
+   {
+      SSL_CTX_free(sctx);
+   }
+   if (cctx != NULL)
+   {
+      SSL_CTX_free(cctx);
+   }
+   MCTF_FINISH();
+}
+
+// A payload larger than a single TLS record survives the pump intact
+MCTF_TEST(test_pgexporter_tls_large_payload)
+{
+   const size_t total = 64 * 1024;
+   SSL_CTX* sctx = NULL;
+   SSL_CTX* cctx = NULL;
+   struct tls* server = NULL;
+   struct tls* client = NULL;
+   unsigned char* msg = NULL;
+   unsigned char* got = NULL;
+   size_t sent = 0;
+   size_t received = 0;
+
+   msg = (unsigned char*)malloc(total);
+   got = (unsigned char*)malloc(total);
+   MCTF_ASSERT_PTR_NONNULL(msg, cleanup, "alloc msg failed");
+   MCTF_ASSERT_PTR_NONNULL(got, cleanup, "alloc got failed");
+   for (size_t i = 0; i < total; i++)
+   {
+      msg[i] = (unsigned char)(i * 31 + 7);
+   }
+
+   sctx = tls_test_server_ctx();
+   cctx = tls_test_client_ctx();
+   MCTF_ASSERT_PTR_NONNULL(sctx, cleanup, "server SSL_CTX creation failed");
+   MCTF_ASSERT_PTR_NONNULL(cctx, cleanup, "client SSL_CTX creation failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(cctx, false, &client), PGEXPORTER_TLS_OK,
+                      cleanup, "client tls context creation failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(sctx, true, &server), PGEXPORTER_TLS_OK,
+                      cleanup, "server tls context creation failed");
+   MCTF_ASSERT_INT_EQ(tls_test_handshake(client, server), 0, cleanup,
+                      "handshake did not complete");
+
+   while (sent < total)
+   {
+      size_t written = 0;
+      int rc = pgexporter_tls_write(client, msg + sent, total - sent, &written);
+      MCTF_ASSERT(rc == PGEXPORTER_TLS_OK, cleanup, "large write failed");
+      sent += written;
+   }
+   MCTF_ASSERT_INT_EQ(tls_test_transfer(client, server), 0, cleanup, "large transfer failed");
+
+   while (received < total)
+   {
+      size_t nread = 0;
+      int rc = pgexporter_tls_read(server, got + received, total - received, &nread);
+      if (rc == PGEXPORTER_TLS_WANT_IO)
+      {
+         break;
+      }
+      MCTF_ASSERT(rc == PGEXPORTER_TLS_OK, cleanup, "large read failed");
+      received += nread;
+   }
+
+   MCTF_ASSERT_INT_EQ((int)received, (int)total, cleanup, "did not receive full payload");
+   MCTF_ASSERT(memcmp(msg, got, total) == 0, cleanup, "large payload mismatch");
+
+cleanup:
+   free(msg);
+   free(got);
+   pgexporter_tls_free(client);
+   pgexporter_tls_free(server);
+   if (sctx != NULL)
+   {
+      SSL_CTX_free(sctx);
+   }
+   if (cctx != NULL)
+   {
+      SSL_CTX_free(cctx);
+   }
+   MCTF_FINISH();
+}
+
+// Malformed ciphertext is reported as an error rather than crashing
+MCTF_TEST(test_pgexporter_tls_rejects_garbage)
+{
+   const unsigned char garbage[64] = {0xde, 0xad, 0xbe, 0xef};
+   SSL_CTX* sctx = NULL;
+   struct tls* server = NULL;
+   size_t consumed = 0;
+   int rc;
+
+   sctx = tls_test_server_ctx();
+   MCTF_ASSERT_PTR_NONNULL(sctx, cleanup, "server SSL_CTX creation failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(sctx, true, &server), PGEXPORTER_TLS_OK,
+                      cleanup, "server tls context creation failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_feed(server, garbage, sizeof(garbage), &consumed),
+                      PGEXPORTER_TLS_OK, cleanup, "feeding bytes should succeed at the BIO layer");
+
+   rc = pgexporter_tls_handshake(server);
+   MCTF_ASSERT(rc == PGEXPORTER_TLS_ERROR, cleanup,
+               "handshake on malformed ClientHello must report an error");
+   MCTF_ASSERT(!server->handshake_complete, cleanup,
+               "handshake must not be marked complete on garbage input");
+
+cleanup:
+   pgexporter_tls_free(server);
+   if (sctx != NULL)
+   {
+      SSL_CTX_free(sctx);
+   }
+   MCTF_FINISH();
+}
+
+// The socket-driver shim interoperates with a stock SSL_set_fd peer over a real socket
+MCTF_TEST(test_pgexporter_tls_socket_shim_roundtrip)
+{
+   const char* msg = "socket driver round trip";
+   SSL_CTX* sctx = NULL;
+   SSL_CTX* cctx = NULL;
+   struct tls* client = NULL;
+   pid_t pid = -1;
+   int sv[2] = {-1, -1};
+   unsigned char out[256];
+   size_t nread = 0;
+
+   sctx = tls_test_server_ctx();
+   cctx = tls_test_client_ctx();
+   MCTF_ASSERT_PTR_NONNULL(sctx, cleanup, "server SSL_CTX creation failed");
+   MCTF_ASSERT_PTR_NONNULL(cctx, cleanup, "client SSL_CTX creation failed");
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair failed");
+
+   pid = fork();
+   MCTF_ASSERT(pid >= 0, cleanup, "fork failed");
+
+   if (pid == 0)
+   {
+      /* child: stock socket-bound TLS server -- accept, echo one message, close */
+      SSL* ssl = SSL_new(sctx);
+      char buf[256];
+      int n;
+
+      close(sv[1]);
+      SSL_set_fd(ssl, sv[0]);
+      if (SSL_accept(ssl) == 1)
+      {
+         n = SSL_read(ssl, buf, sizeof(buf));
+         if (n > 0)
+         {
+            SSL_write(ssl, buf, n);
+         }
+      }
+      SSL_shutdown(ssl);
+      SSL_free(ssl);
+      close(sv[0]);
+      _exit(0);
+   }
+
+   close(sv[0]);
+   sv[0] = -1;
+
+   /* parent: drive the client end entirely through the wrapper + socket shim */
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(cctx, false, &client), PGEXPORTER_TLS_OK,
+                      cleanup, "client tls context creation failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_socket_handshake(client, sv[1]), PGEXPORTER_TLS_OK,
+                      cleanup, "socket handshake against stock peer failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_socket_write(client, sv[1], msg, strlen(msg)), PGEXPORTER_TLS_OK,
+                      cleanup, "socket write failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_socket_read(client, sv[1], out, sizeof(out), &nread),
+                      PGEXPORTER_TLS_OK, cleanup, "socket read failed");
+   MCTF_ASSERT_INT_EQ((int)nread, (int)strlen(msg), cleanup, "echo length mismatch");
+   MCTF_ASSERT(memcmp(out, msg, strlen(msg)) == 0, cleanup, "echo payload mismatch");
+
+cleanup:
+   if (pid > 0)
+   {
+      waitpid(pid, NULL, 0);
+   }
+   pgexporter_tls_free(client);
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   if (sctx != NULL)
+   {
+      SSL_CTX_free(sctx);
+   }
+   if (cctx != NULL)
+   {
+      SSL_CTX_free(cctx);
+   }
+   MCTF_FINISH();
+}
+
+// The wrapper is recoverable from its SSL object, enabling transparent I/O routing
+MCTF_TEST(test_pgexporter_tls_from_ssl_backpointer)
+{
+   SSL_CTX* cctx = NULL;
+   struct tls* client = NULL;
+
+   cctx = tls_test_client_ctx();
+   MCTF_ASSERT_PTR_NONNULL(cctx, cleanup, "client SSL_CTX creation failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(cctx, false, &client), PGEXPORTER_TLS_OK,
+                      cleanup, "client tls context creation failed");
+
+   MCTF_ASSERT(pgexporter_tls_from_ssl(client->ssl) == client, cleanup,
+               "from_ssl should recover the owning wrapper");
+   MCTF_ASSERT_PTR_NULL(pgexporter_tls_from_ssl(NULL), cleanup,
+                        "from_ssl(NULL) should be NULL");
+
+   pgexporter_tls_set_fd(client, 42);
+   MCTF_ASSERT_INT_EQ(client->fd, 42, cleanup, "set_fd should store the descriptor");
+
+cleanup:
+   pgexporter_tls_free(client);
+   if (cctx != NULL)
+   {
+      SSL_CTX_free(cctx);
+   }
+   MCTF_FINISH();
+}
+
+/* A sender (write dir) and receiver (read dir) sharing one secret: loopback. */
+static void
+record_mk_pair(struct tls_record* snd, struct tls_record* rcv, int aead, const unsigned char* secret, size_t sl)
+{
+   memset(snd, 0, sizeof(*snd));
+   memset(rcv, 0, sizeof(*rcv));
+   snd->aead = aead;
+   rcv->aead = aead;
+   pgexporter_tls_record_dir_init(&snd->write, aead, secret, sl);
+   pgexporter_tls_record_dir_init(&rcv->read, aead, secret, sl);
+}
+
+// A sealed record opens back to the original plaintext, advancing the sequence
+MCTF_TEST(test_pgexporter_tls_record_roundtrip)
+{
+   unsigned char secret[32];
+   struct tls_record snd, rcv;
+   unsigned char rec[512];
+   unsigned char pt[512];
+   size_t rlen = 0;
+   size_t plen = 0;
+
+   RAND_bytes(secret, sizeof(secret));
+   record_mk_pair(&snd, &rcv, PGEXPORTER_TLS_AEAD_AES_128_GCM, secret, 32);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_seal(&snd, (const unsigned char*)"hello", 5, rec, sizeof(rec), &rlen),
+                      PGEXPORTER_TLS_OK, cleanup, "seal hello");
+   MCTF_ASSERT(rec[0] == 0x17, cleanup, "record is application_data");
+   MCTF_ASSERT(snd.write.seq == 1, cleanup, "write seq advanced");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGEXPORTER_TLS_OK, cleanup, "open hello");
+   MCTF_ASSERT(plen == 5 && memcmp(pt, "hello", 5) == 0, cleanup, "hello round trip");
+   MCTF_ASSERT(rcv.read.seq == 1, cleanup, "read seq advanced");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+// Export/import preserves the sequence state so the stream continues across a move
+MCTF_TEST(test_pgexporter_tls_record_serialize)
+{
+   unsigned char secret[32];
+   struct tls_record snd, rcv, snd2;
+   unsigned char rec[512];
+   unsigned char pt[512];
+   unsigned char blob[256];
+   size_t rlen = 0;
+   size_t plen = 0;
+   size_t blen = 0;
+
+   RAND_bytes(secret, sizeof(secret));
+   record_mk_pair(&snd, &rcv, PGEXPORTER_TLS_AEAD_AES_128_GCM, secret, 32);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_seal(&snd, (const unsigned char*)"one", 3, rec, sizeof(rec), &rlen),
+                      PGEXPORTER_TLS_OK, cleanup, "seal one");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGEXPORTER_TLS_OK, cleanup, "open one");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_export(&snd, blob, sizeof(blob), &blen),
+                      PGEXPORTER_TLS_OK, cleanup, "export");
+   memset(&snd2, 0, sizeof(snd2));
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_import(blob, blen, &snd2),
+                      PGEXPORTER_TLS_OK, cleanup, "import");
+   MCTF_ASSERT(snd2.write.seq == snd.write.seq, cleanup, "sequence preserved across import");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_seal(&snd2, (const unsigned char*)"two", 3, rec, sizeof(rec), &rlen),
+                      PGEXPORTER_TLS_OK, cleanup, "seal two (imported)");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGEXPORTER_TLS_OK, cleanup, "open two");
+   MCTF_ASSERT(plen == 3 && memcmp(pt, "two", 3) == 0, cleanup, "two round trip after import");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+// A tampered record fails AEAD integrity
+MCTF_TEST(test_pgexporter_tls_record_tamper)
+{
+   unsigned char secret[32];
+   struct tls_record snd, rcv;
+   unsigned char rec[512];
+   unsigned char pt[512];
+   size_t rlen = 0;
+   size_t plen = 0;
+
+   RAND_bytes(secret, sizeof(secret));
+   record_mk_pair(&snd, &rcv, PGEXPORTER_TLS_AEAD_AES_128_GCM, secret, 32);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_seal(&snd, (const unsigned char*)"secret-data", 11, rec, sizeof(rec), &rlen),
+                      PGEXPORTER_TLS_OK, cleanup, "seal");
+   rec[7] ^= 0x01;
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGEXPORTER_TLS_ERROR, cleanup, "tampered record rejected");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+// The AES-256-GCM suite (SHA-384, 48-byte secret) seals, opens, and survives export/import
+MCTF_TEST(test_pgexporter_tls_record_aes256)
+{
+   unsigned char secret[48];
+   struct tls_record snd, rcv, snd2;
+   unsigned char rec[512];
+   unsigned char pt[512];
+   unsigned char blob[256];
+   size_t rlen = 0;
+   size_t plen = 0;
+   size_t blen = 0;
+
+   RAND_bytes(secret, sizeof(secret));
+   record_mk_pair(&snd, &rcv, PGEXPORTER_TLS_AEAD_AES_256_GCM, secret, 48);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_seal(&snd, (const unsigned char*)"aes256", 6, rec, sizeof(rec), &rlen),
+                      PGEXPORTER_TLS_OK, cleanup, "seal aes256");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGEXPORTER_TLS_OK, cleanup, "open aes256");
+   MCTF_ASSERT(plen == 6 && memcmp(pt, "aes256", 6) == 0, cleanup, "aes256 round trip");
+
+   /* Export/import must preserve the SHA-384 secret length and the sequence */
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_export(&snd, blob, sizeof(blob), &blen),
+                      PGEXPORTER_TLS_OK, cleanup, "export aes256");
+   memset(&snd2, 0, sizeof(snd2));
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_import(blob, blen, &snd2),
+                      PGEXPORTER_TLS_OK, cleanup, "import aes256");
+   MCTF_ASSERT(snd2.aead == PGEXPORTER_TLS_AEAD_AES_256_GCM, cleanup, "aead preserved across import");
+   MCTF_ASSERT(snd2.write.secret_len == 48, cleanup, "sha-384 secret length preserved");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_seal(&snd2, (const unsigned char*)"more", 4, rec, sizeof(rec), &rlen),
+                      PGEXPORTER_TLS_OK, cleanup, "seal after import");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_record_open(&rcv, rec, rlen, pt, sizeof(pt), &plen),
+                      PGEXPORTER_TLS_OK, cleanup, "open after import");
+   MCTF_ASSERT(plen == 4 && memcmp(pt, "more", 4) == 0, cleanup, "round trip after import");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+static SSL_CTX*
+tls_test_server_ctx_tls13(void)
+{
+   EVP_PKEY* key = NULL;
+   X509* crt = NULL;
+   SSL_CTX* ctx = NULL;
+
+   if (tls_test_self_signed(&key, &crt))
+   {
+      return NULL;
+   }
+   ctx = SSL_CTX_new(TLS_server_method());
+   if (ctx == NULL)
+   {
+      goto error;
+   }
+   SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
+   SSL_CTX_set_max_proto_version(ctx, TLS1_3_VERSION);
+   SSL_CTX_set_ciphersuites(ctx, "TLS_AES_128_GCM_SHA256");
+   SSL_CTX_set_num_tickets(ctx, 0);
+   if (SSL_CTX_use_certificate(ctx, crt) != 1 || SSL_CTX_use_PrivateKey(ctx, key) != 1)
+   {
+      goto error;
+   }
+   X509_free(crt);
+   EVP_PKEY_free(key);
+   return ctx;
+
+error:
+   if (ctx != NULL)
+   {
+      SSL_CTX_free(ctx);
+   }
+   X509_free(crt);
+   EVP_PKEY_free(key);
+   return NULL;
+}
+
+static SSL_CTX*
+tls_test_client_ctx_tls13(void)
+{
+   SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
+
+   if (ctx == NULL)
+   {
+      return NULL;
+   }
+   SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
+   SSL_CTX_set_max_proto_version(ctx, TLS1_3_VERSION);
+   SSL_CTX_set_num_tickets(ctx, 0);
+   SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+   return ctx;
+}
+
+/* OpenSSL writes one app record; our harvested record context must decrypt it. */
+static int
+harvest_check_dir(struct tls* writer, struct tls_record* reader, const char* msg)
+{
+   unsigned char rec[4096];
+   unsigned char pt[4096];
+   size_t rlen = 0;
+   size_t plen = 0;
+   size_t written = 0;
+
+   if (pgexporter_tls_write(writer, msg, strlen(msg), &written) != PGEXPORTER_TLS_OK)
+   {
+      return 1;
+   }
+   if (pgexporter_tls_drain(writer, rec, sizeof(rec), &rlen) != PGEXPORTER_TLS_OK || rlen == 0)
+   {
+      return 1;
+   }
+   if (pgexporter_tls_record_open(reader, rec, rlen, pt, sizeof(pt), &plen) != PGEXPORTER_TLS_OK)
+   {
+      return 1;
+   }
+   if (plen != strlen(msg) || memcmp(pt, msg, plen) != 0)
+   {
+      return 1;
+   }
+   return 0;
+}
+
+// After a TLS 1.3 handshake, the harvested record context decrypts OpenSSL's own records
+MCTF_TEST(test_pgexporter_tls_harvest_handoff)
+{
+   SSL_CTX* sctx = NULL;
+   SSL_CTX* cctx = NULL;
+   struct tls* s = NULL;
+   struct tls* c = NULL;
+   struct tls_record srec;
+   struct tls_record crec;
+   int i;
+
+   sctx = tls_test_server_ctx_tls13();
+   cctx = tls_test_client_ctx_tls13();
+   MCTF_ASSERT_PTR_NONNULL(sctx, cleanup, "server ctx");
+   MCTF_ASSERT_PTR_NONNULL(cctx, cleanup, "client ctx");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(sctx, true, &s), PGEXPORTER_TLS_OK, cleanup, "server create");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(cctx, false, &c), PGEXPORTER_TLS_OK, cleanup, "client create");
+
+   for (i = 0; i < 32; i++)
+   {
+      pgexporter_tls_handshake(c);
+      pgexporter_tls_handshake(s);
+      tls_test_transfer(c, s);
+      tls_test_transfer(s, c);
+      if (s->handshake_complete && c->handshake_complete)
+      {
+         break;
+      }
+   }
+   MCTF_ASSERT(s->handshake_complete && c->handshake_complete, cleanup, "handshake complete");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_harvest(s, &srec), PGEXPORTER_TLS_OK, cleanup, "harvest server");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_harvest(c, &crec), PGEXPORTER_TLS_OK, cleanup, "harvest client");
+
+   MCTF_ASSERT_INT_EQ(harvest_check_dir(s, &crec, "from the server"), 0, cleanup, "server->client decrypt");
+   MCTF_ASSERT_INT_EQ(harvest_check_dir(c, &srec, "from the client"), 0, cleanup, "client->server decrypt");
+
+cleanup:
+   pgexporter_tls_free(s);
+   pgexporter_tls_free(c);
+   if (sctx != NULL)
+   {
+      SSL_CTX_free(sctx);
+   }
+   if (cctx != NULL)
+   {
+      SSL_CTX_free(cctx);
+   }
+   MCTF_FINISH();
+}
+
+// After pgexporter_tls_own, I/O flows over a real socket via our own record layer
+MCTF_TEST(test_pgexporter_tls_owned_io)
+{
+   SSL_CTX* sctx = NULL;
+   SSL_CTX* cctx = NULL;
+   struct tls* s = NULL;
+   struct tls* c = NULL;
+   int sv[2] = {-1, -1};
+   unsigned char out[256];
+   size_t n = 0;
+   int i;
+
+   sctx = tls_test_server_ctx_tls13();
+   cctx = tls_test_client_ctx_tls13();
+   MCTF_ASSERT_PTR_NONNULL(sctx, cleanup, "server ctx");
+   MCTF_ASSERT_PTR_NONNULL(cctx, cleanup, "client ctx");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(sctx, true, &s), PGEXPORTER_TLS_OK, cleanup, "server create");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_create(cctx, false, &c), PGEXPORTER_TLS_OK, cleanup, "client create");
+
+   for (i = 0; i < 32; i++)
+   {
+      pgexporter_tls_handshake(c);
+      pgexporter_tls_handshake(s);
+      tls_test_transfer(c, s);
+      tls_test_transfer(s, c);
+      if (s->handshake_complete && c->handshake_complete)
+      {
+         break;
+      }
+   }
+   MCTF_ASSERT(s->handshake_complete && c->handshake_complete, cleanup, "handshake complete");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_own(s), PGEXPORTER_TLS_OK, cleanup, "own server");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_own(c), PGEXPORTER_TLS_OK, cleanup, "own client");
+   MCTF_ASSERT(s->owned && c->owned, cleanup, "owned flag set");
+
+   MCTF_ASSERT_INT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0, cleanup, "socketpair");
+   pgexporter_tls_set_fd(s, sv[0]);
+   pgexporter_tls_set_fd(c, sv[1]);
+
+   /* server -> client over our own record layer */
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_socket_write(s, sv[0], "ping", 4), PGEXPORTER_TLS_OK, cleanup, "owned write s->c");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_socket_read(c, sv[1], out, sizeof(out), &n), PGEXPORTER_TLS_OK, cleanup, "owned read c");
+   MCTF_ASSERT(n == 4 && memcmp(out, "ping", 4) == 0, cleanup, "s->c via owned layer");
+
+   /* client -> server over our own record layer */
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_socket_write(c, sv[1], "pong", 4), PGEXPORTER_TLS_OK, cleanup, "owned write c->s");
+   MCTF_ASSERT_INT_EQ(pgexporter_tls_socket_read(s, sv[0], out, sizeof(out), &n), PGEXPORTER_TLS_OK, cleanup, "owned read s");
+   MCTF_ASSERT(n == 4 && memcmp(out, "pong", 4) == 0, cleanup, "c->s via owned layer");
+
+cleanup:
+   pgexporter_tls_free(s);
+   pgexporter_tls_free(c);
+   if (sv[0] >= 0)
+   {
+      close(sv[0]);
+   }
+   if (sv[1] >= 0)
+   {
+      close(sv[1]);
+   }
+   if (sctx != NULL)
+   {
+      SSL_CTX_free(sctx);
+   }
+   if (cctx != NULL)
+   {
+      SSL_CTX_free(cctx);
+   }
+   MCTF_FINISH();
+}


### PR DESCRIPTION
Drive the OpenSSL state machine through memory BIOs instead of SSL_set_fd, decoupling TLS state from the TCP socket, and route the backend connection path through the wrapper. Includes the serializable TLS 1.3 record layer and MCTF unit tests.

Park/resume is not wired: pgexporter closes backend connections per scrape, so cross-scrape persistence would be a separate opt-in feature.

Ported from pgagroal.