### PR TITLE
[#574] Changed SQLite history schema

### DIFF
--- a/src/include/history.h
+++ b/src/include/history.h
@@ -35,10 +35,20 @@ extern "C" {
 
 #include <pgexporter.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <time.h>
 
 #include <openssl/ssl.h>
+
+/** Bytes of the SHA-256 digest used for the canonical label hash: the full 256. */
+#define HISTORY_LABEL_HASH_BYTES 32
+
+/**
+ * Length of the canonical label hash rendered as lowercase hex, including the
+ * terminating NUL.
+ */
+#define HISTORY_LABEL_HASH_LENGTH ((HISTORY_LABEL_HASH_BYTES * 2) + 1)
 
 /**
  * @struct history_record
@@ -54,6 +64,33 @@ struct history_record
                                         the whole array with pgexporter_history_records_free(). */
    double value;                   /**< Metric value */
 };
+
+/**
+ * Compute the canonical hash of a Prometheus label set.
+ *
+ * The label string is the text between the braces of an exposition line, for
+ * example `server="primary",database="postgres"`. Pairs are sorted by key
+ * before hashing, so emission order does not change a series' identity.
+ * Input that does not parse is hashed verbatim, which is still stable.
+ *
+ * @param labels The label string, or NULL/empty for a series with no labels
+ * @param out    Buffer of at least HISTORY_LABEL_HASH_LENGTH bytes
+ * @return 0 on success, 1 on failure
+ */
+int
+pgexporter_history_label_hash(const char* labels, char* out);
+
+/**
+ * Look up one label's value in a Prometheus label string.
+ *
+ * @param labels   The label string, or NULL
+ * @param key      The label name to find
+ * @param out      Buffer receiving the value, NUL-terminated and truncated to fit
+ * @param out_size Size of out in bytes
+ * @return true if the key was found, otherwise false
+ */
+bool
+pgexporter_history_label_find(const char* labels, const char* key, char* out, size_t out_size);
 
 /**
  * Free an array of history records returned by pgexporter_history_query_range,

--- a/src/include/history_sqlite.h
+++ b/src/include/history_sqlite.h
@@ -67,7 +67,9 @@ pgexporter_history_sqlite_query_range(const char* metric, time_t start, time_t e
                                       struct history_record** records_out, int* count_out);
 
 /**
- * Delete records whose timestamp is older than config->history_retention.
+ * Delete samples whose timestamp is older than config->history_retention, then
+ * remove any series left with no samples at all.
+ *
  * @return 0 on success, 1 on failure
  */
 int

--- a/src/libpgexporter/history.c
+++ b/src/libpgexporter/history.c
@@ -52,7 +52,296 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <openssl/evp.h>
+
+/** Upper bound on the number of labels parsed from one exposition line. */
+#define HISTORY_LABEL_MAX 64
+
+/**
+ * @struct history_label
+ * @brief One parsed `key="value"` pair, pointing into the caller's string.
+ */
+struct history_label
+{
+   const char* key; /**< Start of the label name */
+   size_t key_len;  /**< Length of the label name */
+   const char* val; /**< Start of the label value, inside the quotes */
+   size_t val_len;  /**< Length of the label value, escapes left intact */
+};
+
 static const struct history_backend_ops* ops = NULL;
+
+static int
+label_compare(const void* a, const void* b)
+{
+   const struct history_label* la = (const struct history_label*)a;
+   const struct history_label* lb = (const struct history_label*)b;
+   size_t n = la->key_len < lb->key_len ? la->key_len : lb->key_len;
+   int c = memcmp(la->key, lb->key, n);
+
+   if (c != 0)
+   {
+      return c;
+   }
+
+   if (la->key_len != lb->key_len)
+   {
+      return la->key_len < lb->key_len ? -1 : 1;
+   }
+
+   n = la->val_len < lb->val_len ? la->val_len : lb->val_len;
+   c = memcmp(la->val, lb->val, n);
+
+   if (c != 0)
+   {
+      return c;
+   }
+
+   if (la->val_len == lb->val_len)
+   {
+      return 0;
+   }
+
+   return la->val_len < lb->val_len ? -1 : 1;
+}
+
+/**
+ * Parse a Prometheus label string into key/value pairs.
+ * A string carrying more than HISTORY_LABEL_MAX pairs is reported as
+ * malformed rather than truncated.
+ * @param labels The label string, or NULL
+ * @param out    Array of at least HISTORY_LABEL_MAX entries
+ * @param count  Set to the number of pairs parsed
+ * @return 0 on success, 1 if the string is not a well-formed label set
+ */
+static int
+label_parse(const char* labels, struct history_label* out, int* count)
+{
+   const char* p = labels;
+   int n = 0;
+
+   *count = 0;
+
+   if (labels == NULL)
+   {
+      return 0;
+   }
+
+   while (*p != '\0')
+   {
+      const char* key_start;
+      const char* val_start;
+      bool escaped = false;
+
+      while (*p == ' ' || *p == ',')
+      {
+         p++;
+      }
+
+      if (*p == '\0')
+      {
+         break;
+      }
+
+      key_start = p;
+      while (*p != '\0' && *p != '=')
+      {
+         p++;
+      }
+
+      if (*p != '=' || p == key_start)
+      {
+         goto error;
+      }
+
+      if (n == HISTORY_LABEL_MAX)
+      {
+         goto error;
+      }
+
+      out[n].key = key_start;
+      out[n].key_len = (size_t)(p - key_start);
+      p++;
+
+      if (*p != '"')
+      {
+         goto error;
+      }
+      p++;
+
+      val_start = p;
+      while (*p != '\0')
+      {
+         if (!escaped && *p == '"')
+         {
+            break;
+         }
+         escaped = (*p == '\\' && !escaped);
+         p++;
+      }
+
+      if (*p != '"')
+      {
+         goto error;
+      }
+
+      out[n].val = val_start;
+      out[n].val_len = (size_t)(p - val_start);
+      n++;
+      p++;
+
+      while (*p == ' ')
+      {
+         p++;
+      }
+
+      if (*p != '\0' && *p != ',')
+      {
+         goto error;
+      }
+   }
+
+   *count = n;
+   return 0;
+
+error:
+
+   *count = 0;
+   return 1;
+}
+
+bool
+pgexporter_history_label_find(const char* labels, const char* key, char* out, size_t out_size)
+{
+   struct history_label pairs[HISTORY_LABEL_MAX];
+   size_t key_len;
+   int count = 0;
+   int i;
+
+   if (out == NULL || out_size == 0)
+   {
+      return false;
+   }
+
+   out[0] = '\0';
+
+   if (labels == NULL || key == NULL)
+   {
+      return false;
+   }
+
+   if (label_parse(labels, pairs, &count))
+   {
+      return false;
+   }
+
+   key_len = strlen(key);
+
+   for (i = 0; i < count; i++)
+   {
+      if (pairs[i].key_len == key_len && memcmp(pairs[i].key, key, key_len) == 0)
+      {
+         size_t len = pairs[i].val_len;
+
+         if (len >= out_size)
+         {
+            len = out_size - 1;
+         }
+
+         memcpy(out, pairs[i].val, len);
+         out[len] = '\0';
+         return true;
+      }
+   }
+
+   return false;
+}
+
+int
+pgexporter_history_label_hash(const char* labels, char* out)
+{
+   struct history_label pairs[HISTORY_LABEL_MAX];
+   EVP_MD_CTX* ctx = NULL;
+   unsigned char digest[EVP_MAX_MD_SIZE];
+   unsigned int digest_len = 0;
+   int count = 0;
+   int i;
+
+   if (out == NULL)
+   {
+      goto error;
+   }
+
+   out[0] = '\0';
+
+   ctx = EVP_MD_CTX_new();
+   if (ctx == NULL)
+   {
+      goto error;
+   }
+
+   if (EVP_DigestInit_ex(ctx, EVP_sha256(), NULL) != 1)
+   {
+      goto error;
+   }
+
+   if (labels != NULL && label_parse(labels, pairs, &count))
+   {
+      /* Unrecognised label set: hash verbatim, still stable for this input */
+      if (EVP_DigestUpdate(ctx, labels, strlen(labels)) != 1)
+      {
+         goto error;
+      }
+   }
+   else
+   {
+      qsort(pairs, (size_t)count, sizeof(struct history_label), label_compare);
+
+      for (i = 0; i < count; i++)
+      {
+         if (EVP_DigestUpdate(ctx, pairs[i].key, pairs[i].key_len) != 1 ||
+             EVP_DigestUpdate(ctx, "=", 1) != 1 ||
+             EVP_DigestUpdate(ctx, pairs[i].val, pairs[i].val_len) != 1 ||
+             EVP_DigestUpdate(ctx, "\n", 1) != 1)
+         {
+            goto error;
+         }
+      }
+   }
+
+   if (EVP_DigestFinal_ex(ctx, digest, &digest_len) != 1)
+   {
+      goto error;
+   }
+
+   if (digest_len < HISTORY_LABEL_HASH_BYTES)
+   {
+      goto error;
+   }
+
+   for (i = 0; i < HISTORY_LABEL_HASH_BYTES; i++)
+   {
+      pgexporter_snprintf(out + (i * 2), 3, "%02x", digest[i]);
+   }
+
+   EVP_MD_CTX_free(ctx);
+
+   return 0;
+
+error:
+
+   if (ctx != NULL)
+   {
+      EVP_MD_CTX_free(ctx);
+   }
+
+   if (out != NULL)
+   {
+      out[0] = '\0';
+   }
+
+   return 1;
+}
 
 static const struct
 {
@@ -259,17 +548,8 @@ pgexporter_history_store_metrics(struct prometheus_metrics_container* container)
                         memcpy(labels, labels_start, labels_len);
                         labels[labels_len] = '\0';
 
-                        char* server_pos = strstr(labels, "server=\"");
-                        if (server_pos)
-                        {
-                           server_pos += 8;
-                           char* end_quote = strchr(server_pos, '"');
-                           if (end_quote)
-                           {
-                              size_t server_len = end_quote - server_pos;
-                              pgexporter_snprintf(server, sizeof(server), "%.*s", (int)server_len, server_pos);
-                           }
-                        }
+                        /* Same parser as the label hash: no false "server" match, no early quote end */
+                        pgexporter_history_label_find(labels, "server", server, sizeof(server));
                         p++;
                      }
                   }

--- a/src/libpgexporter/history_sqlite.c
+++ b/src/libpgexporter/history_sqlite.c
@@ -56,25 +56,59 @@ static sqlite3* db = NULL;
 /* Maximum free pages reclaimed per prune via PRAGMA incremental_vacuum */
 #define HISTORY_SQLITE_VACUUM_PAGES 1000
 
+/* sample is WITHOUT ROWID: nearly all key, halving space and write amplification */
+/* idx_sample_ts: the PK leads with series_id, but graphs and pruning read by ts */
+static const char* schema_sql =
+   "CREATE TABLE IF NOT EXISTS series ("
+   "series_id INTEGER PRIMARY KEY, "
+   "metric TEXT NOT NULL, "
+   "server TEXT NOT NULL DEFAULT '', "
+   "label_hash TEXT NOT NULL, "
+   "labels TEXT NOT NULL DEFAULT '', "
+   "UNIQUE (metric, server, label_hash)"
+   ");"
+   "CREATE TABLE IF NOT EXISTS sample ("
+   "series_id INTEGER NOT NULL REFERENCES series(series_id), "
+   "ts INTEGER NOT NULL, "
+   "value REAL NOT NULL, "
+   "PRIMARY KEY (series_id, ts)"
+   ") WITHOUT ROWID;"
+   "CREATE INDEX IF NOT EXISTS idx_sample_ts ON sample(ts);";
+
+/**
+ * Run a statement that returns no rows, logging on failure.
+ *
+ * @param sql   The SQL to execute
+ * @param what  Short description used in the log message
+ * @return 0 on success, 1 on failure
+ */
+static int
+exec_sql(const char* sql, const char* what)
+{
+   char* err_msg = NULL;
+
+   if (sqlite3_exec(db, sql, NULL, NULL, &err_msg) != SQLITE_OK)
+   {
+      pgexporter_log_error("history_sqlite: %s failed: %s", what, err_msg ? err_msg : sqlite3_errmsg(db));
+      if (err_msg)
+      {
+         sqlite3_free(err_msg);
+      }
+      return 1;
+   }
+
+   if (err_msg)
+   {
+      sqlite3_free(err_msg);
+   }
+
+   return 0;
+}
+
 int
 pgexporter_history_sqlite_init(void)
 {
    struct configuration* config;
-   char* err_msg = NULL;
-   const char* sql = "PRAGMA auto_vacuum=INCREMENTAL;"
-                     "PRAGMA journal_mode=WAL;"
-                     "PRAGMA busy_timeout=5000;"
-                     "CREATE TABLE IF NOT EXISTS history ("
-                     "ts INTEGER, "
-                     "server TEXT, "
-                     "metric TEXT, "
-                     "labels TEXT, "
-                     "value REAL"
-                     ");"
-                     /* Index covers both query_range (metric + ts range) and
-                      * prune (ts range), avoiding a full table scan. */
-                     "CREATE INDEX IF NOT EXISTS idx_history_metric_ts ON history(metric, ts);"
-                     "CREATE INDEX IF NOT EXISTS idx_history_ts ON history(ts);";
 
    if (db != NULL)
    {
@@ -92,25 +126,97 @@ pgexporter_history_sqlite_init(void)
    if (sqlite3_open_v2(config->history_path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL) != SQLITE_OK)
    {
       pgexporter_log_error("history_sqlite: failed to open db %s: %s", config->history_path, db ? sqlite3_errmsg(db) : "out of memory");
-      if (db)
-      {
-         sqlite3_close(db);
-         db = NULL;
-      }
       goto error;
    }
 
-   if (sqlite3_exec(db, sql, 0, 0, &err_msg) != SQLITE_OK)
+   /* auto_vacuum must precede the first table to stick on a fresh file */
+   if (exec_sql("PRAGMA auto_vacuum=INCREMENTAL;"
+                "PRAGMA journal_mode=WAL;"
+                "PRAGMA busy_timeout=5000;"
+                "PRAGMA foreign_keys=ON;",
+                "pragma setup"))
    {
-      pgexporter_log_error("history_sqlite: failed to create table: %s", err_msg);
-      if (err_msg)
-      {
-         sqlite3_free(err_msg);
-      }
+      goto error;
+   }
+
+   if (exec_sql(schema_sql, "schema create"))
+   {
       goto error;
    }
 
    pgexporter_log_debug("history_sqlite: initialized at %s", config->history_path);
+   return 0;
+
+error:
+
+   if (db)
+   {
+      sqlite3_close_v2(db);
+      db = NULL;
+   }
+
+   return 1;
+}
+
+/**
+ * Resolve a record's series, inserting it the first time it is seen.
+ *
+ * @param record  The record whose metric/server/labels identify the series
+ * @param select  Prepared SELECT over the (metric, server, label_hash) unique index
+ * @param insert  Prepared INSERT into series
+ * @param out     Receives the series_id
+ * @return 0 on success, 1 on failure
+ */
+static int
+series_resolve(struct history_record* record, sqlite3_stmt* select, sqlite3_stmt* insert, sqlite3_int64* out)
+{
+   char label_hash[HISTORY_LABEL_HASH_LENGTH];
+   const char* labels = record->labels ? record->labels : "";
+   int rc;
+
+   if (pgexporter_history_label_hash(labels, label_hash))
+   {
+      pgexporter_log_error("history_sqlite: failed to hash labels for metric %s", record->metric);
+      goto error;
+   }
+
+   sqlite3_reset(select);
+   sqlite3_bind_text(select, 1, record->metric, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(select, 2, record->server, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(select, 3, label_hash, -1, SQLITE_TRANSIENT);
+
+   rc = sqlite3_step(select);
+
+   if (rc == SQLITE_ROW)
+   {
+      *out = sqlite3_column_int64(select, 0);
+      sqlite3_reset(select);
+      return 0;
+   }
+
+   if (rc != SQLITE_DONE)
+   {
+      pgexporter_log_error("history_sqlite: series lookup failed: %s", sqlite3_errmsg(db));
+      goto error;
+   }
+
+   sqlite3_reset(select);
+
+   sqlite3_reset(insert);
+   sqlite3_bind_text(insert, 1, record->metric, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(insert, 2, record->server, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(insert, 3, label_hash, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(insert, 4, labels, -1, SQLITE_TRANSIENT);
+
+   if (sqlite3_step(insert) != SQLITE_DONE)
+   {
+      pgexporter_log_error("history_sqlite: series insert failed: %s", sqlite3_errmsg(db));
+      goto error;
+   }
+
+   sqlite3_reset(insert);
+   *out = sqlite3_last_insert_rowid(db);
+
    return 0;
 
 error:
@@ -121,8 +227,13 @@ error:
 int
 pgexporter_history_sqlite_write_batch(struct history_record* records, int count)
 {
-   sqlite3_stmt* stmt = NULL;
-   const char* sql = "INSERT INTO history(ts, server, metric, labels, value) VALUES(?, ?, ?, ?, ?);";
+   sqlite3_stmt* select_series = NULL;
+   sqlite3_stmt* insert_series = NULL;
+   sqlite3_stmt* insert_sample = NULL;
+   const char* select_series_sql = "SELECT series_id FROM series WHERE metric = ? AND server = ? AND label_hash = ?;";
+   const char* insert_series_sql = "INSERT INTO series(metric, server, label_hash, labels) VALUES(?, ?, ?, ?);";
+
+   const char* insert_sample_sql = "INSERT OR REPLACE INTO sample(series_id, ts, value) VALUES(?, ?, ?);";
    bool in_txn = false;
    int i;
 
@@ -131,13 +242,17 @@ pgexporter_history_sqlite_write_batch(struct history_record* records, int count)
       goto error;
    }
 
-   if (sqlite3_exec(db, "BEGIN TRANSACTION;", NULL, NULL, NULL) != SQLITE_OK)
+   /* IMMEDIATE: resolving a series reads before it writes, else SQLITE_BUSY_SNAPSHOT */
+   if (sqlite3_exec(db, "BEGIN IMMEDIATE;", NULL, NULL, NULL) != SQLITE_OK)
    {
+      pgexporter_log_error("history_sqlite: begin failed: %s", sqlite3_errmsg(db));
       goto error;
    }
    in_txn = true;
 
-   if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+   if (sqlite3_prepare_v2(db, select_series_sql, -1, &select_series, NULL) != SQLITE_OK ||
+       sqlite3_prepare_v2(db, insert_series_sql, -1, &insert_series, NULL) != SQLITE_OK ||
+       sqlite3_prepare_v2(db, insert_sample_sql, -1, &insert_sample, NULL) != SQLITE_OK)
    {
       pgexporter_log_error("history_sqlite: prepare failed: %s", sqlite3_errmsg(db));
       goto error;
@@ -145,25 +260,35 @@ pgexporter_history_sqlite_write_batch(struct history_record* records, int count)
 
    for (i = 0; i < count; i++)
    {
-      sqlite3_bind_int64(stmt, 1, (sqlite3_int64)records[i].ts);
-      sqlite3_bind_text(stmt, 2, records[i].server, -1, SQLITE_TRANSIENT);
-      sqlite3_bind_text(stmt, 3, records[i].metric, -1, SQLITE_TRANSIENT);
-      sqlite3_bind_text(stmt, 4, records[i].labels ? records[i].labels : "", -1, SQLITE_TRANSIENT);
-      sqlite3_bind_double(stmt, 5, records[i].value);
+      sqlite3_int64 series_id = 0;
 
-      if (sqlite3_step(stmt) != SQLITE_DONE)
+      if (series_resolve(&records[i], select_series, insert_series, &series_id))
+      {
+         goto error;
+      }
+
+      sqlite3_reset(insert_sample);
+      sqlite3_bind_int64(insert_sample, 1, series_id);
+      sqlite3_bind_int64(insert_sample, 2, (sqlite3_int64)records[i].ts);
+      sqlite3_bind_double(insert_sample, 3, records[i].value);
+
+      if (sqlite3_step(insert_sample) != SQLITE_DONE)
       {
          pgexporter_log_error("history_sqlite: insert failed: %s", sqlite3_errmsg(db));
          goto error;
       }
-      sqlite3_reset(stmt);
    }
 
-   sqlite3_finalize(stmt);
-   stmt = NULL;
+   sqlite3_finalize(select_series);
+   select_series = NULL;
+   sqlite3_finalize(insert_series);
+   insert_series = NULL;
+   sqlite3_finalize(insert_sample);
+   insert_sample = NULL;
 
    if (sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL) != SQLITE_OK)
    {
+      pgexporter_log_error("history_sqlite: commit failed: %s", sqlite3_errmsg(db));
       goto error;
    }
 
@@ -171,9 +296,17 @@ pgexporter_history_sqlite_write_batch(struct history_record* records, int count)
 
 error:
 
-   if (stmt)
+   if (select_series)
    {
-      sqlite3_finalize(stmt);
+      sqlite3_finalize(select_series);
+   }
+   if (insert_series)
+   {
+      sqlite3_finalize(insert_series);
+   }
+   if (insert_sample)
+   {
+      sqlite3_finalize(insert_sample);
    }
 
    /* Only roll back if a transaction was actually started */
@@ -193,7 +326,10 @@ pgexporter_history_sqlite_query_range(const char* metric, time_t start, time_t e
                                       struct history_record** records_out, int* count_out)
 {
    sqlite3_stmt* stmt = NULL;
-   const char* sql = "SELECT ts, server, metric, labels, value FROM history WHERE metric = ? AND ts >= ? AND ts <= ? ORDER BY ts ASC;";
+   const char* sql = "SELECT sa.ts, se.server, se.metric, se.labels, sa.value "
+                     "FROM sample sa JOIN series se ON se.series_id = sa.series_id "
+                     "WHERE se.metric = ? AND sa.ts >= ? AND sa.ts <= ? "
+                     "ORDER BY sa.ts ASC;";
    int count = 0;
    int capacity = 100;
    struct history_record* results = NULL;
@@ -302,7 +438,9 @@ pgexporter_history_sqlite_prune(void)
 {
    struct configuration* config;
    sqlite3_stmt* stmt = NULL;
-   const char* sql = "DELETE FROM history WHERE ts < ?;";
+   const char* sql = "DELETE FROM sample WHERE ts < ?;";
+   const char* sweep_sql = "DELETE FROM series WHERE NOT EXISTS ("
+                           "SELECT 1 FROM sample WHERE sample.series_id = series.series_id);";
    char vacuum_sql[48];
    time_t cutoff;
    int64_t retention_s;
@@ -321,6 +459,7 @@ pgexporter_history_sqlite_prune(void)
    }
 
    cutoff = time(NULL) - (time_t)retention_s;
+
    if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
    {
       pgexporter_log_error("history_sqlite: prune prepare failed: %s", sqlite3_errmsg(db));
@@ -337,6 +476,12 @@ pgexporter_history_sqlite_prune(void)
 
    sqlite3_finalize(stmt);
    stmt = NULL;
+
+   /* Separate lock: the sweep re-checks NOT EXISTS, so an insert in between is safe */
+   if (exec_sql(sweep_sql, "orphan series sweep"))
+   {
+      goto error;
+   }
 
    /* Hand reclaimed pages back to the OS. Bounded so the write lock is held
     * only briefly; a no-op when auto_vacuum freed nothing. */

--- a/test/testcases/test_history.c
+++ b/test/testcases/test_history.c
@@ -44,6 +44,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <sqlite3.h>
+
 /*
  * Path of the SQLite database used by the test currently running. Set in
  * setup, unlinked in teardown so every test starts from an empty database.
@@ -89,6 +91,94 @@ unlink_db(const char* path)
    unlink(sibling);
    pgexporter_snprintf(sibling, MAX_PATH, "%s-journal", path);
    unlink(sibling);
+}
+
+/*
+ * Run a scalar query against the history database on a second connection and
+ * return the first column of the first row, or -1 if anything went wrong.
+ * The backend keeps its own connection open in WAL mode, so a reader here sees
+ * everything it has committed.
+ */
+static int64_t
+db_scalar(const char* sql)
+{
+   sqlite3* conn = NULL;
+   sqlite3_stmt* stmt = NULL;
+   int64_t result = -1;
+
+   if (sqlite3_open_v2(db_path, &conn, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK)
+   {
+      goto done;
+   }
+
+   if (sqlite3_prepare_v2(conn, sql, -1, &stmt, NULL) != SQLITE_OK)
+   {
+      goto done;
+   }
+
+   if (sqlite3_step(stmt) == SQLITE_ROW)
+   {
+      result = (int64_t)sqlite3_column_int64(stmt, 0);
+   }
+
+done:
+   if (stmt)
+   {
+      sqlite3_finalize(stmt);
+   }
+   if (conn)
+   {
+      sqlite3_close_v2(conn);
+   }
+
+   return result;
+}
+
+/*
+ * Copy the first column of the first row into `out` as text. Returns false if
+ * the query produced no row.
+ */
+static bool
+db_text(const char* sql, char* out, size_t out_size)
+{
+   sqlite3* conn = NULL;
+   sqlite3_stmt* stmt = NULL;
+   bool found = false;
+
+   out[0] = '\0';
+
+   if (sqlite3_open_v2(db_path, &conn, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK)
+   {
+      goto done;
+   }
+
+   if (sqlite3_prepare_v2(conn, sql, -1, &stmt, NULL) != SQLITE_OK)
+   {
+      goto done;
+   }
+
+   if (sqlite3_step(stmt) == SQLITE_ROW)
+   {
+      const unsigned char* text = sqlite3_column_text(stmt, 0);
+
+      if (text != NULL)
+      {
+         pgexporter_snprintf(out, out_size, "%s", (const char*)text);
+      }
+      found = true;
+   }
+
+done:
+   if (stmt)
+   {
+      sqlite3_finalize(stmt);
+   }
+   if (conn)
+   {
+      sqlite3_close_v2(conn);
+   }
+
+   return found;
 }
 
 MCTF_TEST_SETUP(history)
@@ -205,12 +295,14 @@ MCTF_TEST(test_history_query_metric_filter)
 
    MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
 
+   /* in[0] and in[2] are the same series, so they need distinct timestamps:
+    * one series holds one value per instant. */
    make_record(&in[0], now, "s", "metric_a", "", 1.0);
    make_record(&in[1], now, "s", "metric_b", "", 2.0);
-   make_record(&in[2], now, "s", "metric_a", "", 3.0);
+   make_record(&in[2], now + 1, "s", "metric_a", "", 3.0);
    MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 3), 0, cleanup, "write failed");
 
-   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("metric_a", now - 1, now + 1, &out, &count), 0,
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("metric_a", now - 1, now + 2, &out, &count), 0,
                       cleanup, "query failed");
    MCTF_ASSERT_INT_EQ(count, 2, cleanup, "expected 2 metric_a rows, got %d", count);
    MCTF_ASSERT_STR_EQ(out[0].metric, "metric_a", cleanup, "filtered metric mismatch");
@@ -740,6 +832,413 @@ MCTF_TEST(test_history_prune_spans_all_metrics)
    MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("metric_b", 0, now + 10, NULL, &count), 0,
                       cleanup, "query metric_b failed");
    MCTF_ASSERT_INT_EQ(count, 1, cleanup, "metric_b should have 1 row after prune, got %d", count);
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* Schema shape */
+MCTF_TEST(test_history_schema_tables)
+{
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'series';"),
+                      1, cleanup, "series table missing");
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sample';"),
+                      1, cleanup, "sample table missing");
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_sample_ts';"),
+                      1, cleanup, "idx_sample_ts missing: prune and multi-series reads would scan");
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'history';"),
+                      0, cleanup, "the flat history table should be gone");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_reopen_preserves_data)
+{
+   struct history_record in[1];
+   struct history_record* out = NULL;
+   int count = 0;
+   time_t base = 4600000;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   make_record(&in[0], base, "primary", "pg_up", "server=\"primary\"", 5.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 1), 0, cleanup, "write failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_shutdown(), 0, cleanup, "shutdown failed");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "reopen failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("pg_up", base, base, &out, &count), 0, cleanup, "query failed");
+   MCTF_ASSERT_INT_EQ(count, 1, cleanup, "the sample written before shutdown should survive, got %d", count);
+   MCTF_ASSERT(out[0].value == 5.0, cleanup, "value changed across reopen");
+
+cleanup:
+   pgexporter_history_records_free(out, count);
+   MCTF_FINISH();
+}
+
+/* Canonical label hash */
+MCTF_TEST(test_history_label_hash_shape)
+{
+   char hash[HISTORY_LABEL_HASH_LENGTH];
+   size_t i;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("server=\"a\"", hash), 0, cleanup, "hash failed");
+   MCTF_ASSERT_INT_EQ((int)strlen(hash), HISTORY_LABEL_HASH_LENGTH - 1, cleanup,
+                      "expected %d hex characters, got %d", HISTORY_LABEL_HASH_LENGTH - 1, (int)strlen(hash));
+
+   for (i = 0; i < strlen(hash); i++)
+   {
+      MCTF_ASSERT((hash[i] >= '0' && hash[i] <= '9') || (hash[i] >= 'a' && hash[i] <= 'f'), cleanup,
+                  "hash character %zu is '%c', expected lowercase hex", i, hash[i]);
+   }
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_label_hash_is_stable)
+{
+   char first[HISTORY_LABEL_HASH_LENGTH];
+   char second[HISTORY_LABEL_HASH_LENGTH];
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("a=\"1\",b=\"2\"", first), 0, cleanup, "hash failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("a=\"1\",b=\"2\"", second), 0, cleanup, "hash failed");
+   MCTF_ASSERT_STR_EQ(first, second, cleanup, "the same label set must hash the same way twice");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* UNIQUE constraint on the raw label string
+ * would split one series in two as soon as emission order changed. */
+MCTF_TEST(test_history_label_hash_ignores_order)
+{
+   char forward[HISTORY_LABEL_HASH_LENGTH];
+   char reverse[HISTORY_LABEL_HASH_LENGTH];
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("a=\"1\",b=\"2\",c=\"3\"", forward), 0, cleanup, "hash failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("c=\"3\",a=\"1\",b=\"2\"", reverse), 0, cleanup, "hash failed");
+   MCTF_ASSERT_STR_EQ(forward, reverse, cleanup, "label order must not change the hash");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_label_hash_separates_distinct_sets)
+{
+   char a[HISTORY_LABEL_HASH_LENGTH];
+   char b[HISTORY_LABEL_HASH_LENGTH];
+   char empty[HISTORY_LABEL_HASH_LENGTH];
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("database=\"one\"", a), 0, cleanup, "hash failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("database=\"two\"", b), 0, cleanup, "hash failed");
+   MCTF_ASSERT(strcmp(a, b) != 0, cleanup, "different label values must hash differently");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("", empty), 0, cleanup, "hash failed");
+   MCTF_ASSERT(strcmp(a, empty) != 0, cleanup, "a labelled series must not collide with an unlabelled one");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_label_hash_null_matches_empty)
+{
+   char from_null[HISTORY_LABEL_HASH_LENGTH];
+   char from_empty[HISTORY_LABEL_HASH_LENGTH];
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash(NULL, from_null), 0, cleanup, "hash of NULL failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("", from_empty), 0, cleanup, "hash of \"\" failed");
+   MCTF_ASSERT_STR_EQ(from_null, from_empty, cleanup, "no labels must hash the same either way");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_label_hash_unparsable_is_stable)
+{
+   char first[HISTORY_LABEL_HASH_LENGTH];
+   char second[HISTORY_LABEL_HASH_LENGTH];
+   char other[HISTORY_LABEL_HASH_LENGTH];
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("broken", first), 0, cleanup, "hash failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("broken", second), 0, cleanup, "hash failed");
+   MCTF_ASSERT_STR_EQ(first, second, cleanup, "unparsable input must still hash consistently");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("also broken", other), 0, cleanup, "hash failed");
+   MCTF_ASSERT(strcmp(first, other) != 0, cleanup, "distinct unparsable input must not collide");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_label_hash_orders_duplicate_keys)
+{
+   char forward[HISTORY_LABEL_HASH_LENGTH];
+   char reverse[HISTORY_LABEL_HASH_LENGTH];
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("a=\"1\",a=\"2\"", forward), 0, cleanup, "hash failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash("a=\"2\",a=\"1\"", reverse), 0, cleanup, "hash failed");
+   MCTF_ASSERT_STR_EQ(forward, reverse, cleanup, "repeated keys must still sort deterministically");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_label_hash_handles_sql_label_value)
+{
+   char with_query[HISTORY_LABEL_HASH_LENGTH];
+   char reordered[HISTORY_LABEL_HASH_LENGTH];
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash(
+                         "query=\"SELECT a, b FROM t WHERE c = \\\"x\\\"\",server=\"primary\"", with_query),
+                      0, cleanup, "hash failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_label_hash(
+                         "server=\"primary\",query=\"SELECT a, b FROM t WHERE c = \\\"x\\\"\"", reordered),
+                      0, cleanup, "hash failed");
+   MCTF_ASSERT_STR_EQ(with_query, reordered, cleanup,
+                      "a value holding commas and escaped quotes must not break pair splitting");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* Label lookup */
+MCTF_TEST(test_history_label_find_basic)
+{
+   char value[MISC_LENGTH];
+
+   MCTF_ASSERT(pgexporter_history_label_find("server=\"primary\",database=\"pgbench\"", "server", value, sizeof(value)),
+               cleanup, "server should be found");
+   MCTF_ASSERT_STR_EQ(value, "primary", cleanup, "wrong server value");
+
+   MCTF_ASSERT(pgexporter_history_label_find("server=\"primary\",database=\"pgbench\"", "database", value, sizeof(value)),
+               cleanup, "database should be found");
+   MCTF_ASSERT_STR_EQ(value, "pgbench", cleanup, "wrong database value");
+
+   MCTF_ASSERT(!pgexporter_history_label_find("server=\"primary\"", "missing", value, sizeof(value)),
+               cleanup, "absent key should not be found");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_label_find_rejects_substring_key)
+{
+   char value[MISC_LENGTH];
+
+   MCTF_ASSERT(!pgexporter_history_label_find("upstream_server=\"other\"", "server", value, sizeof(value)),
+               cleanup, "'server' must not match the tail of 'upstream_server'");
+
+   MCTF_ASSERT(pgexporter_history_label_find("upstream_server=\"other\",server=\"real\"", "server", value, sizeof(value)),
+               cleanup, "the real server label should still be found");
+   MCTF_ASSERT_STR_EQ(value, "real", cleanup, "matched the wrong label");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_label_find_escaped_quote)
+{
+   char value[MISC_LENGTH];
+
+   MCTF_ASSERT(pgexporter_history_label_find("note=\"a\\\"b\",server=\"primary\"", "server", value, sizeof(value)),
+               cleanup, "an escaped quote must not end the preceding value");
+   MCTF_ASSERT_STR_EQ(value, "primary", cleanup, "wrong server value");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* Series identity */
+MCTF_TEST(test_history_series_written_once)
+{
+   struct history_record in[1];
+   time_t base = 4000000;
+   int i;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   /* Ten snapshots of one series, written as ten separate batches the way the
+    * collection path would produce them. */
+   for (i = 0; i < 10; i++)
+   {
+      make_record(&in[0], base + (i * 60), "primary", "pg_up", "server=\"primary\"", (double)i);
+      MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 1), 0, cleanup, "write %d failed", i);
+   }
+
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM series;"), 1, cleanup,
+                      "ten snapshots of one series should store one series row");
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM sample;"), 10, cleanup,
+                      "ten snapshots should store ten samples");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_series_survives_label_reorder)
+{
+   struct history_record in[2];
+   struct history_record* out = NULL;
+   int count = 0;
+   time_t base = 4100000;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   make_record(&in[0], base, "primary", "pg_x", "server=\"primary\",database=\"pgbench\"", 1.0);
+   make_record(&in[1], base + 60, "primary", "pg_x", "database=\"pgbench\",server=\"primary\"", 2.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 2), 0, cleanup, "write failed");
+
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM series;"), 1, cleanup,
+                      "reordered labels must resolve to the same series, not a second one");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("pg_x", base, base + 60, &out, &count), 0,
+                      cleanup, "query failed");
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "both samples should still be readable, got %d", count);
+
+cleanup:
+   pgexporter_history_records_free(out, count);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_series_split_by_server_and_metric)
+{
+   struct history_record in[4];
+   time_t base = 4200000;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   make_record(&in[0], base, "primary", "pg_up", "server=\"primary\"", 1.0);
+   make_record(&in[1], base, "replica", "pg_up", "server=\"replica\"", 1.0);
+   make_record(&in[2], base, "primary", "pg_down", "server=\"primary\"", 0.0);
+   /* Same metric and labels as in[0], different server column. */
+   make_record(&in[3], base, "replica", "pg_up", "server=\"primary\"", 1.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 4), 0, cleanup, "write failed");
+
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM series;"), 4, cleanup,
+                      "metric, server and label set must each separate a series");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_series_keeps_raw_labels)
+{
+   struct history_record in[1];
+   char labels[512];
+   time_t base = 4300000;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   make_record(&in[0], base, "primary", "pg_x", "server=\"primary\",database=\"pgbench\"", 1.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 1), 0, cleanup, "write failed");
+
+   MCTF_ASSERT(db_text("SELECT labels FROM series;", labels, sizeof(labels)), cleanup, "no series row");
+   MCTF_ASSERT_STR_EQ(labels, "server=\"primary\",database=\"pgbench\"", cleanup,
+                      "the label string must be stored verbatim for display");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_sample_duplicate_last_wins)
+{
+   struct history_record in[2];
+   struct history_record* out = NULL;
+   int count = 0;
+   time_t base = 4400000;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   make_record(&in[0], base, "primary", "pg_up", "server=\"primary\"", 1.0);
+   make_record(&in[1], base, "primary", "pg_up", "server=\"primary\"", 9.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 2), 0, cleanup, "write failed");
+
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM sample;"), 1, cleanup,
+                      "the same series at the same instant is one row");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_query_range("pg_up", base, base, &out, &count), 0,
+                      cleanup, "query failed");
+   MCTF_ASSERT_INT_EQ(count, 1, cleanup, "expected 1 row, got %d", count);
+   MCTF_ASSERT(out[0].value == 9.0, cleanup, "the later write should win, got %f", out[0].value);
+
+cleanup:
+   pgexporter_history_records_free(out, count);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_sample_no_orphans)
+{
+   struct history_record in[2];
+   time_t base = 4500000;
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   make_record(&in[0], base, "primary", "pg_up", "server=\"primary\"", 1.0);
+   make_record(&in[1], base, "replica", "pg_up", "server=\"replica\"", 1.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 2), 0, cleanup, "write failed");
+
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM sample WHERE series_id NOT IN (SELECT series_id FROM series);"),
+                      0, cleanup, "every sample must point at a series that exists");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* Pruning */
+MCTF_TEST(test_history_prune_sweeps_orphan_series)
+{
+   struct configuration* config = (struct configuration*)shmem;
+   struct history_record in[3];
+   time_t now = time(NULL);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   config->history_retention = PGEXPORTER_TIME_SEC(3600);
+
+   /* stale_series has nothing left after the cutoff; live_series does. */
+   make_record(&in[0], now - 7200, "primary", "stale_series", "server=\"primary\"", 1.0);
+   make_record(&in[1], now - 7200, "primary", "live_series", "server=\"primary\"", 2.0);
+   make_record(&in[2], now - 60, "primary", "live_series", "server=\"primary\"", 3.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 3), 0, cleanup, "write failed");
+
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM series;"), 2, cleanup, "expected 2 series before prune");
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_prune(), 0, cleanup, "prune failed");
+
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM sample;"), 1, cleanup,
+                      "only the sample inside the retention window should remain");
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM series;"), 1, cleanup,
+                      "a series with no samples left is no longer a series");
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM series WHERE metric = 'live_series';"), 1, cleanup,
+                      "the series that still has samples must be kept");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_history_prune_keeps_series_reusable)
+{
+   struct configuration* config = (struct configuration*)shmem;
+   struct history_record in[1];
+   time_t now = time(NULL);
+
+   MCTF_ASSERT_INT_EQ(pgexporter_history_init(), 0, cleanup, "init failed");
+
+   config->history_retention = PGEXPORTER_TIME_SEC(3600);
+
+   make_record(&in[0], now - 7200, "primary", "pg_up", "server=\"primary\"", 1.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 1), 0, cleanup, "write failed");
+   MCTF_ASSERT_INT_EQ(pgexporter_history_prune(), 0, cleanup, "prune failed");
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM series;"), 0, cleanup, "series should have been swept");
+
+   /* The next snapshot has to be able to recreate the series it just lost. */
+   make_record(&in[0], now, "primary", "pg_up", "server=\"primary\"", 2.0);
+   MCTF_ASSERT_INT_EQ(pgexporter_history_write_batch(in, 1), 0, cleanup, "write after sweep failed");
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM series;"), 1, cleanup, "series should have been recreated");
+   MCTF_ASSERT_INT_EQ((int)db_scalar("SELECT COUNT(*) FROM sample WHERE series_id NOT IN (SELECT series_id FROM series);"),
+                      0, cleanup, "the recreated sample must point at the new series");
 
 cleanup:
    MCTF_FINISH();


### PR DESCRIPTION
Resolves #574
Changes

- Replaced the flat history table with a series/sample split - series holds the metric,
  server and label set once, sample holds one row per series per timestamp
- Added pgexporter_history_label_hash() in history.c - label pairs sorted by key then
  hashed with SHA-256, so a series keeps its identity when the emission order of its
  labels changes.
- Fixed: the server label was pulled out with strstr(labels, "server=\"") which matched
  the tail of keys like upstream_server and stopped at an escaped quote in an earlier
  value. It now goes through the same parser as the hash.

NOTE: Delete the previous db file before running this

