### PR TITLE
Fix Prometheus HELP and TYPE format

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,3 +38,4 @@ Ameen Sakr <ameensakr623@gmail.com>
 Som Shegokar <akashshegokar2186@gmail.com>
 youssef-joe <joe92228@gmail.com>
 Omar ElAzouny <omarlazouny@gmail.com>
+Mohamed Adel <mmomoadel@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -42,6 +42,7 @@ Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 Ameen Sakr <ameensakr623@gmail.com>
 youssef-joe <joe92228@gmail.com>
 Omar ElAzouny <omarlazouny@gmail.com>
+Mohamed Adel <mmomoadel@gmail.com>
 ```
 
 ## Committers

--- a/src/libpgexporter/bridge.c
+++ b/src/libpgexporter/bridge.c
@@ -730,13 +730,13 @@ retry_cache_json_locking:
       struct prometheus_metric* metric_data = (struct prometheus_metric*)metrics_iterator->value->data;
       struct deque_iterator* definition_iterator = NULL;
 
-      data = pgexporter_append(data, "#HELP ");
+      data = pgexporter_append(data, "# HELP ");
       data = pgexporter_append(data, metric_data->name);
       data = pgexporter_append_char(data, ' ');
       data = pgexporter_append(data, metric_data->help);
       data = pgexporter_append_char(data, '\n');
 
-      data = pgexporter_append(data, "#TYPE ");
+      data = pgexporter_append(data, "# TYPE ");
       data = pgexporter_append(data, metric_data->name);
       data = pgexporter_append_char(data, ' ');
       data = pgexporter_append(data, metric_data->type);

--- a/src/libpgexporter/prometheus.c
+++ b/src/libpgexporter/prometheus.c
@@ -680,8 +680,8 @@ general_information(prometheus_metrics_container_t* container)
 
    /* pgexporter_state */
    data = pgexporter_vappend(data, 3,
-                             "#HELP pgexporter_state The state of pgexporter\n",
-                             "#TYPE pgexporter_state gauge\n",
+                             "# HELP pgexporter_state The state of pgexporter\n",
+                             "# TYPE pgexporter_state gauge\n",
                              "pgexporter_state 1\n");
    add_metric_to_art(container->general_metrics, "pgexporter_state", data, NULL, NULL, 0);
    free(data);
@@ -689,8 +689,8 @@ general_information(prometheus_metrics_container_t* container)
 
    /* pgexporter_logging_info */
    data = pgexporter_vappend(data, 3,
-                             "#HELP pgexporter_logging_info The number of INFO logging statements\n",
-                             "#TYPE pgexporter_logging_info gauge\n",
+                             "# HELP pgexporter_logging_info The number of INFO logging statements\n",
+                             "# TYPE pgexporter_logging_info gauge\n",
                              "pgexporter_logging_info ");
    data = pgexporter_append_ulong(data, atomic_load(&config->logging_info));
    data = pgexporter_append(data, "\n");
@@ -700,8 +700,8 @@ general_information(prometheus_metrics_container_t* container)
 
    /* pgexporter_logging_warn */
    data = pgexporter_vappend(data, 3,
-                             "#HELP pgexporter_logging_warn The number of WARN logging statements\n",
-                             "#TYPE pgexporter_logging_warn gauge\n",
+                             "# HELP pgexporter_logging_warn The number of WARN logging statements\n",
+                             "# TYPE pgexporter_logging_warn gauge\n",
                              "pgexporter_logging_warn ");
    data = pgexporter_append_ulong(data, atomic_load(&config->logging_warn));
    data = pgexporter_append(data, "\n");
@@ -711,8 +711,8 @@ general_information(prometheus_metrics_container_t* container)
 
    /* pgexporter_logging_error */
    data = pgexporter_vappend(data, 3,
-                             "#HELP pgexporter_logging_error The number of ERROR logging statements\n",
-                             "#TYPE pgexporter_logging_error gauge\n",
+                             "# HELP pgexporter_logging_error The number of ERROR logging statements\n",
+                             "# TYPE pgexporter_logging_error gauge\n",
                              "pgexporter_logging_error ");
    data = pgexporter_append_ulong(data, atomic_load(&config->logging_error));
    data = pgexporter_append(data, "\n");
@@ -722,8 +722,8 @@ general_information(prometheus_metrics_container_t* container)
 
    /* pgexporter_logging_fatal */
    data = pgexporter_vappend(data, 3,
-                             "#HELP pgexporter_logging_fatal The number of FATAL logging statements\n",
-                             "#TYPE pgexporter_logging_fatal gauge\n",
+                             "# HELP pgexporter_logging_fatal The number of FATAL logging statements\n",
+                             "# TYPE pgexporter_logging_fatal gauge\n",
                              "pgexporter_logging_fatal ");
    data = pgexporter_append_ulong(data, atomic_load(&config->logging_fatal));
    data = pgexporter_append(data, "\n");
@@ -742,8 +742,8 @@ query_statistics_information(prometheus_metrics_container_t* container)
 
    /* pgexporter_query_executions_total */
    data = pgexporter_vappend(data, 3,
-                             "#HELP pgexporter_query_executions_total The total number of metric queries executed\n",
-                             "#TYPE pgexporter_query_executions_total counter\n",
+                             "# HELP pgexporter_query_executions_total The total number of metric queries executed\n",
+                             "# TYPE pgexporter_query_executions_total counter\n",
                              "pgexporter_query_executions_total ");
    data = pgexporter_append_ulong(data, atomic_load(&config->query_executions_total));
    data = pgexporter_append(data, "\n");
@@ -753,8 +753,8 @@ query_statistics_information(prometheus_metrics_container_t* container)
 
    /* pgexporter_query_errors_total */
    data = pgexporter_vappend(data, 3,
-                             "#HELP pgexporter_query_errors_total The total number of metric queries that failed\n",
-                             "#TYPE pgexporter_query_errors_total counter\n",
+                             "# HELP pgexporter_query_errors_total The total number of metric queries that failed\n",
+                             "# TYPE pgexporter_query_errors_total counter\n",
                              "pgexporter_query_errors_total ");
    data = pgexporter_append_ulong(data, atomic_load(&config->query_errors_total));
    data = pgexporter_append(data, "\n");
@@ -764,8 +764,8 @@ query_statistics_information(prometheus_metrics_container_t* container)
 
    /* pgexporter_query_timeouts_total */
    data = pgexporter_vappend(data, 3,
-                             "#HELP pgexporter_query_timeouts_total The total number of metric queries that timed out\n",
-                             "#TYPE pgexporter_query_timeouts_total counter\n",
+                             "# HELP pgexporter_query_timeouts_total The total number of metric queries that timed out\n",
+                             "# TYPE pgexporter_query_timeouts_total counter\n",
                              "pgexporter_query_timeouts_total ");
    data = pgexporter_append_ulong(data, atomic_load(&config->query_timeouts_total));
    data = pgexporter_append(data, "\n");
@@ -783,8 +783,8 @@ server_information(prometheus_metrics_container_t* container)
    config = (struct configuration*)shmem;
 
    data = pgexporter_vappend(data, 2,
-                             "#HELP pgexporter_postgresql_active The state of PostgreSQL\n",
-                             "#TYPE pgexporter_postgresql_active gauge\n");
+                             "# HELP pgexporter_postgresql_active The state of PostgreSQL\n",
+                             "# TYPE pgexporter_postgresql_active gauge\n");
 
    for (int server = 0; server < config->number_of_servers; server++)
    {
@@ -849,8 +849,8 @@ version_information(prometheus_metrics_container_t* container)
       if (current != NULL)
       {
          data = pgexporter_vappend(data, 2,
-                                   "#HELP pgexporter_postgresql_version The PostgreSQL version\n",
-                                   "#TYPE pgexporter_postgresql_version gauge\n");
+                                   "# HELP pgexporter_postgresql_version The PostgreSQL version\n",
+                                   "# TYPE pgexporter_postgresql_version gauge\n");
 
          server = 0;
 
@@ -923,8 +923,8 @@ uptime_information(prometheus_metrics_container_t* container)
       if (current != NULL)
       {
          data = pgexporter_vappend(data, 2,
-                                   "#HELP pgexporter_postgresql_uptime The PostgreSQL uptime in seconds\n",
-                                   "#TYPE pgexporter_postgresql_uptime counter\n");
+                                   "# HELP pgexporter_postgresql_uptime The PostgreSQL uptime in seconds\n",
+                                   "# TYPE pgexporter_postgresql_uptime counter\n");
 
          server = 0;
 
@@ -991,8 +991,8 @@ primary_information(prometheus_metrics_container_t* container)
       if (current != NULL)
       {
          data = pgexporter_vappend(data, 2,
-                                   "#HELP pgexporter_postgresql_primary Is the PostgreSQL instance the primary\n",
-                                   "#TYPE pgexporter_postgresql_primary gauge\n");
+                                   "# HELP pgexporter_postgresql_primary Is the PostgreSQL instance the primary\n",
+                                   "# TYPE pgexporter_postgresql_primary gauge\n");
 
          server = 0;
 
@@ -1044,8 +1044,8 @@ fips_information(prometheus_metrics_container_t* container)
    openssl_fips = pgexporter_fips_pgexporter();
 
    data = pgexporter_vappend(data, 2,
-                             "#HELP pgexporter_fips Is pgexporter running with FIPS-compliant OpenSSL\n",
-                             "#TYPE pgexporter_fips gauge\n");
+                             "# HELP pgexporter_fips Is pgexporter running with FIPS-compliant OpenSSL\n",
+                             "# TYPE pgexporter_fips gauge\n");
 
    data = pgexporter_vappend(data, 2,
                              "pgexporter_fips ",
@@ -1060,8 +1060,8 @@ fips_information(prometheus_metrics_container_t* container)
    }
 
    data = pgexporter_vappend(data, 2,
-                             "#HELP pgexporter_postgresql_fips Is PostgreSQL running in FIPS mode\n",
-                             "#TYPE pgexporter_postgresql_fips gauge\n");
+                             "# HELP pgexporter_postgresql_fips Is PostgreSQL running in FIPS mode\n",
+                             "# TYPE pgexporter_postgresql_fips gauge\n");
 
    for (server = 0; server < config->number_of_servers; server++)
    {
@@ -1098,8 +1098,8 @@ core_information(prometheus_metrics_container_t* container)
    char* data = NULL;
 
    data = pgexporter_vappend(data, 5,
-                             "#HELP pgexporter_version The pgexporter version\n",
-                             "#TYPE pgexporter_version counter\n",
+                             "# HELP pgexporter_version The pgexporter version\n",
+                             "# TYPE pgexporter_version counter\n",
                              "pgexporter_version{pgexporter_version=\"",
                              VERSION,
                              "\"} 1\n");
@@ -1129,8 +1129,8 @@ extension_list_information(prometheus_metrics_container_t* container)
    }
 
    data = pgexporter_vappend(data, 2,
-                             "#HELP pgexporter_postgresql_extension_info Information about installed PostgreSQL extensions\n",
-                             "#TYPE pgexporter_postgresql_extension_info gauge\n");
+                             "# HELP pgexporter_postgresql_extension_info Information about installed PostgreSQL extensions\n",
+                             "# TYPE pgexporter_postgresql_extension_info gauge\n");
 
    for (int server = 0; server < config->number_of_servers; server++)
    {
@@ -1222,14 +1222,14 @@ settings_information(prometheus_metrics_container_t* container)
       {
          safe_key = safe_prometheus_key(pgexporter_get_column(0, current));
          data = pgexporter_vappend(data, 12,
-                                   "#HELP pgexporter_",
+                                   "# HELP pgexporter_",
                                    &all->tag[0],
                                    "_",
                                    safe_key,
                                    " ",
                                    pgexporter_get_column(2, current),
                                    "\n",
-                                   "#TYPE pgexporter_",
+                                   "# TYPE pgexporter_",
                                    &all->tag[0],
                                    "_",
                                    safe_key,
@@ -1337,9 +1337,9 @@ alert_information(prometheus_metrics_container_t* container)
       pgexporter_snprintf(metric_name, sizeof(metric_name), "pgexporter_alert_%s", alert->name);
 
       data = pgexporter_vappend(data, 5,
-                                "#HELP ", metric_name, " ", alert->description, "\n");
+                                "# HELP ", metric_name, " ", alert->description, "\n");
       data = pgexporter_vappend(data, 3,
-                                "#TYPE ", metric_name, " gauge\n");
+                                "# TYPE ", metric_name, " gauge\n");
 
       for (server = 0; server < config->number_of_servers; server++)
       {
@@ -2719,7 +2719,7 @@ static void
 append_help_info(char** data, char* tag, char* name, char* description)
 {
    *data = pgexporter_vappend(*data, 2,
-                              "#HELP pgexporter_",
+                              "# HELP pgexporter_",
                               tag);
 
    if (strlen(name) > 0)
@@ -2756,7 +2756,7 @@ static void
 append_type_info(char** data, char* tag, char* name, int typeId)
 {
    *data = pgexporter_vappend(*data, 2,
-                              "#TYPE pgexporter_",
+                              "# TYPE pgexporter_",
                               tag);
 
    if (strlen(name) > 0)
@@ -3151,7 +3151,7 @@ prometheus_endpoints_information(SSL* client_ssl, int client_fd)
          line = strtok_r(body_copy, "\n", &saveptr);
          while (line != NULL)
          {
-            if (!first_line && strncmp(line, "#HELP", 5) == 0)
+            if (!first_line && strncmp(line, "# HELP", 6) == 0)
             {
                data = pgexporter_append(data, "\n");
             }

--- a/src/libpgexporter/prometheus_client.c
+++ b/src/libpgexporter/prometheus_client.c
@@ -1003,22 +1003,23 @@ parse_body_to_bridge(int endpoint, time_t timestamp, char* body, struct promethe
       }
       else if (line[0] == '#')
       {
-         if (!strncmp(&line[1], "HELP", 4))
+         if (!strncmp(&line[2], "HELP", 4))
          {
-            sscanf(line + 6, "%127s %1021[^\n]", name, help);
+            sscanf(line + 7, "%127s %1021[^\n]", name, help);
 
             metric_find_create(bridge, name, &metric);
 
             metric_set_name(metric, name);
             metric_set_help(metric, help);
          }
-         else if (!strncmp(&line[1], "TYPE", 4))
+         else if (!strncmp(&line[2], "TYPE", 4))
          {
-            sscanf(line + 6, "%127s %127[^\n]", name, type);
+            sscanf(line + 7, "%127s %127[^\n]", name, type);
             metric_set_type(metric, type);
          }
          else
          {
+            pgexporter_log_error("parse_body_to_bridge: unknown # line: %s", line);
             goto error;
          }
       }

--- a/test/testcases/test_http.c
+++ b/test/testcases/test_http.c
@@ -52,6 +52,39 @@
 
 static int validate_metrics_response(char* response_body, const char* metric_pattern);
 
+struct metrics_write_cb_context
+{
+   char* data;
+   size_t data_size;
+};
+
+static size_t collect_metrics_write_cb(void* buffer, size_t size, void* userdata);
+
+static size_t
+collect_metrics_write_cb(void* buffer, size_t size, void* userdata)
+{
+   struct metrics_write_cb_context* context = (struct metrics_write_cb_context*)userdata;
+   char* data;
+
+   if (context == NULL)
+   {
+      return 0;
+   }
+
+   data = realloc(context->data, context->data_size + size + 1);
+   if (data == NULL)
+   {
+      return 0;
+   }
+
+   memcpy(data + context->data_size, buffer, size);
+   context->data = data;
+   context->data_size += size;
+   context->data[context->data_size] = '\0';
+
+   return size;
+}
+
 MCTF_TEST(test_http_metrics)
 {
    struct http* connection = NULL;
@@ -79,6 +112,10 @@ MCTF_TEST(test_http_metrics)
    response_body = strdup((char*)response->payload.data);
    MCTF_ASSERT_PTR_NONNULL(response_body, cleanup, "Failed to duplicate response body");
    MCTF_ASSERT(strlen(response_body) > 0, cleanup, "Response body is empty");
+   MCTF_ASSERT(strstr(response_body, "# HELP pgexporter_state The state of pgexporter\n") != NULL,
+               cleanup, "Missing Prometheus HELP line");
+   MCTF_ASSERT(strstr(response_body, "# TYPE pgexporter_state gauge\n") != NULL,
+               cleanup, "Missing Prometheus TYPE line");
 
    ret = validate_metrics_response(response_body, "pgexporter_state 1");
    MCTF_ASSERT(ret == 0, cleanup, "HTTP metrics response validation failed");
@@ -110,6 +147,7 @@ MCTF_TEST(test_http_bridge_endpoint)
    struct http_request* request = NULL;
    struct http_response* response = NULL;
    struct configuration* config;
+   struct metrics_write_cb_context write_context = {0};
    char* response_body = NULL;
    int ret;
 
@@ -125,18 +163,29 @@ MCTF_TEST(test_http_bridge_endpoint)
    ret = pgexporter_http_request_create(PGEXPORTER_HTTP_GET, "/metrics", &request);
    MCTF_ASSERT(ret == 0, cleanup, "Failed to create HTTP request");
 
+   response = calloc(1, sizeof(struct http_response));
+   MCTF_ASSERT_PTR_NONNULL(response, cleanup, "Failed to allocate HTTP response");
+   response->write_cb = collect_metrics_write_cb;
+   response->write_userdata = &write_context;
+
    ret = pgexporter_http_invoke(connection, request, &response);
    MCTF_ASSERT(ret == 0, cleanup, "Failed to execute HTTP GET /metrics");
 
-   MCTF_ASSERT_PTR_NONNULL(response->payload.data, cleanup, "HTTP response body is NULL");
+   MCTF_ASSERT_PTR_NONNULL(write_context.data, cleanup, "HTTP response body is NULL");
 
-   response_body = strdup((char*)response->payload.data);
+   response_body = strdup(write_context.data);
    MCTF_ASSERT_PTR_NONNULL(response_body, cleanup, "Failed to duplicate response body");
    MCTF_ASSERT(strlen(response_body) > 0, cleanup, "Response body is empty");
+   MCTF_ASSERT(strstr(response_body, "# HELP pgexporter_state The state of pgexporter\n") != NULL,
+               cleanup, "Missing Prometheus HELP line");
+   MCTF_ASSERT(strstr(response_body, "# TYPE pgexporter_state gauge\n") != NULL,
+               cleanup, "Missing Prometheus TYPE line");
 
    ret = validate_metrics_response(response_body, "pgexporter_state{endpoint=");
    MCTF_ASSERT(ret == 0, cleanup, "HTTP bridge metrics response validation failed");
 
+   free(write_context.data);
+   write_context.data = NULL;
    free(response_body);
    response_body = NULL;
    pgexporter_http_response_destroy(response);
@@ -148,6 +197,8 @@ MCTF_TEST(test_http_bridge_endpoint)
 cleanup:
    if (response_body)
       free(response_body);
+   if (write_context.data)
+      free(write_context.data);
    if (response)
       pgexporter_http_response_destroy(response);
    if (request)


### PR DESCRIPTION
Fix Prometheus metric formatting to follow the standard exposition format.

### Changes

* Change `#HELP` to `# HELP`.
* Change `#TYPE` to `# TYPE`.
* Update the Prometheus endpoint parser to handle the standard `# HELP` format.
* Add HTTP and bridge endpoint tests for `HELP` and `TYPE` lines.

### Testing

* `./test/check.sh ci -t test_http_metrics`
* 3 tests passed.

Fixes #597