### PR TITLE
Cross-port: Build the value strings with format_and_append

### DIFF
--- a/src/libpgexporter/value.c
+++ b/src/libpgexporter/value.c
@@ -420,12 +420,9 @@ static char*
 int8_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "%" PRId8, (int8_t)data);
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "%" PRId8, (int8_t)data);
    return ret;
 }
 
@@ -433,11 +430,9 @@ static char*
 uint8_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
+
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "%" PRIu8, (uint8_t)data);
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "%" PRIu8, (uint8_t)data);
    return ret;
 }
 
@@ -445,12 +440,9 @@ static char*
 int16_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "%" PRId16, (int16_t)data);
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "%" PRId16, (int16_t)data);
    return ret;
 }
 
@@ -458,12 +450,9 @@ static char*
 uint16_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "%" PRIu16, (uint16_t)data);
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "%" PRIu16, (uint16_t)data);
    return ret;
 }
 
@@ -471,12 +460,9 @@ static char*
 int32_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "%" PRId32, (int32_t)data);
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "%" PRId32, (int32_t)data);
    return ret;
 }
 
@@ -484,12 +470,9 @@ static char*
 uint32_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "%" PRIu32, (uint32_t)data);
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "%" PRIu32, (uint32_t)data);
    return ret;
 }
 
@@ -497,12 +480,9 @@ static char*
 int64_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "%" PRId64, (int64_t)data);
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "%" PRId64, (int64_t)data);
    return ret;
 }
 
@@ -510,12 +490,9 @@ static char*
 uint64_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "%" PRIu64, (uint64_t)data);
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "%" PRIu64, (uint64_t)data);
    return ret;
 }
 
@@ -523,12 +500,9 @@ static char*
 float_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "%f", pgexporter_value_to_float(data));
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "%f", pgexporter_value_to_float(data));
    return ret;
 }
 
@@ -536,12 +510,9 @@ static char*
 double_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "%f", pgexporter_value_to_double(data));
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "%f", pgexporter_value_to_double(data));
 
    return ret;
 }
@@ -605,12 +576,9 @@ static char*
 char_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "'%c'", (char)data);
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "'%c'", (char)data);
 
    return ret;
 }
@@ -637,12 +605,9 @@ static char*
 mem_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* tag, int indent)
 {
    char* ret = NULL;
-   char buf[MISC_LENGTH];
 
    ret = pgexporter_indent(ret, tag, indent);
-   memset(buf, 0, MISC_LENGTH);
-   snprintf(buf, MISC_LENGTH, "%p", (void*)data);
-   ret = pgexporter_append(ret, buf);
+   ret = pgexporter_format_and_append(ret, "%p", (void*)data);
 
    return ret;
 }


### PR DESCRIPTION
> **This is a cross-port, not a new proposal.** The original is pgagroal/pgagroal#1041, already reviewed and **merged**. The change here is identical apart from the `pgexporter_` prefix, so it should only need a committer's eye rather than a full review.

Fixes #603.

The twelve `*_to_string_cb` callbacks each declared a fixed `char buf[MISC_LENGTH]`, memset it, formatted into it and appended it. `pgexporter_format_and_append()` does that in one line and sizes the allocation from `vsnprintf(NULL, 0, ...)`, so the fixed buffers go away entirely: 48 lines removed, 13 added.

It also fixes a truncation. `MISC_LENGTH` is 128, but `%f` prints the whole integer part:

```
%f of 1e300 needs : 308 chars
buffer holds      : 127
produced strlen   : 127  -> TRUNCATED
```

So `float_to_string_cb` and `double_to_string_cb` were emitting a silently wrong number for large values. The other ten format an integer or a pointer, which always fit in 128, so for those this is simplification only.

## Verification

Every removed line belongs to the pattern: 12 x `char buf[MISC_LENGTH];`, 12 x `memset`, 12 x `append(ret, buf)`, and the 12 `snprintf` calls that became the `format_and_append` arguments. No other line in the file changed.